### PR TITLE
feat: add multilingual UI support (i18n)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 
 > **Origin:** This project is a further development of the original [Berliner Spielplatzkarte](https://github.com/SupaplexOSM/spielplatzkarte) by Alex Seidel.
 
-> **Language:** The UI is currently in German only. Internationalisation (i18n) is a known limitation — all user-facing strings are hardcoded in German, equipment names are German, and the opening hours parser is configured for Germany (`country_code: de`). Contributions to add i18n support are welcome.
-
 ---
 
 ## Features
@@ -77,12 +75,63 @@ CORS is enabled on `/api/` so the Hub can query instances cross-origin from the 
 | UI framework | [Bootstrap 5](https://getbootstrap.com/) + [Bootstrap Icons](https://icons.getbootstrap.com/) |
 | Opening hours parser | [opening_hours.js](https://github.com/opening-hours/opening_hours.js) |
 | Build tool | [Vite 6](https://vitejs.dev/) |
+| Internationalisation | [i18next](https://www.i18next.com/) |
 | Language | JavaScript (ES Modules) |
 | Database | [PostgreSQL 16](https://www.postgresql.org/) + [PostGIS 3.4](https://postgis.net/) |
 | OSM import | [osm2pgsql](https://osm2pgsql.org/) (classic schema, `--hstore`) |
 | API layer | [PostgREST v12](https://postgrest.org/) |
 | Web server | [nginx](https://nginx.org/) |
 | Container runtime | [Docker](https://www.docker.com/) / Docker Compose |
+
+---
+
+## Internationalisation
+
+The UI is fully translated using [i18next](https://www.i18next.com/). The language is detected automatically from the visitor's browser settings, with English as the fallback.
+
+### Supported languages
+
+| Code | Language |
+|---|---|
+| `de` | German |
+| `en` | English |
+| `fr` | French |
+| `es` | Spanish |
+| `it` | Italian |
+| `pl` | Polish |
+| `nl` | Dutch |
+| `cs` | Czech |
+| `pt` | Portuguese |
+| `sv` | Swedish |
+| `uk` | Ukrainian |
+| `ja` | Japanese |
+
+> **Note:** Translations were not done by native speakers and may contain errors. Corrections and improvements are very welcome — see below for how to contribute.
+
+### Testing a specific language
+
+Add `?lang=xx` to the URL to force a language regardless of browser settings:
+
+```
+http://localhost:5173/?lang=fr
+http://localhost:8080/?lang=ja
+```
+
+### Adding a new language
+
+1. Copy `locales/en.json` to `locales/xx.json` (replace `xx` with the [BCP 47 language code](https://en.wikipedia.org/wiki/IETF_language_tag), e.g. `ro` for Romanian).
+2. Translate all the string values in the new file. Do not change the keys.
+3. For languages with complex plural forms (e.g. Polish, Ukrainian), add the appropriate plural suffixes (`_one`, `_few`, `_many`, `_other`) to the equipment count strings. See [i18next pluralisation docs](https://www.i18next.com/translation-function/plurals) and the existing `locales/pl.json` for reference.
+4. In `js/i18n.js`, add an import and register the new locale:
+   ```js
+   import ro from '../locales/ro.json';
+   // …
+   resources: {
+       // …existing entries…
+       ro: { translation: ro },
+   }
+   ```
+5. Run `npm run build` to verify there are no errors.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="h-100">
+<html class="h-100" lang="de">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -26,17 +26,17 @@
             <img src="./img/swing.png" alt="Logo" height="20" class="search-logo">
             <span id="app-version" class="search-version"></span>
             <span id="inputSearchIcon" class="bi bi-search search-icon"></span>
-            <input id="inputSearch" type="text" class="search-input" placeholder="Doppel-Shift für Suche">
+            <input id="inputSearch" type="text" class="search-input" placeholder="Doppel-Shift für Suche" data-i18n-placeholder="search.placeholder">
             <div class="search-nav-links">
-                <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalDatenErgaenzen">Daten ergänzen</a>
-                <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalUeberDasProjekt">Über das Projekt</a>
+                <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalDatenErgaenzen" data-i18n="nav.addData">Daten ergänzen</a>
+                <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalUeberDasProjekt" data-i18n="nav.about">Über das Projekt</a>
             </div>
-            <button class="search-menu-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Menü">
+            <button class="search-menu-btn" type="button" data-bs-toggle="dropdown" aria-expanded="false" title="Menü" data-i18n-title="nav.menu">
                 <span class="bi bi-three-dots-vertical"></span>
             </button>
             <ul class="dropdown-menu dropdown-menu-end">
-                <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#modalDatenErgaenzen">Daten ergänzen</a></li>
-                <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#modalUeberDasProjekt">Über das Projekt</a></li>
+                <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#modalDatenErgaenzen" data-i18n="nav.addData">Daten ergänzen</a></li>
+                <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#modalUeberDasProjekt" data-i18n="nav.about">Über das Projekt</a></li>
             </ul>
         </div>
 
@@ -49,19 +49,19 @@
 
             <div id="info-more" class="info-more-hint">
                 <span class="bi bi-hand-index"></span>
-                <p>Spielplatz antippen für Details</p>
+                <p data-i18n="info.hint">Spielplatz antippen für Details</p>
                 <div class="completeness-legend">
                     <div class="completeness-legend-item">
                         <span class="completeness-swatch completeness-swatch--complete"></span>
-                        Fotos, Name &amp; Details vorhanden
+                        <span data-i18n="completeness.complete">Fotos, Name &amp; Details vorhanden</span>
                     </div>
                     <div class="completeness-legend-item">
                         <span class="completeness-swatch completeness-swatch--partial"></span>
-                        Teilweise erfasst
+                        <span data-i18n="completeness.partial">Teilweise erfasst</span>
                     </div>
                     <div class="completeness-legend-item">
                         <span class="completeness-swatch completeness-swatch--missing"></span>
-                        Noch keine Daten
+                        <span data-i18n="completeness.missing">Noch keine Daten</span>
                     </div>
                 </div>
             </div>
@@ -82,12 +82,12 @@
                 <div class="position-absolute top-0 end-0 m-1 d-flex gap-1">
                     <button id="info-share-btn" type="button"
                         class="btn btn-sm btn-outline-light py-0 px-1"
-                        title="Spielplatz teilen">
+                        title="Spielplatz teilen" data-i18n-title="info.shareBtn">
                         <span class="bi bi-share"></span>
                     </button>
                     <a id="info-osm-url" href="#" target="_blank" rel="noopener"
                         class="btn btn-sm btn-outline-light py-0 px-1"
-                        title="Bei OpenStreetMap anzeigen">
+                        title="Bei OpenStreetMap anzeigen" data-i18n-title="info.osmBtn">
                         <span class="bi bi-map"></span> OSM
                     </a>
                 </div>
@@ -100,7 +100,7 @@
                 <!-------------------------->
                 <div class="accordion-item">
                     <h2 class="accordion-header">
-                        <button id="accordion-btn-panoramax" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-panoramax" aria-expanded="true" aria-controls="accordion-panoramax">
+                        <button id="accordion-btn-panoramax" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-panoramax" aria-expanded="true" aria-controls="accordion-panoramax" data-i18n="accordion.photos">
                             Bilder
                         </button>
                     </h2>
@@ -116,7 +116,7 @@
                 <!------------------------------->
                 <div class="accordion-item">
                     <h2 class="accordion-header">
-                        <button id="accordion-btn-ausstattung" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-ausstattung" aria-expanded="true" aria-controls="accordion-ausstattung">
+                        <button id="accordion-btn-ausstattung" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-ausstattung" aria-expanded="true" aria-controls="accordion-ausstattung" data-i18n="accordion.equipment">
                             Ausstattung
                         </button>
                     </h2>
@@ -312,7 +312,7 @@
                 <!-------------------------->
                 <div class="accordion-item">
                     <h2 class="accordion-header">
-                        <button id="accordion-btn-umfeld" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-umfeld" aria-expanded="true" aria-controls="accordion-umfeld">
+                        <button id="accordion-btn-umfeld" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-umfeld" aria-expanded="true" aria-controls="accordion-umfeld" data-i18n="accordion.surroundings">
                             Umfeld
                         </button>
                     </h2>
@@ -328,7 +328,7 @@
                 <!------------------------------>
                 <div class="accordion-item">
                     <h2 class="accordion-header">
-                        <button id="accordion-btn-reviews" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-reviews" aria-expanded="true" aria-controls="accordion-reviews">
+                        <button id="accordion-btn-reviews" class="accordion-button p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-reviews" aria-expanded="true" aria-controls="accordion-reviews" data-i18n="accordion.reviews">
                             Bewertungen
                         </button>
                     </h2>
@@ -345,7 +345,7 @@
                 <div class="accordion-item" style="display: none;">
                     <h2 class="accordion-header">
                         <button id="accordion-btn-datenvollstaendigkeit" class="accordion-button collapsed p-2" type="button" data-bs-toggle="collapse" data-bs-target="#accordion-datenvollstaendigkeit" aria-expanded="false" aria-controls="accordion-datenvollstaendigkeit">
-                            Datenvollständigkeit&nbsp;&nbsp;<span class="badge text-bg-danger" style="font-size: xx-small;">TODO</span>
+                            <span data-i18n="accordion.completeness">Datenvollständigkeit</span>&nbsp;&nbsp;<span class="badge text-bg-danger" style="font-size: xx-small;">TODO</span>
                         </button>
                     </h2>
                     <div id="accordion-datenvollstaendigkeit" class="accordion-collapse collapse" data-bs-parent="#info-accordion">
@@ -362,7 +362,7 @@
         <!-- Floating Action Buttons  -->
         <!------------------------------>
         <div id="map-fabs">
-            <button id="btn-location" type="button" class="map-fab" title="Standort verfolgen">
+            <button id="btn-location" type="button" class="map-fab" title="Standort verfolgen" data-i18n-title="location.btn">
                 <span class="bi bi-crosshair"></span>
             </button>
             <!-- TODO (GeoServer): Datenprobleme-Button — requires GeoServer backend -->
@@ -441,15 +441,15 @@
             <div class="modal-dialog modal-xl modal-dialog-centered">
                 <div class="modal-content">
                     <div class="modal-header p-2 d-flex align-items-center gap-2">
-                        <button id="panoramax-modal-prev" type="button" class="btn btn-sm btn-outline-secondary py-0" title="Vorheriges Foto">
+                        <button id="panoramax-modal-prev" type="button" class="btn btn-sm btn-outline-secondary py-0" title="Vorheriges Foto" data-i18n-title="modal.prevPhoto">
                             <span class="bi bi-chevron-left"></span>
                         </button>
-                        <button id="panoramax-modal-next" type="button" class="btn btn-sm btn-outline-secondary py-0" title="Nächstes Foto">
+                        <button id="panoramax-modal-next" type="button" class="btn btn-sm btn-outline-secondary py-0" title="Nächstes Foto" data-i18n-title="modal.nextPhoto">
                             <span class="bi bi-chevron-right"></span>
                         </button>
                         <span id="panoramax-modal-counter" class="text-muted" style="font-size:smaller;"></span>
-                        <h5 class="modal-title ms-1 mb-0">Straßenfoto</h5>
-                        <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal" aria-label="Schließen"></button>
+                        <h5 class="modal-title ms-1 mb-0" data-i18n="modal.streetPhoto">Straßenfoto</h5>
+                        <button type="button" class="btn-close ms-auto" data-bs-dismiss="modal" aria-label="Schließen" data-i18n-aria-label="modal.closeBtn"></button>
                     </div>
                     <div class="modal-body p-0">
                         <iframe id="panoramax-modal-iframe" style="width:100%; height:82vh; border:none;" allowfullscreen></iframe>
@@ -463,14 +463,14 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h1 class="modal-title fs-5">Daten ergänzen</h1>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+                        <h1 class="modal-title fs-5" data-i18n="nav.addData">Daten ergänzen</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen" data-i18n-aria-label="modal.closeBtn"></button>
                     </div>
                     <div class="modal-body">
                         <!-- wird dynamisch aus config.js befüllt (siehe main.js) -->
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Zurück zur Karte</button>
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal" data-i18n="modal.backToMap">Zurück zur Karte</button>
                     </div>
                 </div>
             </div>
@@ -481,14 +481,14 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h1 class="modal-title fs-5">Über das Projekt</h1>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
+                        <h1 class="modal-title fs-5" data-i18n="nav.about">Über das Projekt</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen" data-i18n-aria-label="modal.closeBtn"></button>
                     </div>
                     <div class="modal-body">
                         <!-- wird dynamisch aus config.js befüllt (siehe main.js) -->
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Zurück zur Karte</button>
+                        <button type="button" class="btn btn-primary" data-bs-dismiss="modal" data-i18n="modal.backToMap">Zurück zur Karte</button>
                     </div>
                 </div>
             </div>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,67 @@
+//----------------------------------//
+// Internationalisierung (i18next)  //
+//----------------------------------//
+
+import i18next from 'i18next';
+import de from '../locales/de.json';
+import en from '../locales/en.json';
+import fr from '../locales/fr.json';
+import es from '../locales/es.json';
+import it from '../locales/it.json';
+import pl from '../locales/pl.json';
+import nl from '../locales/nl.json';
+import cs from '../locales/cs.json';
+import pt from '../locales/pt.json';
+import sv from '../locales/sv.json';
+import uk from '../locales/uk.json';
+import ja from '../locales/ja.json';
+
+// Pick language: URL parameter ?lang=xx overrides browser setting, fall back to German
+const urlLang = new URLSearchParams(window.location.search).get('lang');
+const lng = urlLang || (navigator.language || 'de').split('-')[0];
+
+// initImmediate: false → synchronous init (safe because resources are bundled, no HTTP fetch needed)
+i18next.init({
+    lng,
+    fallbackLng: 'en',
+    resources: {
+        de: { translation: de },
+        en: { translation: en },
+        fr: { translation: fr },
+        es: { translation: es },
+        it: { translation: it },
+        pl: { translation: pl },
+        nl: { translation: nl },
+        cs: { translation: cs },
+        pt: { translation: pt },
+        sv: { translation: sv },
+        uk: { translation: uk },
+        ja: { translation: ja },
+    },
+    interpolation: { escapeValue: false },
+    initImmediate: false,
+});
+
+// The language that was actually selected (e.g. 'de' or 'en')
+export const language = i18next.language;
+
+// Translation function — use as: t('some.key') or t('some.key', { count: 3 })
+export const t = i18next.t.bind(i18next);
+
+// Apply translations to static HTML elements marked with data-i18n attributes.
+// Call once after the DOM is ready.
+export function applyTranslations() {
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+        el.textContent = t(el.dataset.i18n);
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+        el.placeholder = t(el.dataset.i18nPlaceholder);
+    });
+    document.querySelectorAll('[data-i18n-title]').forEach(el => {
+        el.title = t(el.dataset.i18nTitle);
+    });
+    document.querySelectorAll('[data-i18n-aria-label]').forEach(el => {
+        el.setAttribute('aria-label', t(el.dataset.i18nAriaLabel));
+    });
+    document.documentElement.lang = i18next.language;
+}

--- a/js/locate.js
+++ b/js/locate.js
@@ -13,6 +13,7 @@ import { unByKey } from 'ol/Observable.js';
 import map from './map.js';
 import { showNearbyPlaygrounds } from './selectPlayground.js';
 import { transform } from 'ol/proj';
+import { t } from './i18n.js';
 
 // Einmalige Standortbestimmung: Karte zentrieren, Spielplätze in der Nähe anzeigen
 let locationListenerKey = null;
@@ -37,7 +38,7 @@ document.getElementById('btn-location').addEventListener('click', function() {
         geolocation.setTracking(false);
 
         const [lon, lat] = transform(coordinates, 'EPSG:3857', 'EPSG:4326');
-        showNearbyPlaygrounds(lon, lat, 'deinem Standort');
+        showNearbyPlaygrounds(lon, lat, t('location.yourLocation'));
     });
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../css/bootstrap_custom.css';
 import { Modal } from 'bootstrap';
+import { t, applyTranslations } from './i18n.js';
 
 // Bootstrap's data-api may be tree-shaken away — wire up modal triggers explicitly
 document.querySelectorAll('[data-bs-toggle="modal"]').forEach(trigger => {
@@ -38,40 +39,46 @@ const DEFAULT_PLAYGROUND_WIKI_URL = 'https://wiki.openstreetmap.org/wiki/DE:Tag:
         console.warn('Region info could not be fetched from Nominatim:', e);
     }
 
+    applyTranslations();
+
     // Seitenname aus Konfiguration setzen
-    const appTitle = `${region.name}er Spielplatzkarte`;
+    const appTitle = t('appTitle', { regionName: region.name });
     document.title = appTitle;
     document.getElementById('app-version').textContent = `v${version}`;
 
-    buildDatenErgaenzenModal(region.name);
+    buildDatenErgaenzenModal();
     buildUeberModal();
 }());
 
 // "Daten ergänzen"-Modal dynamisch befüllen
-function buildDatenErgaenzenModal(regionName) {
-    const l = (text) => `<span class="info-label">${text}</span>`;
+function buildDatenErgaenzenModal() {
+    const l = text => `<span class="info-label">${text}</span>`;
+    const p = text => `<p>${text}</p>`;
+    const a = (href, text, extra = '') => `<a href="${href}" class="link-secondary" ${extra}>${text}</a>`;
     const wikiUrl = regionPlaygroundWikiUrl || DEFAULT_PLAYGROUND_WIKI_URL;
 
+    const osmWikiLink   = a(t('modal.addData.osm.wikiUrl'), 'OpenStreetMap');
+    const learnOsmLink  = a(t('modal.addData.contribute.learnOsmUrl'), 'LearnOSM.org');
+    const wikiLink      = a(wikiUrl, t('modal.addData.contribute.wikiLabel'), 'target="_blank" rel="noopener"');
+    const equipmentLink = a('https://wiki.openstreetmap.org/wiki/Key:playground', t('modal.addData.contribute.equipmentLabel'));
+    const mapcompleteLink = a('https://mapcomplete.org/playgrounds', 'MapComplete', 'target="_blank" rel="noopener"');
+    const panoramaxLink = a('https://panoramax.xyz', 'Panoramax', 'target="_blank" rel="noopener"');
+
     let html = `
-        ${l('OpenStreetMap')}
-        <p>Die Daten stammen aus <a href="https://de.wikipedia.org/wiki/OpenStreetMap" class="link-secondary">OpenStreetMap</a> —
-        einer freien, kollaborativen Weltkarte von Millionen Freiwilligen. Nur was eingetragen wurde, erscheint auch hier.</p>
+        ${l(t('modal.addData.osm.label'))}
+        ${p(t('modal.addData.osm.text', { osmLink: osmWikiLink }))}
 
-        ${l('Spielplätze beitragen')}
-        <p>Jede und jeder kann mitmachen. Einen Einstieg bietet <a href="https://learnosm.org/de/beginner/" class="link-secondary">LearnOSM.org</a>.
-        Die relevanten Tags sind im <a href="${wikiUrl}" class="link-secondary" target="_blank" rel="noopener">OSM-Wiki</a>
-        und auf der Seite zur <a href="https://wiki.openstreetmap.org/wiki/Key:playground" class="link-secondary">Erfassung einzelner Spielgeräte</a> dokumentiert.</p>
+        ${l(t('modal.addData.contribute.label'))}
+        ${p(t('modal.addData.contribute.text', { learnOsmLink, wikiLink, equipmentLink }))}
 
-        ${l('Fotos hinzufügen')}
-        <p>Fotos lassen sich direkt über <a href="https://mapcomplete.org/playgrounds" class="link-secondary" target="_blank" rel="noopener">MapComplete</a>
-        hochladen — einfach einen Spielplatz öffnen und „Foto hinzufügen" klicken.
-        Die Fotos werden über <a href="https://panoramax.xyz" class="link-secondary" target="_blank" rel="noopener">Panoramax</a> bereitgestellt.</p>`;
+        ${l(t('modal.addData.photos.label'))}
+        ${p(t('modal.addData.photos.text', { mapcompleteLink, panoramaxLink }))}`;
 
     if (regionChatUrl) {
+        const chatLink = a(regionChatUrl, t('modal.addData.community.chatLabel'), 'target="_blank" rel="noopener"');
         html += `
-        ${l('Community')}
-        <p>Fragen oder mitmachen? Die lokale OSM-Community ist erreichbar über den
-        <a href="${regionChatUrl}" class="link-secondary" target="_blank" rel="noopener">lokalen OSM-Community-Chat</a>.</p>`;
+        ${l(t('modal.addData.community.label'))}
+        ${p(t('modal.addData.community.text', { chatLink }))}`;
     }
 
     document.querySelector('#modalDatenErgaenzen .modal-body').innerHTML = html;
@@ -79,26 +86,26 @@ function buildDatenErgaenzenModal(regionName) {
 
 // "Über das Projekt"-Modal dynamisch befüllen
 function buildUeberModal() {
-    const l = (text) => `<span class="info-label">${text}</span>`;
-    const authorLink = `<a href="${projectAuthorOsmUrl}" class="link-secondary" target="_blank" rel="noopener">Alex Seidel (Supaplex030)</a>`;
+    const l = text => `<span class="info-label">${text}</span>`;
+    const p = text => `<p>${text}</p>`;
+    const a = (href, text, extra = '') => `<a href="${href}" class="link-secondary" ${extra}>${text}</a>`;
+
+    const authorLink = a(projectAuthorOsmUrl, 'Alex Seidel (Supaplex030)', 'target="_blank" rel="noopener"');
+    const courseLink = a(t('modal.about.history.courseUrl'), t('modal.about.history.courseLabel'));
+    const osmLink    = a(t('modal.about.project.osmWikiUrl'), 'OpenStreetMap');
 
     let html = `
-        ${l('Geschichte')}
-        <p>Die Spielplatzkarte wurde von ${authorLink} als Abschlussprojekt einer
-        <a href="https://gis-trainer.com/de/gis_webmapping.php" class="link-secondary">GIS- und Webmapping-Weiterbildung</a>
-        ins Leben gerufen — ursprünglich mit Fokus auf Berlin. Im Laufe der Zeit wurde sie zu einer
-        generischen Spielplatzkarte weiterentwickelt, die für jede beliebige OSM-Region eingesetzt werden kann.</p>
+        ${l(t('modal.about.history.label'))}
+        ${p(t('modal.about.history.text', { authorLink, courseLink }))}
 
-        ${l('Das Projekt')}
-        <p>Die Spielplatzkarte ist eine freie, interaktive Webkarte auf Basis von
-        <a href="https://de.wikipedia.org/wiki/OpenStreetMap" class="link-secondary">OpenStreetMap</a>-Daten.
-        Sie enthält keine proprietären Daten, erfordert keine Anmeldung und verfolgt keine Nutzer.
-        Wer Spielplatzdaten in OSM verbessert, verbessert damit automatisch auch diese Karte.</p>`;
+        ${l(t('modal.about.project.label'))}
+        ${p(t('modal.about.project.text', { osmLink }))}`;
 
     if (projectRepoUrl) {
+        const repoLink = a(projectRepoUrl, t('modal.about.source.repoLabel'), 'target="_blank" rel="noopener"');
         html += `
-        ${l('Quellcode')}
-        <p>Das Projekt ist OpenSource und <a href="${projectRepoUrl}" class="link-secondary" target="_blank" rel="noopener">öffentlich verfügbar</a>.</p>`;
+        ${l(t('modal.about.source.label'))}
+        ${p(t('modal.about.source.text', { repoLink }))}`;
     }
 
     html += `<p class="mt-3 mb-0" style="font-size:11px; color:#9ca3af;">Version ${version}</p>`;

--- a/js/search.js
+++ b/js/search.js
@@ -7,6 +7,7 @@ import map from './map.js';
 import { getRegionExtent, showNotification } from './map.js';
 import { pulse } from './pulse.js';
 import { showNearbyPlaygrounds } from './selectPlayground.js';
+import { t } from './i18n.js';
 
 // Suchanfragen starten
 document.getElementById('inputSearch').addEventListener('keypress', (e) => {
@@ -46,14 +47,16 @@ export async function searchLocation(query) {
             var addr_suburb = result.address.suburb;
             var addr_city = result.address.city || result.address.town || result.address.village;
             var locationHint = addr_suburb ? `${addr_suburb}, ${addr_city || ''}` : addr_city;
-            var notification = locationHint ? `„${query}" in ${locationHint}` : `„${query}" gefunden`;
+            var notification = locationHint
+                ? t('search.found', { query, location: locationHint })
+                : t('search.foundGeneric', { query });
             showNotification(notification);
 
             // Spielplätze in der Nähe des Suchergebnisses anzeigen
             const label = addr_suburb || result.address.city || query;
             showNearbyPlaygrounds(parseFloat(result.lon), parseFloat(result.lat), `„${label}"`);
         } else {
-            showNotification("Kein Suchergebnis gefunden!");
+            showNotification(t('search.notFound'));
         }
     } catch (error) {
         console.error('Fehler bei der Suchanfrage:', error);

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -32,6 +32,7 @@ import { poiRadiusM } from './config.js';
 import { panoramaxViewerUrl, panoramaxThumbUrl } from './panoramax.js';
 import { getEquipmentAttributesFromProps } from './popup.js';
 import { renderReviews } from './reviews.js';
+import { t, language } from './i18n.js';
 
 const el = id => document.getElementById(id);
 const show = id => { el(id).style.display = ''; };
@@ -51,7 +52,7 @@ let nearbyClickController = null; // AbortController for nearby-item click deleg
 let panoramaxEnlargeController = null; // AbortController for panoramax-preview click
 let panoramaxThumbController = null;  // AbortController for panoramax-thumb click
 
-export function showNearbyPlaygrounds(lon, lat, label = 'diesem Ort') {
+export function showNearbyPlaygrounds(lon, lat, label = t('nearby.thisLocation')) {
     const source = dataPlaygrounds.getSource ? dataPlaygrounds.getSource() : null;
     if (!source) return;
     const features = source.getFeatures();
@@ -81,12 +82,12 @@ export function showNearbyPlaygrounds(lon, lat, label = 'diesem Ort') {
     nearbyListFeatures = nearest.map(x => x.feature);
 
     let html = `<div class="nearby-panel">
-        <span class="info-label">In der Nähe von ${label}</span>`;
+        <span class="info-label">${t('nearby.title', { label })}</span>`;
 
     for (let i = 0; i < nearest.length; i++) {
         const { feature, dist } = nearest[i];
         const attr = feature.getProperties();
-        const name = getPlaygroundTitle(attr) || 'Spielplatz';
+        const name = getPlaygroundTitle(attr) || t('nearby.defaultName');
         html += `<div class="nearby-item" data-idx="${i}">
             <span class="nearby-name">${name}</span>
             <span class="nearby-dist">${formatDistance(dist)}</span>
@@ -419,21 +420,11 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     }
 
     let equipment_str = '<ul>';
-    if (deviceCount) {
-        equipment_str += `<li>${deviceCount} Spielgerät${deviceCount !== 1 ? 'e' : ''}</li>`;
-    }
-    if (fitnessCount) {
-        equipment_str += fitnessCount === 1 ? '<li>1 Fitnessgerät</li>' : `<li>${fitnessCount} Fitnessgeräte</li>`;
-    }
-    if (benchCount) {
-        equipment_str += benchCount === 1 ? '<li>1 Sitzbank</li>' : `<li>${benchCount} Sitzbänke</li>`;
-    }
-    if (shelterCount) {
-        equipment_str += shelterCount === 1 ? '<li>1 Unterstand</li>' : `<li>${shelterCount} Unterstände</li>`;
-    }
-    if (picnicCount) {
-        equipment_str += picnicCount === 1 ? '<li>1 Picknicktisch</li>' : `<li>${picnicCount} Picknicktische</li>`;
-    }
+    if (deviceCount)  equipment_str += `<li>${t('equipment.devices',  { count: deviceCount  })}</li>`;
+    if (fitnessCount) equipment_str += `<li>${t('equipment.fitness',  { count: fitnessCount })}</li>`;
+    if (benchCount)   equipment_str += `<li>${t('equipment.benches',  { count: benchCount   })}</li>`;
+    if (shelterCount) equipment_str += `<li>${t('equipment.shelters', { count: shelterCount })}</li>`;
+    if (picnicCount)  equipment_str += `<li>${t('equipment.picnic',   { count: picnicCount  })}</li>`;
     equipment_str += '</ul>';
     el('info-equipment').innerHTML = equipment_str;
 
@@ -462,7 +453,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     const fitnessColor = objColors['activity'] ?? objColors['fallback'];
     for (const f of features.filter(f => f.properties.leisure === 'fitness_station')) {
         const fsType = f.properties.fitness_station;
-        const name = (fsType && fsType in objFitnessStation) ? objFitnessStation[fsType] : 'Fitnessgerät';
+        const name = (fsType && fsType in objFitnessStation) ? objFitnessStation[fsType] : t('equipment.fitnessDefault');
         const detail = getEquipmentAttributesFromProps(f.properties);
         const uid = `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
         if (detail) {
@@ -515,7 +506,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     // "Hilf mit"-Hinweis — nur wenn keine separat gemappten Geräte vorhanden
     if (!deviceFeatures.length) {
         el('info-device-list').insertAdjacentHTML('beforeend',
-            '<p class="text-muted mt-2 mb-0" style="font-size:smaller">Spielgeräte noch nicht einzeln kartiert – hilf mit! 👇</p>'
+            `<p class="text-muted mt-2 mb-0" style="font-size:smaller">${t('equipment.addHint')}</p>`
         );
     }
 
@@ -528,7 +519,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
         );
         const mapcompleteUrl = `https://mapcomplete.org/playgrounds.html?z=19&lat=${lat.toFixed(7)}&lon=${lon.toFixed(7)}#new_point_dialog_0`;
         el('info-device-list').insertAdjacentHTML('beforeend',
-            `<div class="mt-1"><a href="${mapcompleteUrl}" target="_blank" rel="noopener" class="mc-add-link"><span class="bi bi-plus-circle"></span> Spielgerät hinzufügen</a></div>`
+            `<div class="mt-1"><a href="${mapcompleteUrl}" target="_blank" rel="noopener" class="mc-add-link"><span class="bi bi-plus-circle"></span> ${t('equipment.addLink')}</a></div>`
         );
     }
 }
@@ -547,20 +538,20 @@ function showPanoramaxFromTags(attr) {
     const osmType = osmTypeMap[attr['osm_type']] ?? 'way';
     const osmId = attr['osm_id'];
     const mapcompletePhotoUrl = `https://mapcomplete.org/playgrounds.html#${osmType}/${osmId}`;
-    const addPhotoLink = `<a href="${mapcompletePhotoUrl}" target="_blank" rel="noopener" class="mc-add-link"><span class="bi bi-camera"></span> Foto hinzufügen</a>`;
+    const addPhotoLink = `<a href="${mapcompletePhotoUrl}" target="_blank" rel="noopener" class="mc-add-link"><span class="bi bi-camera"></span> ${t('photos.addLink')}</a>`;
 
     if (!uuids.length) {
         el('info-panoramax').innerHTML =
             `<div class="text-center py-2">` +
             `<span class="bi bi-camera" style="font-size:1.8rem; color:#d1d5db;"></span>` +
-            `<p class="text-muted mt-1 mb-2" style="font-size:smaller;">Noch keine Fotos für diesen Spielplatz.<br>Warst du schon dort?</p>` +
+            `<p class="text-muted mt-1 mb-2" style="font-size:smaller;">${t('photos.none')}</p>` +
             addPhotoLink +
             `</div>`;
         return;
     }
 
     // Inline-Viewer mit klickbarem Overlay für Vollbild
-    let html = `<div style="position:relative; cursor:pointer;" id="panoramax-preview" data-uuid="${uuids[0]}" title="Klicken zum Vergrößern">
+    let html = `<div style="position:relative; cursor:pointer;" id="panoramax-preview" data-uuid="${uuids[0]}" title="${t('photos.enlarge')}">
         <iframe id="panoramax-iframe"
             src="${panoramaxViewerUrl(uuids[0])}"
             style="width:100%; height:260px; border:none; border-radius:4px; pointer-events:none;"
@@ -577,7 +568,7 @@ function showPanoramaxFromTags(attr) {
             html += `<img src="${panoramaxThumbUrl(uuids[i])}"
                 data-uuid="${uuids[i]}"
                 class="panoramax-thumb"
-                alt="Foto ${i + 1}"
+                alt="${t('photos.thumbnail', { n: i + 1 })}"
                 style="height:52px; width:72px; border-radius:3px; cursor:pointer; object-fit:cover; opacity:${opacity};">`;
         }
         html += '</div>';
@@ -607,7 +598,7 @@ function showPanoramaxFromTags(attr) {
         const uuid = thumb.dataset.uuid;
         el('panoramax-iframe').src = panoramaxViewerUrl(uuid);
         el('panoramax-preview').dataset.uuid = uuid;
-        document.querySelectorAll('.panoramax-thumb').forEach(t => { t.style.opacity = '0.55'; });
+        document.querySelectorAll('.panoramax-thumb').forEach(thumb => { thumb.style.opacity = '0.55'; });
         thumb.style.opacity = '1';
     }, { signal: panoramaxThumbController.signal });
 }
@@ -621,7 +612,7 @@ async function loadNearbyPOIs(lat, lon, radiusM, osmId) {
     } catch (e) {
         console.warn('Umfeld-Daten konnten nicht geladen werden:', e);
         if (generation !== nearbyLoadGeneration) return;
-        el('info-umfeld').innerHTML = '<small class="text-muted"><i>Umfeld-Daten konnten nicht geladen werden.</i></small>';
+        el('info-umfeld').innerHTML = `<small class="text-muted"><i>${t('poi.errorLoad')}</i></small>`;
         return;
     }
     if (generation !== nearbyLoadGeneration) return;
@@ -630,52 +621,51 @@ async function loadNearbyPOIs(lat, lon, radiusM, osmId) {
 
 const POI_CATEGORIES = [
     {
-        icon: '🚻', label: 'Toiletten',
-        match: t => t.amenity === 'toilets',
-        fallback: 'Öffentliche Toilette'
+        icon: '🚻', get label() { return t('poi.categories.toilets'); },
+        match: f => f.amenity === 'toilets',
+        get fallback() { return t('poi.fallbacks.toilets'); }
     },
     {
-        icon: '🚌', label: 'Bushaltestellen',
-        match: t => t.highway === 'bus_stop',
-        fallback: 'Bushaltestelle',
+        icon: '🚌', get label() { return t('poi.categories.busStops'); },
+        match: f => f.highway === 'bus_stop',
+        get fallback() { return t('poi.fallbacks.busStops'); },
         hint: (poi, playLat, playLon) => poi.tags.towards
             ? `→ ${poi.tags.towards}`
             : bearingToDir(bearingDeg(playLat, playLon, poi.lat, poi.lon))
     },
     {
-        icon: '🍦', label: 'Eis',
-        match: t => t.amenity === 'ice_cream' || (t.cuisine && t.cuisine.includes('ice_cream')),
-        fallback: 'Eisdiele'
+        icon: '🍦', get label() { return t('poi.categories.iceCream'); },
+        match: f => f.amenity === 'ice_cream' || (f.cuisine && f.cuisine.includes('ice_cream')),
+        get fallback() { return t('poi.fallbacks.iceCream'); }
     },
     {
-        icon: '🛒', label: 'Einkaufen',
-        match: t => t.shop === 'supermarket' || t.shop === 'convenience',
-        fallback: 'Einkaufsmöglichkeit'
+        icon: '🛒', get label() { return t('poi.categories.shopping'); },
+        match: f => f.shop === 'supermarket' || f.shop === 'convenience',
+        get fallback() { return t('poi.fallbacks.shopping'); }
     },
     {
-        icon: '🧴', label: 'Drogerie',
-        match: t => t.shop === 'chemist',
-        fallback: 'Drogerie'
+        icon: '🧴', get label() { return t('poi.categories.drugstore'); },
+        match: f => f.shop === 'chemist',
+        get fallback() { return t('poi.fallbacks.drugstore'); }
     },
     {
-        icon: '🏥', label: 'Notaufnahme',
-        match: t => t.emergency === 'yes' || t['healthcare:speciality'] === 'emergency',
-        fallback: 'Krankenhaus'
+        icon: '🏥', get label() { return t('poi.categories.emergency'); },
+        match: f => f.emergency === 'yes' || f['healthcare:speciality'] === 'emergency',
+        get fallback() { return t('poi.fallbacks.emergency'); }
     }
 ];
 
 function formatOpeningHours(ohStr) {
-    const fmt = t => t.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+    const fmt = date => date.toLocaleTimeString(language, { hour: '2-digit', minute: '2-digit' });
 
     // Returns a human-readable day label for a future date.
-    // Within 6 days: weekday name ("Mittwoch"). Further away: full date ("Mi., 15.04.").
     const dayLabel = (d, now) => {
         const diffDays = Math.round((d - now) / 86400000);
-        if (d.toDateString() === now.toDateString()) return 'Heute';
+        if (d.toDateString() === now.toDateString()) return t('poi.today');
         const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
-        if (d.toDateString() === tomorrow.toDateString()) return 'Morgen';
-        if (diffDays <= 6) return d.toLocaleDateString('de-DE', { weekday: 'long' });
-        return d.toLocaleDateString('de-DE', { weekday: 'short', day: '2-digit', month: '2-digit' });
+        if (d.toDateString() === tomorrow.toDateString()) return t('poi.tomorrow');
+        if (diffDays <= 6) return d.toLocaleDateString(language, { weekday: 'long' });
+        return d.toLocaleDateString(language, { weekday: 'short', day: '2-digit', month: '2-digit' });
     };
 
     try {
@@ -686,22 +676,24 @@ function formatOpeningHours(ohStr) {
 
         let statusHtml;
         if (ohStr.trim() === '24/7') {
-            statusHtml = `<span style="color:#16a34a;">● Immer geöffnet</span>`;
+            statusHtml = `<span style="color:#16a34a;">● ${t('poi.alwaysOpen')}</span>`;
         } else if (isOpen) {
-            const until = nextChange ? ` bis ${fmt(nextChange)}` : '';
-            statusHtml = `<span style="color:#16a34a;">● Geöffnet${until}</span>`;
+            const label = nextChange
+                ? t('poi.openUntil', { time: fmt(nextChange) })
+                : t('poi.open');
+            statusHtml = `<span style="color:#16a34a;">● ${label}</span>`;
         } else {
             if (nextChange) {
-                statusHtml = `<span style="color:#dc2626;">● Geschlossen</span> · Öffnet ${dayLabel(nextChange, now)} um\u00A0${fmt(nextChange)}`;
+                statusHtml = `<span style="color:#dc2626;">● ${t('poi.closed')}</span> · ${t('poi.opensAt', { day: dayLabel(nextChange, now), time: fmt(nextChange) })}`;
             } else {
-                statusHtml = `<span style="color:#dc2626;">● Geschlossen</span>`;
+                statusHtml = `<span style="color:#dc2626;">● ${t('poi.closed')}</span>`;
             }
         }
 
-        return `<span class="info-label">Öffnungszeiten</span> ${statusHtml}`;
+        return `<span class="info-label">${t('poi.openingHours')}</span> ${statusHtml}`;
     } catch {
         // Fallback für unbekannte Formate
-        return `<span class="info-label">Öffnungszeiten</span> <code style="font-size:smaller;">${ohStr}</code>`;
+        return `<span class="info-label">${t('poi.openingHours')}</span> <code style="font-size:smaller;">${ohStr}</code>`;
     }
 }
 
@@ -714,7 +706,9 @@ function haversineDistance(lat1, lon1, lat2, lon2) {
 }
 
 function formatDistance(m) {
-    return m < 1000 ? `~${Math.round(m / 10) * 10} m` : `~${(m / 1000).toFixed(1).replace('.', ',')} km`;
+    if (m < 1000) return `~${Math.round(m / 10) * 10} m`;
+    const km = (m / 1000).toLocaleString(language, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    return `~${km} km`;
 }
 
 function bearingDeg(lat1, lon1, lat2, lon2) {

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -1,0 +1,142 @@
+{
+  "appTitle": "Mapa hřišť \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Dvojitý Shift pro vyhledávání",
+    "found": "\"{{query}}\" v {{location}}",
+    "foundGeneric": "\"{{query}}\" nalezeno",
+    "notFound": "Žádné výsledky nenalezeny!"
+  },
+  "nav": {
+    "addData": "Přidat data",
+    "about": "O projektu",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Klepněte na hřiště pro zobrazení podrobností",
+    "shareBtn": "Sdílet hřiště",
+    "osmBtn": "Zobrazit na OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Fotografie, název a podrobnosti k dispozici",
+    "partial": "Částečně zmapováno",
+    "missing": "Žádná data"
+  },
+  "accordion": {
+    "photos": "Fotografie",
+    "equipment": "Vybavení",
+    "shadow": "Stín",
+    "surroundings": "Okolí",
+    "reviews": "Recenze",
+    "completeness": "Úplnost dat"
+  },
+  "location": {
+    "btn": "Moje poloha",
+    "yourLocation": "vaší polohy"
+  },
+  "nearby": {
+    "title": "V blízkosti {{label}}",
+    "defaultName": "Hřiště",
+    "thisLocation": "tohoto místa"
+  },
+  "equipment": {
+    "devices_one": "{{count}} zařízení",
+    "devices_few": "{{count}} zařízení",
+    "devices_other": "{{count}} zařízení",
+    "fitness_one": "{{count}} fitness zařízení",
+    "fitness_few": "{{count}} fitness zařízení",
+    "fitness_other": "{{count}} fitness zařízení",
+    "benches_one": "{{count}} lavička",
+    "benches_few": "{{count}} lavičky",
+    "benches_other": "{{count}} laviček",
+    "shelters_one": "{{count}} přístřešek",
+    "shelters_few": "{{count}} přístřešky",
+    "shelters_other": "{{count}} přístřešků",
+    "picnic_one": "{{count}} piknikový stůl",
+    "picnic_few": "{{count}} piknikové stoly",
+    "picnic_other": "{{count}} piknikových stolů",
+    "fitnessDefault": "Fitness zařízení",
+    "addHint": "Vybavení zatím není individuálně zmapováno \u2013 pomozte! 👇",
+    "addLink": "Přidat vybavení"
+  },
+  "photos": {
+    "none": "Pro toto hřiště zatím nejsou žádné fotografie.<br>Byli jste tam?",
+    "addLink": "Přidat fotografii",
+    "enlarge": "Kliknutím zvětšíte",
+    "thumbnail": "Fotografie {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Nepodařilo se načíst data okolí.",
+    "alwaysOpen": "Vždy otevřeno",
+    "open": "Otevřeno",
+    "openUntil": "Otevřeno do {{time}}",
+    "closed": "Zavřeno",
+    "opensAt": "Otevírá {{day}} v {{time}}",
+    "openingHours": "Otevírací doba",
+    "today": "Dnes",
+    "tomorrow": "Zítra",
+    "categories": {
+      "toilets": "Toalety",
+      "busStops": "Autobusové zastávky",
+      "iceCream": "Zmrzlina",
+      "shopping": "Nákupy",
+      "drugstore": "Drogerie",
+      "emergency": "Pohotovost"
+    },
+    "fallbacks": {
+      "toilets": "Veřejná toaleta",
+      "busStops": "Autobusová zastávka",
+      "iceCream": "Zmrzlinárna",
+      "shopping": "Obchod",
+      "drugstore": "Drogerie",
+      "emergency": "Nemocnice"
+    }
+  },
+  "modal": {
+    "closeBtn": "Zavřít",
+    "backToMap": "Zpět na mapu",
+    "streetPhoto": "Fotografie ulice",
+    "prevPhoto": "Předchozí fotografie",
+    "nextPhoto": "Další fotografie",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Data pocházejí z {{osmLink}} \u2014 volné, kolaborativní mapy světa vytvořené miliony dobrovolníků. Zobrazuje se pouze to, co bylo zmapováno.",
+        "wikiUrl": "https://cs.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Přispívejte do hřišť",
+        "text": "Kdokoli může přispívat. Dobrým výchozím bodem je {{learnOsmLink}}. Příslušné tagy jsou zdokumentovány v {{wikiLink}} a na stránce o {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/cs/beginner/",
+        "wikiLabel": "wiki OSM",
+        "equipmentLabel": "mapování jednotlivých zařízení"
+      },
+      "photos": {
+        "label": "Přidávejte fotografie",
+        "text": "Fotografie lze nahrát přímo přes {{mapcompleteLink}} \u2014 otevřete hřiště a klikněte na \"Přidat fotografii\". Fotografie jsou poskytovány prostřednictvím {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Komunita",
+        "text": "Máte otázky nebo chcete se zapojit? Místní komunita OSM je dostupná přes {{chatLink}}.",
+        "chatLabel": "chat místní komunity OSM"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Historie",
+        "text": "Mapa hřišť byla vytvořena {{authorLink}} jako závěrečný projekt {{courseLink}} \u2014 původně zaměřený na Berlín. Postupem času se rozvinula v obecnou mapu použitelnou pro jakoukoli oblast OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "kurzu GIS a webového mapování"
+      },
+      "project": {
+        "label": "Projekt",
+        "text": "Mapa hřišť je volná, interaktivní webová mapa založená na datech {{osmLink}}. Neobsahuje proprietární data, nevyžaduje přihlášení a nesleduje uživatele. Kdo zlepší data hřišť v OSM, automaticky zlepšuje i tuto mapu.",
+        "osmWikiUrl": "https://cs.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Zdrojový kód",
+        "text": "Projekt je open source a {{repoLink}}.",
+        "repoLabel": "veřejně dostupný"
+      }
+    }
+  }
+}

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "{{regionName}}er Spielplatzkarte",
+  "search": {
+    "placeholder": "Doppel-Shift für Suche",
+    "found": "\u201e{{query}}\u201c in {{location}}",
+    "foundGeneric": "\u201e{{query}}\u201c gefunden",
+    "notFound": "Kein Suchergebnis gefunden!"
+  },
+  "nav": {
+    "addData": "Daten ergänzen",
+    "about": "Über das Projekt",
+    "menu": "Menü"
+  },
+  "info": {
+    "hint": "Spielplatz antippen für Details",
+    "shareBtn": "Spielplatz teilen",
+    "osmBtn": "Bei OpenStreetMap anzeigen"
+  },
+  "completeness": {
+    "complete": "Fotos, Name & Details vorhanden",
+    "partial": "Teilweise erfasst",
+    "missing": "Noch keine Daten"
+  },
+  "accordion": {
+    "photos": "Bilder",
+    "equipment": "Ausstattung",
+    "shadow": "Schattigkeit",
+    "surroundings": "Umfeld",
+    "reviews": "Bewertungen",
+    "completeness": "Datenvollständigkeit"
+  },
+  "location": {
+    "btn": "Standort verfolgen",
+    "yourLocation": "deinem Standort"
+  },
+  "nearby": {
+    "title": "In der Nähe von {{label}}",
+    "defaultName": "Spielplatz",
+    "thisLocation": "diesem Ort"
+  },
+  "equipment": {
+    "devices_one": "{{count}} Spielgerät",
+    "devices_other": "{{count}} Spielgeräte",
+    "fitness_one": "{{count}} Fitnessgerät",
+    "fitness_other": "{{count}} Fitnessgeräte",
+    "benches_one": "{{count}} Sitzbank",
+    "benches_other": "{{count}} Sitzbänke",
+    "shelters_one": "{{count}} Unterstand",
+    "shelters_other": "{{count}} Unterstände",
+    "picnic_one": "{{count}} Picknicktisch",
+    "picnic_other": "{{count}} Picknicktische",
+    "fitnessDefault": "Fitnessgerät",
+    "addHint": "Spielgeräte noch nicht einzeln kartiert – hilf mit! 👇",
+    "addLink": "Spielgerät hinzufügen"
+  },
+  "photos": {
+    "none": "Noch keine Fotos für diesen Spielplatz.<br>Warst du schon dort?",
+    "addLink": "Foto hinzufügen",
+    "enlarge": "Klicken zum Vergrößern",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Umfeld-Daten konnten nicht geladen werden.",
+    "alwaysOpen": "Immer geöffnet",
+    "open": "Geöffnet",
+    "openUntil": "Geöffnet bis {{time}}",
+    "closed": "Geschlossen",
+    "opensAt": "Öffnet {{day}} um\u00a0{{time}}",
+    "openingHours": "Öffnungszeiten",
+    "today": "Heute",
+    "tomorrow": "Morgen",
+    "categories": {
+      "toilets": "Toiletten",
+      "busStops": "Bushaltestellen",
+      "iceCream": "Eis",
+      "shopping": "Einkaufen",
+      "drugstore": "Drogerie",
+      "emergency": "Notaufnahme"
+    },
+    "fallbacks": {
+      "toilets": "Öffentliche Toilette",
+      "busStops": "Bushaltestelle",
+      "iceCream": "Eisdiele",
+      "shopping": "Einkaufsmöglichkeit",
+      "drugstore": "Drogerie",
+      "emergency": "Krankenhaus"
+    }
+  },
+  "modal": {
+    "closeBtn": "Schlie\u00dfen",
+    "backToMap": "Zur\u00fcck zur Karte",
+    "streetPhoto": "Stra\u00dfenfoto",
+    "prevPhoto": "Vorheriges Foto",
+    "nextPhoto": "N\u00e4chstes Foto",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Die Daten stammen aus {{osmLink}} — einer freien, kollaborativen Weltkarte von Millionen Freiwilligen. Nur was eingetragen wurde, erscheint auch hier.",
+        "wikiUrl": "https://de.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Spielplätze beitragen",
+        "text": "Jede und jeder kann mitmachen. Einen Einstieg bietet {{learnOsmLink}}. Die relevanten Tags sind im {{wikiLink}} und auf der Seite zur {{equipmentLink}} dokumentiert.",
+        "learnOsmUrl": "https://learnosm.org/de/beginner/",
+        "wikiLabel": "OSM-Wiki",
+        "equipmentLabel": "Erfassung einzelner Spielgeräte"
+      },
+      "photos": {
+        "label": "Fotos hinzufügen",
+        "text": "Fotos lassen sich direkt über {{mapcompleteLink}} hochladen — einfach einen Spielplatz öffnen und „Foto hinzufügen“ klicken. Die Fotos werden über {{panoramaxLink}} bereitgestellt."
+      },
+      "community": {
+        "label": "Community",
+        "text": "Fragen oder mitmachen? Die lokale OSM-Community ist erreichbar über den {{chatLink}}.",
+        "chatLabel": "lokalen OSM-Community-Chat"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Geschichte",
+        "text": "Die Spielplatzkarte wurde von {{authorLink}} als Abschlussprojekt einer {{courseLink}} ins Leben gerufen — ursprünglich mit Fokus auf Berlin. Im Laufe der Zeit wurde sie zu einer generischen Spielplatzkarte weiterentwickelt, die für jede beliebige OSM-Region eingesetzt werden kann.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "GIS- und Webmapping-Weiterbildung"
+      },
+      "project": {
+        "label": "Das Projekt",
+        "text": "Die Spielplatzkarte ist eine freie, interaktive Webkarte auf Basis von {{osmLink}}-Daten. Sie enthält keine proprietären Daten, erfordert keine Anmeldung und verfolgt keine Nutzer. Wer Spielplatzdaten in OSM verbessert, verbessert damit automatisch auch diese Karte.",
+        "osmWikiUrl": "https://de.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Quellcode",
+        "text": "Das Projekt ist OpenSource und {{repoLink}}.",
+        "repoLabel": "öffentlich verfügbar"
+      }
+    }
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "{{regionName}} Playground Map",
+  "search": {
+    "placeholder": "Double-Shift to search",
+    "found": "\"{{query}}\" in {{location}}",
+    "foundGeneric": "\"{{query}}\" found",
+    "notFound": "No results found!"
+  },
+  "nav": {
+    "addData": "Add data",
+    "about": "About",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Tap a playground for details",
+    "shareBtn": "Share playground",
+    "osmBtn": "View on OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Photos, name & details available",
+    "partial": "Partially mapped",
+    "missing": "No data yet"
+  },
+  "accordion": {
+    "photos": "Photos",
+    "equipment": "Equipment",
+    "shadow": "Shade",
+    "surroundings": "Surroundings",
+    "reviews": "Reviews",
+    "completeness": "Data completeness"
+  },
+  "location": {
+    "btn": "My location",
+    "yourLocation": "your location"
+  },
+  "nearby": {
+    "title": "Near {{label}}",
+    "defaultName": "Playground",
+    "thisLocation": "this location"
+  },
+  "equipment": {
+    "devices_one": "{{count}} piece of equipment",
+    "devices_other": "{{count}} pieces of equipment",
+    "fitness_one": "{{count}} fitness station",
+    "fitness_other": "{{count}} fitness stations",
+    "benches_one": "{{count}} bench",
+    "benches_other": "{{count}} benches",
+    "shelters_one": "{{count}} shelter",
+    "shelters_other": "{{count}} shelters",
+    "picnic_one": "{{count}} picnic table",
+    "picnic_other": "{{count}} picnic tables",
+    "fitnessDefault": "Fitness station",
+    "addHint": "Equipment not yet mapped individually – help out! 👇",
+    "addLink": "Add equipment"
+  },
+  "photos": {
+    "none": "No photos for this playground yet.<br>Have you been there?",
+    "addLink": "Add photo",
+    "enlarge": "Click to enlarge",
+    "thumbnail": "Photo {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Could not load surroundings data.",
+    "alwaysOpen": "Always open",
+    "open": "Open",
+    "openUntil": "Open until {{time}}",
+    "closed": "Closed",
+    "opensAt": "Opens {{day}} at {{time}}",
+    "openingHours": "Opening hours",
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "categories": {
+      "toilets": "Toilets",
+      "busStops": "Bus stops",
+      "iceCream": "Ice cream",
+      "shopping": "Shopping",
+      "drugstore": "Drugstore",
+      "emergency": "Emergency"
+    },
+    "fallbacks": {
+      "toilets": "Public toilet",
+      "busStops": "Bus stop",
+      "iceCream": "Ice cream shop",
+      "shopping": "Shop",
+      "drugstore": "Drugstore",
+      "emergency": "Hospital"
+    }
+  },
+  "modal": {
+    "closeBtn": "Close",
+    "backToMap": "Back to map",
+    "streetPhoto": "Street photo",
+    "prevPhoto": "Previous photo",
+    "nextPhoto": "Next photo",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "The data comes from {{osmLink}} — a free, collaborative world map built by millions of volunteers. Only what has been mapped will appear here.",
+        "wikiUrl": "https://en.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Contribute playgrounds",
+        "text": "Anyone can contribute. A good starting point is {{learnOsmLink}}. The relevant tags are documented in the {{wikiLink}} and on the page about {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/en/beginner/",
+        "wikiLabel": "OSM wiki",
+        "equipmentLabel": "mapping individual playground equipment"
+      },
+      "photos": {
+        "label": "Add photos",
+        "text": "Photos can be uploaded directly via {{mapcompleteLink}} — just open a playground and click \"Add photo\". Photos are provided via {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Community",
+        "text": "Questions or want to get involved? The local OSM community can be reached via {{chatLink}}.",
+        "chatLabel": "local OSM community chat"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "History",
+        "text": "The playground map was created by {{authorLink}} as a final project of a {{courseLink}} — originally focused on Berlin. Over time it was developed into a generic playground map that can be used for any OSM region.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "GIS and web mapping course"
+      },
+      "project": {
+        "label": "The project",
+        "text": "The playground map is a free, interactive web map based on {{osmLink}} data. It contains no proprietary data, requires no login and does not track users. Anyone who improves playground data in OSM automatically improves this map.",
+        "osmWikiUrl": "https://en.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Source code",
+        "text": "The project is open source and {{repoLink}}.",
+        "repoLabel": "publicly available"
+      }
+    }
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Parques infantiles \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Doble-Shift para buscar",
+    "found": "\"{{query}}\" en {{location}}",
+    "foundGeneric": "\"{{query}}\" encontrado",
+    "notFound": "\u00a1No se encontraron resultados!"
+  },
+  "nav": {
+    "addData": "Contribuir",
+    "about": "Acerca de",
+    "menu": "Men\u00fa"
+  },
+  "info": {
+    "hint": "Toca un parque para ver detalles",
+    "shareBtn": "Compartir parque",
+    "osmBtn": "Ver en OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Fotos, nombre y detalles disponibles",
+    "partial": "Parcialmente mapeado",
+    "missing": "Sin datos a\u00fan"
+  },
+  "accordion": {
+    "photos": "Fotos",
+    "equipment": "Equipamiento",
+    "shadow": "Sombra",
+    "surroundings": "Entorno",
+    "reviews": "Rese\u00f1as",
+    "completeness": "Completitud de datos"
+  },
+  "location": {
+    "btn": "Mi ubicaci\u00f3n",
+    "yourLocation": "tu ubicaci\u00f3n"
+  },
+  "nearby": {
+    "title": "Cerca de {{label}}",
+    "defaultName": "Parque infantil",
+    "thisLocation": "esta ubicaci\u00f3n"
+  },
+  "equipment": {
+    "devices_one": "{{count}} equipo",
+    "devices_other": "{{count}} equipos",
+    "fitness_one": "{{count}} aparato de fitness",
+    "fitness_other": "{{count}} aparatos de fitness",
+    "benches_one": "{{count}} banco",
+    "benches_other": "{{count}} bancos",
+    "shelters_one": "{{count}} refugio",
+    "shelters_other": "{{count}} refugios",
+    "picnic_one": "{{count}} mesa de p\u00edcnic",
+    "picnic_other": "{{count}} mesas de p\u00edcnic",
+    "fitnessDefault": "Aparato de fitness",
+    "addHint": "Equipos a\u00fan no mapeados individualmente \u2013 \u00a1ayuda! \ud83d\udc47",
+    "addLink": "A\u00f1adir equipo"
+  },
+  "photos": {
+    "none": "A\u00fan no hay fotos de este parque.<br>\u00bfHas estado all\u00ed?",
+    "addLink": "A\u00f1adir foto",
+    "enlarge": "Clic para ampliar",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "No se pudieron cargar los datos del entorno.",
+    "alwaysOpen": "Siempre abierto",
+    "open": "Abierto",
+    "openUntil": "Abierto hasta {{time}}",
+    "closed": "Cerrado",
+    "opensAt": "Abre {{day}} a las {{time}}",
+    "openingHours": "Horario",
+    "today": "Hoy",
+    "tomorrow": "Ma\u00f1ana",
+    "categories": {
+      "toilets": "Aseos",
+      "busStops": "Paradas de autob\u00fas",
+      "iceCream": "Helados",
+      "shopping": "Compras",
+      "drugstore": "Droguер\u00eda",
+      "emergency": "Urgencias"
+    },
+    "fallbacks": {
+      "toilets": "Aseo p\u00fablico",
+      "busStops": "Parada de autob\u00fas",
+      "iceCream": "Helader\u00eda",
+      "shopping": "Tienda",
+      "drugstore": "Droguер\u00eda",
+      "emergency": "Hospital"
+    }
+  },
+  "modal": {
+    "closeBtn": "Cerrar",
+    "backToMap": "Volver al mapa",
+    "streetPhoto": "Foto de calle",
+    "prevPhoto": "Foto anterior",
+    "nextPhoto": "Foto siguiente",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Los datos provienen de {{osmLink}} \u2014 un mapa mundial libre y colaborativo creado por millones de voluntarios. Solo lo que ha sido mapeado aparece aqu\u00ed.",
+        "wikiUrl": "https://es.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Contribuir a los parques",
+        "text": "Cualquiera puede contribuir. Un buen punto de partida es {{learnOsmLink}}. Las etiquetas relevantes est\u00e1n documentadas en el {{wikiLink}} y en la p\u00e1gina sobre {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/es/beginner/",
+        "wikiLabel": "wiki de OSM",
+        "equipmentLabel": "el mapeo de equipos individuales"
+      },
+      "photos": {
+        "label": "A\u00f1adir fotos",
+        "text": "Las fotos se pueden subir directamente a trav\u00e9s de {{mapcompleteLink}} \u2014 abre un parque y haz clic en \"A\u00f1adir foto\". Las fotos son proporcionadas por {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Comunidad",
+        "text": "\u00bfPreguntas o quieres participar? La comunidad OSM local se puede contactar a trav\u00e9s de {{chatLink}}.",
+        "chatLabel": "chat de la comunidad OSM local"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Historia",
+        "text": "El mapa de parques fue creado por {{authorLink}} como proyecto final de un {{courseLink}} \u2014 originalmente centrado en Berl\u00edn. Con el tiempo se desarroll\u00f3 en un mapa gen\u00e9rico utilizable para cualquier regi\u00f3n OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "curso de SIG y cartograf\u00eda web"
+      },
+      "project": {
+        "label": "El proyecto",
+        "text": "El mapa de parques es un mapa web libre e interactivo basado en datos de {{osmLink}}. No contiene datos propietarios, no requiere inicio de sesi\u00f3n y no rastrea usuarios. Quien mejora los datos en OSM mejora autom\u00e1ticamente este mapa.",
+        "osmWikiUrl": "https://es.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "C\u00f3digo fuente",
+        "text": "El proyecto es de c\u00f3digo abierto y {{repoLink}}.",
+        "repoLabel": "disponible p\u00fablicamente"
+      }
+    }
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Aires de jeux \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Double-Shift pour rechercher",
+    "found": "\u00ab\u00a0{{query}}\u00a0\u00bb \u00e0 {{location}}",
+    "foundGeneric": "\u00ab\u00a0{{query}}\u00a0\u00bb trouv\u00e9",
+    "notFound": "Aucun r\u00e9sultat trouv\u00e9\u00a0!"
+  },
+  "nav": {
+    "addData": "Contribuer",
+    "about": "\u00c0 propos",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Appuyer sur une aire de jeux pour les d\u00e9tails",
+    "shareBtn": "Partager",
+    "osmBtn": "Voir sur OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Photos, nom & d\u00e9tails disponibles",
+    "partial": "Partiellement renseign\u00e9",
+    "missing": "Aucune donn\u00e9e"
+  },
+  "accordion": {
+    "photos": "Photos",
+    "equipment": "\u00c9quipements",
+    "shadow": "Ombrage",
+    "surroundings": "Environnement",
+    "reviews": "Avis",
+    "completeness": "Compl\u00e9tude des donn\u00e9es"
+  },
+  "location": {
+    "btn": "Ma position",
+    "yourLocation": "votre position"
+  },
+  "nearby": {
+    "title": "\u00c0 proximit\u00e9 de {{label}}",
+    "defaultName": "Aire de jeux",
+    "thisLocation": "cet endroit"
+  },
+  "equipment": {
+    "devices_one": "{{count}} \u00e9quipement",
+    "devices_other": "{{count}} \u00e9quipements",
+    "fitness_one": "{{count}} appareil de fitness",
+    "fitness_other": "{{count}} appareils de fitness",
+    "benches_one": "{{count}} banc",
+    "benches_other": "{{count}} bancs",
+    "shelters_one": "{{count}} abri",
+    "shelters_other": "{{count}} abris",
+    "picnic_one": "{{count}} table de pique-nique",
+    "picnic_other": "{{count}} tables de pique-nique",
+    "fitnessDefault": "Appareil de fitness",
+    "addHint": "\u00c9quipements pas encore cartographi\u00e9s individuellement \u2013 aidez-nous\u00a0! \ud83d\udc47",
+    "addLink": "Ajouter un \u00e9quipement"
+  },
+  "photos": {
+    "none": "Pas encore de photos pour cette aire de jeux.<br>Vous y \u00eates all\u00e9\u00a0?",
+    "addLink": "Ajouter une photo",
+    "enlarge": "Cliquer pour agrandir",
+    "thumbnail": "Photo {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Impossible de charger les donn\u00e9es environnantes.",
+    "alwaysOpen": "Toujours ouvert",
+    "open": "Ouvert",
+    "openUntil": "Ouvert jusqu'\u00e0 {{time}}",
+    "closed": "Ferm\u00e9",
+    "opensAt": "Ouvre {{day}} \u00e0 {{time}}",
+    "openingHours": "Horaires",
+    "today": "Aujourd'hui",
+    "tomorrow": "Demain",
+    "categories": {
+      "toilets": "Toilettes",
+      "busStops": "Arr\u00eats de bus",
+      "iceCream": "Glaces",
+      "shopping": "Courses",
+      "drugstore": "Droguerie",
+      "emergency": "Urgences"
+    },
+    "fallbacks": {
+      "toilets": "Toilettes publiques",
+      "busStops": "Arr\u00eat de bus",
+      "iceCream": "Glacier",
+      "shopping": "Magasin",
+      "drugstore": "Droguerie",
+      "emergency": "H\u00f4pital"
+    }
+  },
+  "modal": {
+    "closeBtn": "Fermer",
+    "backToMap": "Retour \u00e0 la carte",
+    "streetPhoto": "Photo de rue",
+    "prevPhoto": "Photo pr\u00e9c\u00e9dente",
+    "nextPhoto": "Photo suivante",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Les donn\u00e9es proviennent d'{{osmLink}} \u2014 une carte mondiale libre et collaborative cr\u00e9\u00e9e par des millions de b\u00e9n\u00e9voles. Seul ce qui a \u00e9t\u00e9 cartographi\u00e9 appara\u00eet ici.",
+        "wikiUrl": "https://fr.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Contribuer aux aires de jeux",
+        "text": "Tout le monde peut contribuer. Un bon point de d\u00e9part est {{learnOsmLink}}. Les tags pertinents sont document\u00e9s dans le {{wikiLink}} et sur la page concernant {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/fr/beginner/",
+        "wikiLabel": "wiki OSM",
+        "equipmentLabel": "la cartographie des \u00e9quipements individuels"
+      },
+      "photos": {
+        "label": "Ajouter des photos",
+        "text": "Les photos peuvent \u00eatre t\u00e9l\u00e9vers\u00e9es directement via {{mapcompleteLink}} \u2014 ouvrez simplement une aire de jeux et cliquez sur \"Ajouter une photo\". Les photos sont fournies par {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Communaut\u00e9",
+        "text": "Des questions ou envie de participer\u00a0? La communaut\u00e9 OSM locale est accessible via {{chatLink}}.",
+        "chatLabel": "chat de la communaut\u00e9 OSM locale"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Histoire",
+        "text": "La carte des aires de jeux a \u00e9t\u00e9 cr\u00e9\u00e9e par {{authorLink}} dans le cadre d'un {{courseLink}} \u2014 \u00e0 l'origine centr\u00e9e sur Berlin. Au fil du temps, elle a \u00e9volu\u00e9 en une carte g\u00e9n\u00e9rique utilisable pour n'importe quelle r\u00e9gion OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "cours de SIG et cartographie web"
+      },
+      "project": {
+        "label": "Le projet",
+        "text": "La carte des aires de jeux est une carte web libre et interactive bas\u00e9e sur les donn\u00e9es d'{{osmLink}}. Elle ne contient aucune donn\u00e9e propri\u00e9taire, ne n\u00e9cessite pas de connexion et ne suit pas les utilisateurs. Quiconque am\u00e9liore les donn\u00e9es dans OSM am\u00e9liore automatiquement cette carte.",
+        "osmWikiUrl": "https://fr.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Code source",
+        "text": "Le projet est open source et {{repoLink}}.",
+        "repoLabel": "disponible publiquement"
+      }
+    }
+  }
+}

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Aree gioco \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Doppio-Shift per cercare",
+    "found": "\"{{query}}\" a {{location}}",
+    "foundGeneric": "\"{{query}}\" trovato",
+    "notFound": "Nessun risultato trovato!"
+  },
+  "nav": {
+    "addData": "Contribuisci",
+    "about": "Informazioni",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Tocca un parco giochi per i dettagli",
+    "shareBtn": "Condividi parco",
+    "osmBtn": "Visualizza su OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Foto, nome e dettagli disponibili",
+    "partial": "Parzialmente mappato",
+    "missing": "Nessun dato ancora"
+  },
+  "accordion": {
+    "photos": "Foto",
+    "equipment": "Attrezzatura",
+    "shadow": "Ombra",
+    "surroundings": "Dintorni",
+    "reviews": "Recensioni",
+    "completeness": "Completezza dei dati"
+  },
+  "location": {
+    "btn": "La mia posizione",
+    "yourLocation": "la tua posizione"
+  },
+  "nearby": {
+    "title": "Vicino a {{label}}",
+    "defaultName": "Parco giochi",
+    "thisLocation": "questa posizione"
+  },
+  "equipment": {
+    "devices_one": "{{count}} attrezzo",
+    "devices_other": "{{count}} attrezzi",
+    "fitness_one": "{{count}} attrezzo fitness",
+    "fitness_other": "{{count}} attrezzi fitness",
+    "benches_one": "{{count}} panchina",
+    "benches_other": "{{count}} panchine",
+    "shelters_one": "{{count}} riparo",
+    "shelters_other": "{{count}} ripari",
+    "picnic_one": "{{count}} tavolo da picnic",
+    "picnic_other": "{{count}} tavoli da picnic",
+    "fitnessDefault": "Attrezzo fitness",
+    "addHint": "Attrezzature non ancora mappate individualmente \u2013 aiuta! \ud83d\udc47",
+    "addLink": "Aggiungi attrezzo"
+  },
+  "photos": {
+    "none": "Ancora nessuna foto per questo parco.<br>Ci sei stato?",
+    "addLink": "Aggiungi foto",
+    "enlarge": "Clicca per ingrandire",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Impossibile caricare i dati dei dintorni.",
+    "alwaysOpen": "Sempre aperto",
+    "open": "Aperto",
+    "openUntil": "Aperto fino alle {{time}}",
+    "closed": "Chiuso",
+    "opensAt": "Apre {{day}} alle {{time}}",
+    "openingHours": "Orari",
+    "today": "Oggi",
+    "tomorrow": "Domani",
+    "categories": {
+      "toilets": "Bagni",
+      "busStops": "Fermate bus",
+      "iceCream": "Gelati",
+      "shopping": "Spesa",
+      "drugstore": "Farmacia",
+      "emergency": "Pronto soccorso"
+    },
+    "fallbacks": {
+      "toilets": "Bagno pubblico",
+      "busStops": "Fermata bus",
+      "iceCream": "Gelateria",
+      "shopping": "Negozio",
+      "drugstore": "Farmacia",
+      "emergency": "Ospedale"
+    }
+  },
+  "modal": {
+    "closeBtn": "Chiudi",
+    "backToMap": "Torna alla mappa",
+    "streetPhoto": "Foto di strada",
+    "prevPhoto": "Foto precedente",
+    "nextPhoto": "Foto successiva",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "I dati provengono da {{osmLink}} \u2014 una mappa mondiale libera e collaborativa creata da milioni di volontari. Appare solo ci\u00f2 che \u00e8 stato mappato.",
+        "wikiUrl": "https://it.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Contribuisci ai parchi",
+        "text": "Chiunque pu\u00f2 contribuire. Un buon punto di partenza \u00e8 {{learnOsmLink}}. I tag rilevanti sono documentati nel {{wikiLink}} e nella pagina su {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/it/beginner/",
+        "wikiLabel": "wiki di OSM",
+        "equipmentLabel": "la mappatura delle attrezzature individuali"
+      },
+      "photos": {
+        "label": "Aggiungi foto",
+        "text": "Le foto possono essere caricate direttamente tramite {{mapcompleteLink}} \u2014 apri un parco e clicca su \"Aggiungi foto\". Le foto sono fornite da {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Comunit\u00e0",
+        "text": "Domande o vuoi partecipare? La comunit\u00e0 OSM locale \u00e8 raggiungibile tramite {{chatLink}}.",
+        "chatLabel": "chat della comunit\u00e0 OSM locale"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Storia",
+        "text": "La mappa dei parchi giochi \u00e8 stata creata da {{authorLink}} come progetto finale di un {{courseLink}} \u2014 originariamente focalizzata su Berlino. Nel tempo si \u00e8 evoluta in una mappa generica utilizzabile per qualsiasi regione OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "corso GIS e web mapping"
+      },
+      "project": {
+        "label": "Il progetto",
+        "text": "La mappa dei parchi giochi \u00e8 una mappa web libera e interattiva basata sui dati di {{osmLink}}. Non contiene dati proprietari, non richiede login e non traccia gli utenti. Chi migliora i dati in OSM migliora automaticamente questa mappa.",
+        "osmWikiUrl": "https://it.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Codice sorgente",
+        "text": "Il progetto \u00e8 open source e {{repoLink}}.",
+        "repoLabel": "disponibile pubblicamente"
+      }
+    }
+  }
+}

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,132 @@
+{
+  "appTitle": "遊び場マップ \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Shiftキーを2回押して検索",
+    "found": "{{location}}で「{{query}}」",
+    "foundGeneric": "「{{query}}」が見つかりました",
+    "notFound": "結果が見つかりませんでした！"
+  },
+  "nav": {
+    "addData": "データを追加",
+    "about": "プロジェクトについて",
+    "menu": "メニュー"
+  },
+  "info": {
+    "hint": "遊び場をタップして詳細を表示",
+    "shareBtn": "遊び場を共有",
+    "osmBtn": "OpenStreetMapで表示"
+  },
+  "completeness": {
+    "complete": "写真・名称・詳細あり",
+    "partial": "一部マッピング済み",
+    "missing": "データなし"
+  },
+  "accordion": {
+    "photos": "写真",
+    "equipment": "遊具",
+    "shadow": "日陰",
+    "surroundings": "周辺",
+    "reviews": "レビュー",
+    "completeness": "データの完成度"
+  },
+  "location": {
+    "btn": "現在地",
+    "yourLocation": "現在地"
+  },
+  "nearby": {
+    "title": "{{label}}の近く",
+    "defaultName": "遊び場",
+    "thisLocation": "この場所"
+  },
+  "equipment": {
+    "devices_other": "遊具 {{count}} 個",
+    "fitness_other": "フィットネス器具 {{count}} 個",
+    "benches_other": "ベンチ {{count}} 脚",
+    "shelters_other": "シェルター {{count}} 基",
+    "picnic_other": "ピクニックテーブル {{count}} 台",
+    "fitnessDefault": "フィットネス器具",
+    "addHint": "遊具はまだ個別にマッピングされていません \u2013 ご協力ください！ 👇",
+    "addLink": "遊具を追加"
+  },
+  "photos": {
+    "none": "この遊び場の写真はまだありません。<br>訪れたことがありますか？",
+    "addLink": "写真を追加",
+    "enlarge": "クリックして拡大",
+    "thumbnail": "写真 {{n}}"
+  },
+  "poi": {
+    "errorLoad": "周辺データを読み込めませんでした。",
+    "alwaysOpen": "常時開放",
+    "open": "営業中",
+    "openUntil": "{{time}}まで営業",
+    "closed": "閉店",
+    "opensAt": "{{day}} {{time}}に開きます",
+    "openingHours": "営業時間",
+    "today": "今日",
+    "tomorrow": "明日",
+    "categories": {
+      "toilets": "トイレ",
+      "busStops": "バス停",
+      "iceCream": "アイスクリーム",
+      "shopping": "ショッピング",
+      "drugstore": "ドラッグストア",
+      "emergency": "救急"
+    },
+    "fallbacks": {
+      "toilets": "公衆トイレ",
+      "busStops": "バス停",
+      "iceCream": "アイスクリーム店",
+      "shopping": "店舗",
+      "drugstore": "ドラッグストア",
+      "emergency": "病院"
+    }
+  },
+  "modal": {
+    "closeBtn": "閉じる",
+    "backToMap": "地図に戻る",
+    "streetPhoto": "ストリート写真",
+    "prevPhoto": "前の写真",
+    "nextPhoto": "次の写真",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "データは{{osmLink}}から提供されています \u2014 数百万人のボランティアによって作られた無料の共同世界地図です。マッピングされたものだけが表示されます。",
+        "wikiUrl": "https://ja.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "遊び場に貢献する",
+        "text": "誰でも貢献できます。{{learnOsmLink}}が良い出発点です。関連するタグは{{wikiLink}}および{{equipmentLink}}のページに記載されています。",
+        "learnOsmUrl": "https://learnosm.org/ja/beginner/",
+        "wikiLabel": "OSM wiki",
+        "equipmentLabel": "個別遊具のマッピング"
+      },
+      "photos": {
+        "label": "写真を追加する",
+        "text": "写真は{{mapcompleteLink}}から直接アップロードできます \u2014 遊び場を開いて「写真を追加」をクリックしてください。写真は{{panoramaxLink}}によって提供されます。"
+      },
+      "community": {
+        "label": "コミュニティ",
+        "text": "質問や参加を希望する方は、{{chatLink}}からローカルOSMコミュニティにご連絡ください。",
+        "chatLabel": "ローカルOSMコミュニティチャット"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "歴史",
+        "text": "遊び場マップは{{authorLink}}によって{{courseLink}}の最終プロジェクトとして作成されました \u2014 当初はベルリンを対象としていました。その後、任意のOSM地域で使用できる汎用マップへと発展しました。",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "GISおよびウェブマッピングコース"
+      },
+      "project": {
+        "label": "プロジェクト",
+        "text": "遊び場マップは{{osmLink}}データに基づく無料のインタラクティブウェブマップです。独自データを含まず、ログインも不要で、ユーザーを追跡しません。OSMで遊び場データを改善すると、このマップも自動的に改善されます。",
+        "osmWikiUrl": "https://ja.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "ソースコード",
+        "text": "このプロジェクトはオープンソースで、{{repoLink}}。",
+        "repoLabel": "公開されています"
+      }
+    }
+  }
+}

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Speeltuinenkaart \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Dubbel-Shift om te zoeken",
+    "found": "\"{{query}}\" in {{location}}",
+    "foundGeneric": "\"{{query}}\" gevonden",
+    "notFound": "Geen resultaten gevonden!"
+  },
+  "nav": {
+    "addData": "Gegevens toevoegen",
+    "about": "Over het project",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Tik op een speeltuin voor details",
+    "shareBtn": "Speeltuin delen",
+    "osmBtn": "Bekijk op OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Foto's, naam & details beschikbaar",
+    "partial": "Gedeeltelijk in kaart gebracht",
+    "missing": "Nog geen gegevens"
+  },
+  "accordion": {
+    "photos": "Foto's",
+    "equipment": "Speeltoestellen",
+    "shadow": "Schaduw",
+    "surroundings": "Omgeving",
+    "reviews": "Beoordelingen",
+    "completeness": "Volledigheid van gegevens"
+  },
+  "location": {
+    "btn": "Mijn locatie",
+    "yourLocation": "jouw locatie"
+  },
+  "nearby": {
+    "title": "In de buurt van {{label}}",
+    "defaultName": "Speeltuin",
+    "thisLocation": "deze locatie"
+  },
+  "equipment": {
+    "devices_one": "{{count}} speeltoestel",
+    "devices_other": "{{count}} speeltoestellen",
+    "fitness_one": "{{count}} fitnesstoestel",
+    "fitness_other": "{{count}} fitnesstoestellen",
+    "benches_one": "{{count}} bank",
+    "benches_other": "{{count}} banken",
+    "shelters_one": "{{count}} overkapping",
+    "shelters_other": "{{count}} overkappingen",
+    "picnic_one": "{{count}} picknicktafel",
+    "picnic_other": "{{count}} picknicktafels",
+    "fitnessDefault": "Fitnesstoestel",
+    "addHint": "Toestellen nog niet individueel in kaart gebracht \u2013 help mee! 👇",
+    "addLink": "Toestel toevoegen"
+  },
+  "photos": {
+    "none": "Nog geen foto's voor deze speeltuin.<br>Ben je er al geweest?",
+    "addLink": "Foto toevoegen",
+    "enlarge": "Klikken om te vergroten",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Omgevingsgegevens konden niet worden geladen.",
+    "alwaysOpen": "Altijd open",
+    "open": "Open",
+    "openUntil": "Open tot {{time}}",
+    "closed": "Gesloten",
+    "opensAt": "Opent {{day}} om {{time}}",
+    "openingHours": "Openingstijden",
+    "today": "Vandaag",
+    "tomorrow": "Morgen",
+    "categories": {
+      "toilets": "Toiletten",
+      "busStops": "Bushaltes",
+      "iceCream": "IJsjes",
+      "shopping": "Winkelen",
+      "drugstore": "Drogisterij",
+      "emergency": "Spoedeisende hulp"
+    },
+    "fallbacks": {
+      "toilets": "Openbaar toilet",
+      "busStops": "Bushalte",
+      "iceCream": "IJssalon",
+      "shopping": "Winkel",
+      "drugstore": "Drogisterij",
+      "emergency": "Ziekenhuis"
+    }
+  },
+  "modal": {
+    "closeBtn": "Sluiten",
+    "backToMap": "Terug naar de kaart",
+    "streetPhoto": "Straatfoto",
+    "prevPhoto": "Vorige foto",
+    "nextPhoto": "Volgende foto",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "De gegevens komen van {{osmLink}} \u2014 een vrije, collaboratieve wereldkaart gemaakt door miljoenen vrijwilligers. Alleen wat in kaart is gebracht verschijnt hier.",
+        "wikiUrl": "https://nl.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Bijdragen aan speeltuinen",
+        "text": "Iedereen kan bijdragen. Een goed startpunt is {{learnOsmLink}}. De relevante tags zijn gedocumenteerd in de {{wikiLink}} en op de pagina over {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/nl/beginner/",
+        "wikiLabel": "OSM-wiki",
+        "equipmentLabel": "het in kaart brengen van individuele speeltoestellen"
+      },
+      "photos": {
+        "label": "Foto's toevoegen",
+        "text": "Foto's kunnen direct worden geüpload via {{mapcompleteLink}} \u2014 open een speeltuin en klik op \"Foto toevoegen\". Foto's worden aangeleverd door {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Gemeenschap",
+        "text": "Vragen of wil je meedoen? De lokale OSM-gemeenschap is bereikbaar via {{chatLink}}.",
+        "chatLabel": "lokale OSM-gemeenschapschat"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Geschiedenis",
+        "text": "De speeltuinenkaart is gemaakt door {{authorLink}} als eindproject van een {{courseLink}} \u2014 oorspronkelijk gericht op Berlijn. In de loop van de tijd is het uitgegroeid tot een generieke kaart die voor elke OSM-regio kan worden gebruikt.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "GIS en webmapping cursus"
+      },
+      "project": {
+        "label": "Het project",
+        "text": "De speeltuinenkaart is een vrije, interactieve webkaart op basis van {{osmLink}}-gegevens. Het bevat geen eigendomsgegevens, vereist geen aanmelding en volgt geen gebruikers. Wie speeltuingegevens in OSM verbetert, verbetert automatisch ook deze kaart.",
+        "osmWikiUrl": "https://nl.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Broncode",
+        "text": "Het project is open source en {{repoLink}}.",
+        "repoLabel": "openbaar beschikbaar"
+      }
+    }
+  }
+}

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -1,0 +1,147 @@
+{
+  "appTitle": "Mapa placów zabaw \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Podwójny Shift, aby wyszukać",
+    "found": "\"{{query}}\" w {{location}}",
+    "foundGeneric": "\"{{query}}\" znaleziono",
+    "notFound": "Nie znaleziono wyników!"
+  },
+  "nav": {
+    "addData": "Dodaj dane",
+    "about": "O projekcie",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Dotknij plac zabaw, aby zobaczyć szczegóły",
+    "shareBtn": "Udostępnij plac zabaw",
+    "osmBtn": "Zobacz na OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Zdjęcia, nazwa i szczegóły dostępne",
+    "partial": "Częściowo zmapowane",
+    "missing": "Brak danych"
+  },
+  "accordion": {
+    "photos": "Zdjęcia",
+    "equipment": "Wyposażenie",
+    "shadow": "Cień",
+    "surroundings": "Okolica",
+    "reviews": "Recenzje",
+    "completeness": "Kompletność danych"
+  },
+  "location": {
+    "btn": "Moja lokalizacja",
+    "yourLocation": "twojej lokalizacji"
+  },
+  "nearby": {
+    "title": "W pobliżu {{label}}",
+    "defaultName": "Plac zabaw",
+    "thisLocation": "tej lokalizacji"
+  },
+  "equipment": {
+    "devices_one": "{{count}} urządzenie",
+    "devices_few": "{{count}} urządzenia",
+    "devices_many": "{{count}} urządzeń",
+    "devices_other": "{{count}} urządzeń",
+    "fitness_one": "{{count}} urządzenie fitness",
+    "fitness_few": "{{count}} urządzenia fitness",
+    "fitness_many": "{{count}} urządzeń fitness",
+    "fitness_other": "{{count}} urządzeń fitness",
+    "benches_one": "{{count}} ławka",
+    "benches_few": "{{count}} ławki",
+    "benches_many": "{{count}} ławek",
+    "benches_other": "{{count}} ławek",
+    "shelters_one": "{{count}} wiata",
+    "shelters_few": "{{count}} wiaty",
+    "shelters_many": "{{count}} wiat",
+    "shelters_other": "{{count}} wiat",
+    "picnic_one": "{{count}} stół piknikowy",
+    "picnic_few": "{{count}} stoły piknikowe",
+    "picnic_many": "{{count}} stołów piknikowych",
+    "picnic_other": "{{count}} stołów piknikowych",
+    "fitnessDefault": "Urządzenie fitness",
+    "addHint": "Wyposażenie jeszcze nie zmapowane indywidualnie \u2013 pomóż! 👇",
+    "addLink": "Dodaj wyposażenie"
+  },
+  "photos": {
+    "none": "Brak zdjęć dla tego placu zabaw.<br>Byłeś tam?",
+    "addLink": "Dodaj zdjęcie",
+    "enlarge": "Kliknij, aby powiększyć",
+    "thumbnail": "Zdjęcie {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Nie udało się załadować danych otoczenia.",
+    "alwaysOpen": "Zawsze otwarte",
+    "open": "Otwarte",
+    "openUntil": "Otwarte do {{time}}",
+    "closed": "Zamknięte",
+    "opensAt": "Otwiera {{day}} o {{time}}",
+    "openingHours": "Godziny otwarcia",
+    "today": "Dzisiaj",
+    "tomorrow": "Jutro",
+    "categories": {
+      "toilets": "Toalety",
+      "busStops": "Przystanki autobusowe",
+      "iceCream": "Lody",
+      "shopping": "Zakupy",
+      "drugstore": "Drogeria",
+      "emergency": "Pogotowie"
+    },
+    "fallbacks": {
+      "toilets": "Toaleta publiczna",
+      "busStops": "Przystanek autobusowy",
+      "iceCream": "Lodziarnia",
+      "shopping": "Sklep",
+      "drugstore": "Drogeria",
+      "emergency": "Szpital"
+    }
+  },
+  "modal": {
+    "closeBtn": "Zamknij",
+    "backToMap": "Wróć do mapy",
+    "streetPhoto": "Zdjęcie uliczne",
+    "prevPhoto": "Poprzednie zdjęcie",
+    "nextPhoto": "Następne zdjęcie",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Dane pochodzą z {{osmLink}} \u2014 wolnej, współpracy mapy świata tworzonej przez miliony wolontariuszy. Wyświetlane jest tylko to, co zostało zmapowane.",
+        "wikiUrl": "https://pl.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Dodawaj place zabaw",
+        "text": "Każdy może wnosić wkład. Dobrym punktem startowym jest {{learnOsmLink}}. Odpowiednie tagi są udokumentowane w {{wikiLink}} i na stronie dotyczącej {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/pl/beginner/",
+        "wikiLabel": "wiki OSM",
+        "equipmentLabel": "mapowania indywidualnych urządzeń"
+      },
+      "photos": {
+        "label": "Dodawaj zdjęcia",
+        "text": "Zdjęcia można przesyłać bezpośrednio przez {{mapcompleteLink}} \u2014 otwórz plac zabaw i kliknij \"Dodaj zdjęcie\". Zdjęcia są dostarczane przez {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Społeczność",
+        "text": "Pytania lub chcesz dołączyć? Lokalna społeczność OSM jest dostępna przez {{chatLink}}.",
+        "chatLabel": "czat lokalnej społeczności OSM"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Historia",
+        "text": "Mapa placów zabaw została stworzona przez {{authorLink}} jako projekt końcowy {{courseLink}} \u2014 pierwotnie skupiony na Berlinie. Z czasem rozwinęła się w ogólną mapę, którą można wykorzystać dla dowolnego regionu OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "kursu GIS i webmappingu"
+      },
+      "project": {
+        "label": "Projekt",
+        "text": "Mapa placów zabaw to wolna, interaktywna mapa internetowa oparta na danych {{osmLink}}. Nie zawiera danych własnościowych, nie wymaga logowania i nie śledzi użytkowników. Kto ulepsza dane w OSM, automatycznie ulepsza tę mapę.",
+        "osmWikiUrl": "https://pl.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Kod źródłowy",
+        "text": "Projekt jest open source i {{repoLink}}.",
+        "repoLabel": "publicznie dostępny"
+      }
+    }
+  }
+}

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Mapa de parques infantis \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Duplo Shift para pesquisar",
+    "found": "\"{{query}}\" em {{location}}",
+    "foundGeneric": "\"{{query}}\" encontrado",
+    "notFound": "Nenhum resultado encontrado!"
+  },
+  "nav": {
+    "addData": "Adicionar dados",
+    "about": "Sobre o projeto",
+    "menu": "Menu"
+  },
+  "info": {
+    "hint": "Toque num parque para ver detalhes",
+    "shareBtn": "Partilhar parque",
+    "osmBtn": "Ver no OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Fotos, nome e detalhes disponíveis",
+    "partial": "Parcialmente mapeado",
+    "missing": "Sem dados"
+  },
+  "accordion": {
+    "photos": "Fotos",
+    "equipment": "Equipamentos",
+    "shadow": "Sombra",
+    "surroundings": "Arredores",
+    "reviews": "Avaliações",
+    "completeness": "Completude dos dados"
+  },
+  "location": {
+    "btn": "Minha localização",
+    "yourLocation": "sua localização"
+  },
+  "nearby": {
+    "title": "Perto de {{label}}",
+    "defaultName": "Parque infantil",
+    "thisLocation": "esta localização"
+  },
+  "equipment": {
+    "devices_one": "{{count}} equipamento",
+    "devices_other": "{{count}} equipamentos",
+    "fitness_one": "{{count}} equipamento de fitness",
+    "fitness_other": "{{count}} equipamentos de fitness",
+    "benches_one": "{{count}} banco",
+    "benches_other": "{{count}} bancos",
+    "shelters_one": "{{count}} abrigo",
+    "shelters_other": "{{count}} abrigos",
+    "picnic_one": "{{count}} mesa de piquenique",
+    "picnic_other": "{{count}} mesas de piquenique",
+    "fitnessDefault": "Equipamento de fitness",
+    "addHint": "Equipamentos ainda não mapeados individualmente \u2013 ajude! 👇",
+    "addLink": "Adicionar equipamento"
+  },
+  "photos": {
+    "none": "Ainda sem fotos para este parque.<br>Já lá esteve?",
+    "addLink": "Adicionar foto",
+    "enlarge": "Clique para ampliar",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Não foi possível carregar os dados da área.",
+    "alwaysOpen": "Sempre aberto",
+    "open": "Aberto",
+    "openUntil": "Aberto até às {{time}}",
+    "closed": "Fechado",
+    "opensAt": "Abre {{day}} às {{time}}",
+    "openingHours": "Horário de funcionamento",
+    "today": "Hoje",
+    "tomorrow": "Amanhã",
+    "categories": {
+      "toilets": "Casas de banho",
+      "busStops": "Paragens de autocarro",
+      "iceCream": "Gelados",
+      "shopping": "Compras",
+      "drugstore": "Farmácia",
+      "emergency": "Urgências"
+    },
+    "fallbacks": {
+      "toilets": "Casa de banho pública",
+      "busStops": "Paragem de autocarro",
+      "iceCream": "Gelataria",
+      "shopping": "Loja",
+      "drugstore": "Farmácia",
+      "emergency": "Hospital"
+    }
+  },
+  "modal": {
+    "closeBtn": "Fechar",
+    "backToMap": "Voltar ao mapa",
+    "streetPhoto": "Foto de rua",
+    "prevPhoto": "Foto anterior",
+    "nextPhoto": "Próxima foto",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Os dados provêm do {{osmLink}} \u2014 um mapa mundial livre e colaborativo criado por milhões de voluntários. Apenas o que foi mapeado aparece aqui.",
+        "wikiUrl": "https://pt.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Contribuir para parques infantis",
+        "text": "Qualquer pessoa pode contribuir. Um bom ponto de partida é o {{learnOsmLink}}. As etiquetas relevantes estão documentadas na {{wikiLink}} e na página sobre {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/pt/beginner/",
+        "wikiLabel": "wiki do OSM",
+        "equipmentLabel": "mapeamento de equipamentos individuais"
+      },
+      "photos": {
+        "label": "Adicionar fotos",
+        "text": "As fotos podem ser carregadas diretamente através do {{mapcompleteLink}} \u2014 abra um parque e clique em \"Adicionar foto\". As fotos são fornecidas pelo {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Comunidade",
+        "text": "Tem dúvidas ou quer participar? A comunidade OSM local está disponível através do {{chatLink}}.",
+        "chatLabel": "chat da comunidade OSM local"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "História",
+        "text": "O mapa de parques infantis foi criado por {{authorLink}} como projeto final de um {{courseLink}} \u2014 originalmente focado em Berlim. Com o tempo, tornou-se um mapa genérico utilizável para qualquer região do OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "curso de GIS e webmapping"
+      },
+      "project": {
+        "label": "O projeto",
+        "text": "O mapa de parques infantis é um mapa web gratuito e interativo baseado em dados do {{osmLink}}. Não contém dados proprietários, não requer início de sessão e não rastreia utilizadores. Quem melhora os dados no OSM melhora automaticamente este mapa.",
+        "osmWikiUrl": "https://pt.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Código fonte",
+        "text": "O projeto é open source e {{repoLink}}.",
+        "repoLabel": "publicamente disponível"
+      }
+    }
+  }
+}

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -1,0 +1,137 @@
+{
+  "appTitle": "Lekplatskarta \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Dubbel-Shift för att söka",
+    "found": "\"{{query}}\" i {{location}}",
+    "foundGeneric": "\"{{query}}\" hittades",
+    "notFound": "Inga resultat hittades!"
+  },
+  "nav": {
+    "addData": "Lägg till data",
+    "about": "Om projektet",
+    "menu": "Meny"
+  },
+  "info": {
+    "hint": "Tryck på en lekplats för detaljer",
+    "shareBtn": "Dela lekplats",
+    "osmBtn": "Visa på OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Foton, namn och detaljer tillgängliga",
+    "partial": "Delvis kartlagd",
+    "missing": "Ingen data"
+  },
+  "accordion": {
+    "photos": "Foton",
+    "equipment": "Utrustning",
+    "shadow": "Skugga",
+    "surroundings": "Omgivning",
+    "reviews": "Recensioner",
+    "completeness": "Datakomplettering"
+  },
+  "location": {
+    "btn": "Min plats",
+    "yourLocation": "din plats"
+  },
+  "nearby": {
+    "title": "Nära {{label}}",
+    "defaultName": "Lekplats",
+    "thisLocation": "denna plats"
+  },
+  "equipment": {
+    "devices_one": "{{count}} lekredskap",
+    "devices_other": "{{count}} lekredskap",
+    "fitness_one": "{{count}} fitnessredskap",
+    "fitness_other": "{{count}} fitnessredskap",
+    "benches_one": "{{count}} bänk",
+    "benches_other": "{{count}} bänkar",
+    "shelters_one": "{{count}} skydd",
+    "shelters_other": "{{count}} skydd",
+    "picnic_one": "{{count}} picknicbord",
+    "picnic_other": "{{count}} picknicbord",
+    "fitnessDefault": "Fitnessredskap",
+    "addHint": "Utrustning inte kartlagd individuellt ännu \u2013 hjälp till! 👇",
+    "addLink": "Lägg till utrustning"
+  },
+  "photos": {
+    "none": "Inga foton för den här lekplatsen ännu.<br>Har du besökt den?",
+    "addLink": "Lägg till foto",
+    "enlarge": "Klicka för att förstora",
+    "thumbnail": "Foto {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Kunde inte ladda omgivningsdata.",
+    "alwaysOpen": "Alltid öppet",
+    "open": "Öppet",
+    "openUntil": "Öppet till {{time}}",
+    "closed": "Stängt",
+    "opensAt": "Öppnar {{day}} kl. {{time}}",
+    "openingHours": "Öppettider",
+    "today": "Idag",
+    "tomorrow": "Imorgon",
+    "categories": {
+      "toilets": "Toaletter",
+      "busStops": "Busshållplatser",
+      "iceCream": "Glass",
+      "shopping": "Shopping",
+      "drugstore": "Apotek",
+      "emergency": "Akutmottagning"
+    },
+    "fallbacks": {
+      "toilets": "Offentlig toalett",
+      "busStops": "Busshållplats",
+      "iceCream": "Glasskiosk",
+      "shopping": "Butik",
+      "drugstore": "Apotek",
+      "emergency": "Sjukhus"
+    }
+  },
+  "modal": {
+    "closeBtn": "Stäng",
+    "backToMap": "Tillbaka till kartan",
+    "streetPhoto": "Gatufoto",
+    "prevPhoto": "Föregående foto",
+    "nextPhoto": "Nästa foto",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Data kommer från {{osmLink}} \u2014 en fri, samarbetande världskarta skapad av miljontals volontärer. Endast det som har kartlagts visas här.",
+        "wikiUrl": "https://sv.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Bidra till lekplatser",
+        "text": "Vem som helst kan bidra. En bra startpunkt är {{learnOsmLink}}. Relevanta taggar finns dokumenterade i {{wikiLink}} och på sidan om {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/en/beginner/",
+        "wikiLabel": "OSM-wikin",
+        "equipmentLabel": "kartläggning av enskild utrustning"
+      },
+      "photos": {
+        "label": "Lägg till foton",
+        "text": "Foton kan laddas upp direkt via {{mapcompleteLink}} \u2014 öppna en lekplats och klicka på \"Lägg till foto\". Foton tillhandahålls av {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Gemenskap",
+        "text": "Frågor eller vill du engagera dig? Det lokala OSM-gemenskapen nås via {{chatLink}}.",
+        "chatLabel": "lokal OSM-gemenskapschatt"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Historia",
+        "text": "Lekplatskartan skapades av {{authorLink}} som avslutningsprojekt för en {{courseLink}} \u2014 ursprungligen inriktad på Berlin. Med tiden utvecklades den till en generisk karta som kan användas för vilket OSM-område som helst.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "GIS och webbkartläggningskurs"
+      },
+      "project": {
+        "label": "Projektet",
+        "text": "Lekplatskartan är en fri, interaktiv webbkarta baserad på {{osmLink}}-data. Den innehåller inga proprietära data, kräver ingen inloggning och spårar inga användare. Den som förbättrar lekplatsdata i OSM förbättrar automatiskt även denna karta.",
+        "osmWikiUrl": "https://sv.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Källkod",
+        "text": "Projektet är öppen källkod och {{repoLink}}.",
+        "repoLabel": "offentligt tillgängligt"
+      }
+    }
+  }
+}

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -1,0 +1,147 @@
+{
+  "appTitle": "Карта майданчиків \u2013 {{regionName}}",
+  "search": {
+    "placeholder": "Подвійний Shift для пошуку",
+    "found": "\"{{query}}\" у {{location}}",
+    "foundGeneric": "\"{{query}}\" знайдено",
+    "notFound": "Результатів не знайдено!"
+  },
+  "nav": {
+    "addData": "Додати дані",
+    "about": "Про проєкт",
+    "menu": "Меню"
+  },
+  "info": {
+    "hint": "Натисніть на майданчик, щоб побачити деталі",
+    "shareBtn": "Поділитися майданчиком",
+    "osmBtn": "Переглянути на OpenStreetMap"
+  },
+  "completeness": {
+    "complete": "Фотографії, назва та деталі доступні",
+    "partial": "Частково нанесено на карту",
+    "missing": "Немає даних"
+  },
+  "accordion": {
+    "photos": "Фотографії",
+    "equipment": "Обладнання",
+    "shadow": "Тінь",
+    "surroundings": "Околиці",
+    "reviews": "Відгуки",
+    "completeness": "Повнота даних"
+  },
+  "location": {
+    "btn": "Моє місцезнаходження",
+    "yourLocation": "вашого місцезнаходження"
+  },
+  "nearby": {
+    "title": "Поблизу {{label}}",
+    "defaultName": "Майданчик",
+    "thisLocation": "цього місця"
+  },
+  "equipment": {
+    "devices_one": "{{count}} пристрій",
+    "devices_few": "{{count}} пристрої",
+    "devices_many": "{{count}} пристроїв",
+    "devices_other": "{{count}} пристрою",
+    "fitness_one": "{{count}} тренажер",
+    "fitness_few": "{{count}} тренажери",
+    "fitness_many": "{{count}} тренажерів",
+    "fitness_other": "{{count}} тренажера",
+    "benches_one": "{{count}} лавка",
+    "benches_few": "{{count}} лавки",
+    "benches_many": "{{count}} лавок",
+    "benches_other": "{{count}} лавки",
+    "shelters_one": "{{count}} навіс",
+    "shelters_few": "{{count}} навіси",
+    "shelters_many": "{{count}} навісів",
+    "shelters_other": "{{count}} навісу",
+    "picnic_one": "{{count}} пікнічний стіл",
+    "picnic_few": "{{count}} пікнічні столи",
+    "picnic_many": "{{count}} пікнічних столів",
+    "picnic_other": "{{count}} пікнічного столу",
+    "fitnessDefault": "Тренажер",
+    "addHint": "Обладнання ще не нанесено індивідуально \u2013 допоможіть! 👇",
+    "addLink": "Додати обладнання"
+  },
+  "photos": {
+    "none": "Ще немає фотографій для цього майданчика.<br>Ви вже там були?",
+    "addLink": "Додати фотографію",
+    "enlarge": "Натисніть, щоб збільшити",
+    "thumbnail": "Фотографія {{n}}"
+  },
+  "poi": {
+    "errorLoad": "Не вдалося завантажити дані про околиці.",
+    "alwaysOpen": "Завжди відкрито",
+    "open": "Відкрито",
+    "openUntil": "Відкрито до {{time}}",
+    "closed": "Зачинено",
+    "opensAt": "Відкривається {{day}} о {{time}}",
+    "openingHours": "Години роботи",
+    "today": "Сьогодні",
+    "tomorrow": "Завтра",
+    "categories": {
+      "toilets": "Туалети",
+      "busStops": "Автобусні зупинки",
+      "iceCream": "Морозиво",
+      "shopping": "Магазини",
+      "drugstore": "Аптека",
+      "emergency": "Швидка допомога"
+    },
+    "fallbacks": {
+      "toilets": "Громадський туалет",
+      "busStops": "Автобусна зупинка",
+      "iceCream": "Морозивня",
+      "shopping": "Магазин",
+      "drugstore": "Аптека",
+      "emergency": "Лікарня"
+    }
+  },
+  "modal": {
+    "closeBtn": "Закрити",
+    "backToMap": "Повернутися до карти",
+    "streetPhoto": "Фото вулиці",
+    "prevPhoto": "Попередня фотографія",
+    "nextPhoto": "Наступна фотографія",
+    "addData": {
+      "osm": {
+        "label": "OpenStreetMap",
+        "text": "Дані надходять з {{osmLink}} \u2014 вільної, спільної карти світу, створеної мільйонами волонтерів. Тут відображається лише те, що було нанесено на карту.",
+        "wikiUrl": "https://uk.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "contribute": {
+        "label": "Додавайте майданчики",
+        "text": "Будь-хто може зробити внесок. Гарним відправним пунктом є {{learnOsmLink}}. Відповідні теги задокументовано у {{wikiLink}} та на сторінці про {{equipmentLink}}.",
+        "learnOsmUrl": "https://learnosm.org/uk/beginner/",
+        "wikiLabel": "вікі OSM",
+        "equipmentLabel": "нанесення окремого обладнання"
+      },
+      "photos": {
+        "label": "Додавайте фотографії",
+        "text": "Фотографії можна завантажити безпосередньо через {{mapcompleteLink}} \u2014 відкрийте майданчик і натисніть «Додати фотографію». Фотографії надаються {{panoramaxLink}}."
+      },
+      "community": {
+        "label": "Спільнота",
+        "text": "Маєте питання або хочете приєднатися? Місцева спільнота OSM доступна через {{chatLink}}.",
+        "chatLabel": "чат місцевої спільноти OSM"
+      }
+    },
+    "about": {
+      "history": {
+        "label": "Історія",
+        "text": "Карта майданчиків була створена {{authorLink}} як фінальний проєкт {{courseLink}} \u2014 спочатку орієнтований на Берлін. З часом вона перетворилася на загальну карту, придатну для будь-якого регіону OSM.",
+        "courseUrl": "https://gis-trainer.com/de/gis_webmapping.php",
+        "courseLabel": "курсу GIS та веб-картографії"
+      },
+      "project": {
+        "label": "Проєкт",
+        "text": "Карта майданчиків — це безкоштовна, інтерактивна веб-карта на основі даних {{osmLink}}. Вона не містить пропрієтарних даних, не вимагає входу та не відстежує користувачів. Той, хто покращує дані про майданчики в OSM, автоматично покращує і цю карту.",
+        "osmWikiUrl": "https://uk.wikipedia.org/wiki/OpenStreetMap"
+      },
+      "source": {
+        "label": "Вихідний код",
+        "text": "Проєкт є відкритим і {{repoLink}}.",
+        "repoLabel": "загальнодоступним"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.13.1",
     "fetch-jsonp": "1.3.0",
+    "i18next": "^25.0.0",
     "ol": "latest",
     "opening_hours": "^3.12.0"
   }


### PR DESCRIPTION
## Summary

- Extracts all ~62 user-facing UI strings from hardcoded German into JSON locale files under `locales/`
- Language is auto-detected from browser settings (`navigator.language`), with English as fallback
- `?lang=xx` URL parameter overrides the detected language for testing
- New `js/i18n.js` module wraps i18next (already in node_modules, now added to package.json)
- Static HTML strings use `data-i18n` attributes; dynamic strings use `t()` calls in JS

## Languages added

| Code | Language |
|---|---|
| `de` | German |
| `en` | English |
| `fr` | French |
| `es` | Spanish |
| `it` | Italian |
| `pl` | Polish |
| `nl` | Dutch |
| `cs` | Czech |
| `pt` | Portuguese |
| `sv` | Swedish |
| `uk` | Ukrainian |
| `ja` | Japanese |

Translations are machine-assisted and not reviewed by native speakers.

## Test plan

- [ ] Open the app normally — verify it shows in your browser language
- [ ] Test `?lang=en`, `?lang=fr`, `?lang=ja` — verify UI strings switch correctly
- [ ] Test `?lang=xx` (unknown) — verify fallback to English
- [ ] Check modal content ("Add data", "About") — all strings translated
- [ ] Check equipment counts with plural forms (especially `?lang=pl`, `?lang=uk`)
- [ ] Run `npm run build` — no errors

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)