### PR TITLE
docs(claude): add Git workflow, release, and versioning guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Spielplatzkarte is an interactive web map for exploring playgrounds based on OpenStreetMap data. It is deployable per-region (e.g. Berlin, Fulda) by setting environment variables. The UI language is German throughout — there is no i18n layer, German strings are hardcoded.
 
+## Git workflow
+
+- **Never push directly to `main`.** All changes go through a feature branch and a pull request.
+- Branch naming: `<type>/<short-description>` (e.g. `feat/add-filter-panel`, `fix/popup-scroll`).
+- Use **Conventional Commits** for all commit messages: `<type>[optional scope]: <description>`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`. Breaking changes: append `!` after type/scope or add a `BREAKING CHANGE:` footer.
+- Releases are cut from version tags (e.g. `v0.2.3`). The tag drives both the app version (read from `package.json` at build time) and the container image tag — keep all three in sync when releasing.
+
 ## Development commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Spielplatzkarte is an interactive web map for exploring playgrounds based on Ope
 ## Git workflow
 
 - **Never push directly to `main`.** All changes go through a feature branch and a pull request.
+- **Never create branches or push to `upstream`** (`SupaplexOSM/spielplatzkarte`). Always work on `origin` (the fork: `mfuhrmann/spielplatzkarte`).
 - Branch naming: `<type>/<short-description>` (e.g. `feat/add-filter-panel`, `fix/popup-scroll`).
 - Use **Conventional Commits** for all commit messages: `<type>[optional scope]: <description>`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`. Breaking changes: append `!` after type/scope or add a `BREAKING CHANGE:` footer.
 - Releases are cut from version tags (e.g. `v0.2.3`). The tag drives both the app version (read from `package.json` at build time) and the container image tag — keep all three in sync when releasing.


### PR DESCRIPTION
## Summary

- Documents the branch-and-PR workflow (no direct pushes to `main`)
- Never push branches to `upstream` (`SupaplexOSM/spielplatzkarte`), always work on `origin`
- Adds Conventional Commits guidance with branch naming convention
- Explains the version tag → `package.json` → container image alignment for releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)