### PR TITLE
feat: add Makefile as single entry point for all dev and ops tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,10 @@ jobs:
           node-version: 20
 
       - name: Install Dependencies
-        run: npm ci
+        run: make install
 
       - name: Build
-        run: npm run build
+        run: make build
 
   docker:
     name: Docker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,13 @@ Spielplatzkarte is an interactive web map for exploring playgrounds based on Ope
 
 ## Development commands
 
+All common operations are available via `make`. Run `make help` to list targets.
+
 ```bash
-npm start        # Vite dev server at http://localhost:5173 (hot-reload)
-npm run build    # Production build → dist/
-npm run serve    # Preview production build locally
+make install      # npm ci
+make dev          # Vite dev server at http://localhost:5173 (hot-reload)
+make build        # Production build → dist/
+make serve        # Preview production build locally
 ```
 
 No test framework is configured.
@@ -27,12 +30,16 @@ No test framework is configured.
 ## Docker Compose stack
 
 ```bash
-cp .env.example .env                   # configure OSM_RELATION_ID and PBF_URL
-docker compose run --rm importer       # one-time OSM data import (downloads PBF, runs osm2pgsql)
-docker compose up -d                   # start db + postgrest + nginx/app
+cp .env.example .env   # configure OSM_RELATION_ID and PBF_URL
+make up                # start db + PostgREST + nginx/app
+make import            # one-time OSM data import (downloads PBF, runs osm2pgsql)
+make docker-build      # rebuild and restart only the nginx/app container
+make db-apply          # apply importer/api.sql to the running DB and reload PostgREST
+make db-shell          # open a psql shell in the running DB container
+make down              # stop all containers
 ```
 
-The importer profile is not started by default with `docker compose up`. It must be run explicitly before the app has any data.
+The importer is not started by `make up`. Run `make import` once before the app has any data.
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: install dev build serve \
+        up down import db-apply db-shell \
+        docker-build help
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+
+install:       ## Install Node dependencies
+	npm ci
+
+dev:           ## Start Vite dev server (hot-reload at http://localhost:5173)
+	npm start
+
+build:         ## Production build → dist/
+	npm run build
+
+serve:         ## Preview the production build locally
+	npm run serve
+
+# ── Docker Compose stack ──────────────────────────────────────────────────────
+
+up:            ## Start db + PostgREST + nginx (detached)
+	docker compose up -d
+
+down:          ## Stop and remove containers
+	docker compose down
+
+import:        ## Download PBF and import OSM data into PostGIS (run once or to refresh)
+	docker compose run --rm importer
+
+docker-build:  ## Rebuild and restart the nginx/app container after frontend changes
+	docker compose up -d --build app
+
+# ── Database ──────────────────────────────────────────────────────────────────
+
+db-apply:      ## Apply importer/api.sql to the running database and reload PostgREST schema
+	docker compose exec -T db psql -U osm -d osm < importer/api.sql
+	docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
+
+db-shell:      ## Open a psql shell in the running database container
+	docker compose exec db psql -U osm -d osm
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+
+help:          ## List available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,53 @@
 .PHONY: install dev build serve \
         up down import db-apply db-shell \
