### PR TITLE
feat: add embed mode for Hub iframe integration

### DIFF
--- a/css/bootstrap_custom.css
+++ b/css/bootstrap_custom.css
@@ -180,3 +180,27 @@
 .popover .popover-body a + ul {
     margin-top: 8px;
 }
+
+/* ── Embed mode (?embed=1) — used when loaded as iframe in Spielplatzkarte Hub ── */
+
+body.embed-mode #map,
+body.embed-mode #popup,
+body.embed-mode #mini-popup,
+body.embed-mode #search-bar,
+body.embed-mode #location-fab,
+body.embed-mode .info-more-hint {
+    display: none !important;
+}
+
+body.embed-mode #info {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    border-radius: 0;
+    box-shadow: none;
+    overflow-y: auto;
+    transform: none !important;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -116,6 +116,11 @@ function buildUeberModal() {
 // Schieberegler der Schattenberechnung auf aktuelles Datum setzen
 setCurrentDate();
 
+// Embed mode: hide map and nav when ?embed=1 is set (used by Spielplatzkarte Hub)
+if (new URLSearchParams(window.location.search).get('embed') === '1') {
+    document.body.classList.add('embed-mode');
+}
+
 // Direktlink zu einem Spielplatz wiederherstellen (URL-Hash wie #W123456)
 // Also handles hash changes when embedded as iframe in Spielplatzkarte Hub.
 restoreFromHash();


### PR DESCRIPTION
## Summary

Adds `?embed=1` URL parameter support. When present, a CSS class `embed-mode` is added to `<body>`, which hides the map, search bar, and location button, and makes the detail panel fill the full viewport.

This allows the Spielplatzkarte Hub to load a regional instance in an iframe showing only the playground detail view — no redundant map inside the modal.

## How to test locally

Open the app with `?embed=1` and a playground hash:
```
http://localhost:5173/?embed=1#W12345
```
The map and nav should be gone; the detail panel should fill the screen.

Without `?embed=1`, the app behaves exactly as before.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)