### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spielplatzkarte",
-  "version": "0.2.3",
+  "version": "0.1.1",
   "scripts": {
     "start": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary

- Corrects the version from the erroneous `0.2.3` back to the intended `0.1.1`
- After merge, tag `v0.1.1` will be created on `main` to cut the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)