-        docker-build help
+        docker-build check-node check-docker help
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+
+check-node:
+	@command -v node >/dev/null 2>&1 || { echo "Error: node is not installed (https://nodejs.org/)"; exit 1; }
+	@command -v npm  >/dev/null 2>&1 || { echo "Error: npm is not installed"; exit 1; }
+
+check-docker:
+	@command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed (https://docs.docker.com/get-docker/)"; exit 1; }
+	@docker compose version >/dev/null 2>&1 || { echo "Error: docker compose plugin is not available"; exit 1; }
+	@docker info >/dev/null 2>&1         || { echo "Error: docker daemon is not running"; exit 1; }
 
 # ── Frontend ──────────────────────────────────────────────────────────────────
 
-install:       ## Install Node dependencies
+install: check-node    ## Install Node dependencies
 	npm ci
 
-dev:           ## Start Vite dev server (hot-reload at http://localhost:5173)
+dev: check-node        ## Start Vite dev server (hot-reload at http://localhost:5173)
 	npm start
 
-build:         ## Production build → dist/
+build: check-node      ## Production build → dist/
 	npm run build
 
-serve:         ## Preview the production build locally
+serve: check-node      ## Preview the production build locally
 	npm run serve
 
 # ── Docker Compose stack ──────────────────────────────────────────────────────
 
-up:            ## Start db + PostgREST + nginx (detached)
+up: check-docker           ## Start db + PostgREST + nginx (detached)
 	docker compose up -d
 
-down:          ## Stop and remove containers
+down: check-docker         ## Stop and remove containers
 	docker compose down
 
-import:        ## Download PBF and import OSM data into PostGIS (run once or to refresh)
+import: check-docker       ## Download PBF and import OSM data into PostGIS (run once or to refresh)
 	docker compose run --rm importer
 
-docker-build:  ## Rebuild and restart the nginx/app container after frontend changes
+docker-build: check-docker ## Rebuild and restart the nginx/app container after frontend changes
 	docker compose up -d --build app
 
 # ── Database ──────────────────────────────────────────────────────────────────
 
-db-apply:      ## Apply importer/api.sql to the running database and reload PostgREST schema
+db-apply: check-docker     ## Apply importer/api.sql to the running database and reload PostgREST schema
 	docker compose exec -T db psql -U osm -d osm < importer/api.sql
 	docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
 
-db-shell:      ## Open a psql shell in the running database container
+db-shell: check-docker     ## Open a psql shell in the running database container
 	docker compose exec db psql -U osm -d osm
 
 # ── Help ──────────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,63 @@
 .PHONY: install dev build serve \
-        up down import db-apply db-shell \
-        docker-build check-node check-docker help
+        up down import docker-build db-apply db-shell \
+        require-npm require-docker help
 
-# ── Dependency checks ─────────────────────────────────────────────────────────
+# Bail with a clear message when a required tool is missing.
+define require
+@command -v $(1) >/dev/null 2>&1 || \
+  { printf '\033[31merror:\033[0m %s is required but not found in PATH\n' '$(1)' >&2; exit 1; }
+endef
 
-check-node:
-	@command -v node >/dev/null 2>&1 || { echo "Error: node is not installed (https://nodejs.org/)"; exit 1; }
-	@command -v npm  >/dev/null 2>&1 || { echo "Error: npm is not installed"; exit 1; }
+require-npm:
+	$(call require,node)
+	$(call require,npm)
 
-check-docker:
-	@command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed (https://docs.docker.com/get-docker/)"; exit 1; }
-	@docker compose version >/dev/null 2>&1 || { echo "Error: docker compose plugin is not available"; exit 1; }
-	@docker info >/dev/null 2>&1         || { echo "Error: docker daemon is not running"; exit 1; }
+require-docker:
+	$(call require,docker)
+	@docker compose version >/dev/null 2>&1 || \
+	  { printf '\033[31merror:\033[0m docker compose plugin is not available\n' >&2; exit 1; }
+	@docker info >/dev/null 2>&1 || \
+	  { printf '\033[31merror:\033[0m docker daemon is not running\n' >&2; exit 1; }
 
-# ── Frontend ──────────────────────────────────────────────────────────────────
+## ── Frontend ──────────────────────────────────────────────────────────────────
 
-install: check-node    ## Install Node dependencies
+install: require-npm      ## Install Node dependencies
 	npm ci
 
-dev: check-node        ## Start Vite dev server (hot-reload at http://localhost:5173)
+dev: require-npm          ## Start Vite dev server at http://localhost:5173
 	npm start
 
-build: check-node      ## Production build → dist/
+build: require-npm        ## Production build → dist/
 	npm run build
 
-serve: check-node      ## Preview the production build locally
+serve: require-npm        ## Preview production build locally
 	npm run serve
 
-# ── Docker Compose stack ──────────────────────────────────────────────────────
+## ── Docker Compose stack ──────────────────────────────────────────────────────
 
-up: check-docker           ## Start db + PostgREST + nginx (detached)
+up: require-docker        ## Start db + PostgREST + nginx (detached)
 	docker compose up -d
 
-down: check-docker         ## Stop and remove containers
+down: require-docker      ## Stop and remove containers
 	docker compose down
 
-import: check-docker       ## Download PBF and import OSM data into PostGIS (run once or to refresh)
+import: require-docker    ## Download PBF and import OSM data into PostGIS (run once or to refresh)
 	docker compose run --rm importer
 
-docker-build: check-docker ## Rebuild and restart the nginx/app container after frontend changes
+docker-build: require-docker  ## Rebuild and restart the nginx/app container after frontend changes
 	docker compose up -d --build app
 
-# ── Database ──────────────────────────────────────────────────────────────────
+## ── Database ──────────────────────────────────────────────────────────────────
 
-db-apply: check-docker     ## Apply importer/api.sql to the running database and reload PostgREST schema
+db-apply: require-docker  ## Apply importer/api.sql to the running database and reload PostgREST schema
 	docker compose exec -T db psql -U osm -d osm < importer/api.sql
 	docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
 
-db-shell: check-docker     ## Open a psql shell in the running database container
+db-shell: require-docker  ## Open a psql shell in the running database container
 	docker compose exec db psql -U osm -d osm
 
-# ── Help ──────────────────────────────────────────────────────────────────────
+## ── Help ──────────────────────────────────────────────────────────────────────
 
-help:          ## List available targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
-		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+help:                     ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ See `.env.example` for all available options (UI links, zoom levels, port, DB pa
 
 ```bash
 # Start the database, API, and web server
-docker compose up -d
+make up
 
 # Import OSM data (downloads PBF, runs osm2pgsql, sets up API functions)
 # Takes a few minutes depending on extract size and hardware
-docker compose run --rm importer
+make import
 ```
 
 The app will be available at `http://localhost:8080` (or the port set in `APP_PORT`).
@@ -194,7 +194,7 @@ The app will be available at `http://localhost:8080` (or the port set in `APP_PO
 Re-run the importer at any time to refresh from Geofabrik (extracts are updated daily):
 
 ```bash
-docker compose run --rm importer
+make import
 ```
 
 ---
@@ -220,25 +220,24 @@ All variables can be set in `.env` (copy from `.env.example`).
 
 ## Local development
 
-### npm dev server (recommended for frontend work)
+**Requirements:** [Node.js](https://nodejs.org/) v18 or newer, [Docker](https://www.docker.com/) with Docker Compose
 
-**Requirements:** [Node.js](https://nodejs.org/) v18 or newer
+All common operations are available via `make`. Run `make help` to list all targets.
+
+### Frontend dev server
 
 ```bash
-npm install
-npm start         # dev server with hot-reload at http://localhost:5173
-npm run build     # production build into dist/
-npm run serve     # preview the production build locally
+make install      # install Node dependencies
+make up           # start db + PostgREST + nginx (required backend)
+make dev          # dev server with hot-reload at http://localhost:5173
 ```
 
-A running PostgREST backend is required — the app no longer falls back to Overpass. Start the full stack via `docker compose up -d` before running the dev server, or point `API_BASE_URL` at a remote PostgREST instance.
+A running PostgREST backend is required — the app no longer falls back to Overpass. Start the full stack with `make up` before running the dev server.
 
-### Building the Docker image
-
-If you have the full stack running via `docker compose up -d` and want to rebuild only the frontend container after code changes:
+### Rebuild the app container after code changes
 
 ```bash
-docker compose up -d --build app
+make docker-build
 ```
 
 This runs the Vite build inside the container and replaces the nginx image without touching the database or PostgREST.
@@ -248,8 +247,7 @@ This runs the Vite build inside the container and replaces the nginx image witho
 SQL changes to `importer/api.sql` (PostgREST functions, indexes) can be applied directly to the running database:
 
 ```bash
-docker compose exec -T db psql -U osm -d osm < importer/api.sql
-docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
+make db-apply
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds `Makefile` with targets for frontend dev, Docker Compose ops, and database tasks
- Updates CI workflow (`build.yml`) to use `make install` and `make build`
- Updates `CLAUDE.md` and `README.md` to reference `make` targets instead of raw commands

## Targets

| Target | Description |
|---|---|
| `make install` | `npm ci` |
| `make dev` | Vite dev server (hot-reload) |
| `make build` | Production build → `dist/` |
| `make serve` | Preview production build |
| `make up` | Start full Docker Compose stack |
| `make down` | Stop containers |
| `make import` | Download PBF and run osm2pgsql |
| `make docker-build` | Rebuild only the nginx/app container |
| `make db-apply` | Apply `importer/api.sql` and reload PostgREST |
| `make db-shell` | Open psql shell in running DB container |
| `make help` | List all targets |

🤖 Generated with [Claude Code](https://claude.com/claude-code)