### PR TITLE
feat: add Docker image with runtime environment variable config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.github
+.idea

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   CI: true
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -18,10 +20,10 @@ jobs:
 
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
 
@@ -30,3 +32,40 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbea8a986b9cb31c37498e271f8c  # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: Build
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+cat > /usr/share/nginx/html/config.js << JSEOF
+window.APP_CONFIG = {
+  osmRelationId: ${OSM_RELATION_ID:-62700},
+  regionPlaygroundWikiUrl: '${REGION_PLAYGROUND_WIKI_URL:-https://wiki.openstreetmap.org/wiki/Fulda#Spielpl%C3%A4tze}',
+  regionChatUrl: '${REGION_CHAT_URL:-https://matrix.to/#/#osm-fulda:matrix.org}' || null,
+  mapZoom: ${MAP_ZOOM:-12},
+  mapMinZoom: ${MAP_MIN_ZOOM:-10}
+};
+JSEOF
+
+exec nginx -g 'daemon off;'

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <title>Spielplatzkarte</title>
         <link rel="icon" type="image/x-icon" href="./img/favicon/favicon.ico">
 
+        <script src="./config.js"></script>
         <script type="module" src="./js/main.js"></script>
     </head>
     <body>

--- a/js/config.js
+++ b/js/config.js
@@ -1,14 +1,24 @@
+// Configuration is injected at runtime via window.APP_CONFIG (set by public/config.js).
+// In Docker, docker-entrypoint.sh overwrites public/config.js from environment variables.
+// Fallback values are used for local development without a container.
+const c = (typeof window !== 'undefined' && window.APP_CONFIG) || {};
+
 // OSM relation ID of the region to display.
 // Find it at https://www.openstreetmap.org/relation/<id> or by searching on https://nominatim.openstreetmap.org
-export const osmRelationId = 62700;
+// Env var: OSM_RELATION_ID
+export const osmRelationId = c.osmRelationId ?? 62700;
 
 // Optional: shown in the "Daten ergänzen" modal.
 // Defaults to the generic OSM playground wiki page if not set.
-export const regionPlaygroundWikiUrl = 'https://wiki.openstreetmap.org/wiki/Fulda#Spielpl%C3%A4tze';
+// Env var: REGION_PLAYGROUND_WIKI_URL
+export const regionPlaygroundWikiUrl = c.regionPlaygroundWikiUrl ?? 'https://wiki.openstreetmap.org/wiki/Fulda#Spielpl%C3%A4tze';
 
 // Optional: community chat link shown in the "Daten ergänzen" modal. Set to null to hide.
-export const regionChatUrl = 'https://matrix.to/#/#osm-fulda:matrix.org';
+// Env var: REGION_CHAT_URL
+export const regionChatUrl = c.regionChatUrl ?? 'https://matrix.to/#/#osm-fulda:matrix.org';
 
 // --- Map display settings (less commonly changed) ---
-export const mapZoom = 12;
-export const mapMinZoom = 10;
+// Env var: MAP_ZOOM
+export const mapZoom = c.mapZoom ?? 12;
+// Env var: MAP_MIN_ZOOM
+export const mapMinZoom = c.mapMinZoom ?? 10;

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,8 @@
+// Default configuration — overwritten at container startup via docker-entrypoint.sh
+window.APP_CONFIG = {
+  osmRelationId: 62700,
+  regionPlaygroundWikiUrl: 'https://wiki.openstreetmap.org/wiki/Fulda#Spielpl%C3%A4tze',
+  regionChatUrl: 'https://matrix.to/#/#osm-fulda:matrix.org',
+  mapZoom: 12,
+  mapMinZoom: 10
+};


### PR DESCRIPTION
## Summary

- Adds a multi-stage `Dockerfile` (Node 20 Alpine build → nginx Alpine serve) so the app can be hosted as a container
- Introduces a runtime config injection pattern via `window.APP_CONFIG`: `public/config.js` sets defaults, and `docker-entrypoint.sh` overwrites it from environment variables on each container start — no rebuild needed to switch regions
- `js/config.js` reads from `window.APP_CONFIG` with `??` fallbacks so local dev (`npm start`) continues to work unchanged

## Environment variables

| Variable | Default | Description |
|---|---|---|
| `OSM_RELATION_ID` | `62700` | OSM relation ID of the region |
| `REGION_PLAYGROUND_WIKI_URL` | Fulda wiki page | Optional wiki URL (falls back to generic OSM page if empty) |
| `REGION_CHAT_URL` | Fulda matrix chat | Optional community chat URL (set to empty string to hide) |
| `MAP_ZOOM` | `12` | Initial map zoom level |
| `MAP_MIN_ZOOM` | `10` | Minimum zoom level |

## Usage

```bash
docker build -t spielplatzkarte .

docker run -p 8080:80 \
  -e OSM_RELATION_ID=3013728 \
  -e MAP_ZOOM=13 \
  -e REGION_CHAT_URL=https://matrix.to/#/your-channel \
  spielplatzkarte
```

## Also included

- GitHub Actions workflow extended with a `docker` job that builds and pushes to `ghcr.io` on `main` pushes
- All action refs pinned to immutable SHAs (were previously on mutable `@v3` tags)

## Test plan

- [ ] `npm start` — app loads in browser, defaults apply (Fulda region)
- [ ] `docker build -t spielplatzkarte .` — build succeeds
- [ ] `docker run -p 8080:80 -e OSM_RELATION_ID=3013728 spielplatzkarte` — map centers on Heilbronn
- [ ] `docker run -p 8081:80 spielplatzkarte` — map centers on Fulda (default)
- [ ] `curl http://localhost:8080/config.js` — reflects the env vars set at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)