### PR TITLE
feat: add production installer and importer image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract metadata (app)
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
@@ -66,10 +66,29 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
-      - name: Build and push Docker image
+      - name: Build and push app image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Extract metadata (importer)
+        id: meta-importer
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-importer
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=
+
+      - name: Build and push importer image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1  # v6
+        with:
+          context: ./importer
+          push: true
+          tags: ${{ steps.meta-importer.outputs.tags }}
+          labels: ${{ steps.meta-importer.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install dev build serve \
         up down import docker-build db-apply db-shell \
-        require-npm require-docker help
+        require-npm require-docker installer help
 
 # Bail with a clear message when a required tool is missing.
 define require
@@ -55,6 +55,11 @@ db-apply: require-docker  ## Apply importer/api.sql to the running database and 
 
 db-shell: require-docker  ## Open a psql shell in the running database container
 	docker compose exec db psql -U osm -d osm
+
+## ── Production install ────────────────────────────────────────────────────────
+
+installer: require-docker ## Run the interactive production installer (no git clone required)
+	bash install.sh
 
 ## ── Help ──────────────────────────────────────────────────────────────────────
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,85 @@
+# Spielplatzkarte — production stack (pre-built images, no local source required)
+#
+# Usage:
+#   bash install.sh          # interactive first-time setup (recommended)
+#
+# Manual usage after install.sh has created your .env:
+#   docker compose -f compose.prod.yml up -d
+#   docker compose -f compose.prod.yml run --rm importer
+#
+# Images are published to ghcr.io on every tagged release and on every push
+# to main (tagged :latest). Pin to a specific version for reproducible deploys.
+
+services:
+
+  # ── PostGIS database ────────────────────────────────────────────────────────
+  db:
+    image: postgis/postgis:16-3.4-alpine
+    environment:
+      POSTGRES_DB:       osm
+      POSTGRES_USER:     osm
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/10_init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U osm -d osm"]
+      interval: 10s
+      timeout:  5s
+      retries:  10
+    restart: unless-stopped
+
+  # ── OSM importer (run manually; not started by default) ─────────────────────
+  # docker compose -f compose.prod.yml run --rm importer
+  importer:
+    image: ghcr.io/mfuhrmann/spielplatzkarte-importer:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST:     db
+      POSTGRES_PORT:     5432
+      POSTGRES_DB:       osm
+      POSTGRES_USER:     osm
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PBF_URL:           ${PBF_URL}
+      OSM2PGSQL_THREADS: ${OSM2PGSQL_THREADS:-4}
+    volumes:
+      - pbf_cache:/data
+    profiles: [import]
+    restart: "no"
+
+  # ── PostgREST — auto-generates REST API from the api schema ─────────────────
+  postgrest:
+    image: postgrest/postgrest:v12.2.0
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI:       postgres://osm:${POSTGRES_PASSWORD}@db:5432/osm
+      PGRST_DB_SCHEMA:    api
+      PGRST_DB_ANON_ROLE: web_anon
+      PGRST_SERVER_PORT:  3000
+      PGRST_LOG_LEVEL:    warn
+    restart: unless-stopped
+
+  # ── nginx — serves the app and proxies /api/ to PostgREST ───────────────────
+  app:
+    image: ghcr.io/mfuhrmann/spielplatzkarte:latest
+    depends_on:
+      - postgrest
+    ports:
+      - "${APP_PORT:-8080}:80"
+    environment:
+      OSM_RELATION_ID:            ${OSM_RELATION_ID}
+      REGION_PLAYGROUND_WIKI_URL: ${REGION_PLAYGROUND_WIKI_URL:-}
+      REGION_CHAT_URL:            ${REGION_CHAT_URL:-}
+      MAP_ZOOM:                   ${MAP_ZOOM:-12}
+      MAP_MIN_ZOOM:               ${MAP_MIN_ZOOM:-10}
+      POI_RADIUS_M:               ${POI_RADIUS_M:-5000}
+      API_BASE_URL:               /api
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  pbf_cache:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -18,7 +18,7 @@ services:
     environment:
       POSTGRES_DB:       osm
       POSTGRES_USER:     osm
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/10_init.sql:ro
@@ -41,7 +41,7 @@ services:
       POSTGRES_PORT:     5432
       POSTGRES_DB:       osm
       POSTGRES_USER:     osm
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}
       PBF_URL:           ${PBF_URL}
       OSM2PGSQL_THREADS: ${OSM2PGSQL_THREADS:-4}
     volumes:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Spielplatzkarte installer
+# Downloads the production compose file and db schema, then walks through
+# configuration interactively.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spielplatzkarte/main/install.sh -o install.sh
+#   bash install.sh
+
+set -euo pipefail
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { printf "${CYAN}==>${RESET} %s\n" "$*"; }
+success() { printf "${GREEN}✓${RESET}  %s\n" "$*"; }
+warn()    { printf "${YELLOW}!${RESET}  %s\n" "$*"; }
+die()     { printf "${RED}error:${RESET} %s\n" "$*" >&2; exit 1; }
+
+ask() {
+    # ask <variable> <prompt> [default]
+    local var="$1" prompt="$2" default="${3:-}"
+    if [[ -n "$default" ]]; then
+        printf "${BOLD}%s${RESET} [%s]: " "$prompt" "$default"
+    else
+        printf "${BOLD}%s${RESET}: " "$prompt"
+    fi
+    read -r input
+    if [[ -z "$input" && -n "$default" ]]; then
+        printf -v "$var" '%s' "$default"
+    elif [[ -n "$input" ]]; then
+        printf -v "$var" '%s' "$input"
+    else
+        die "$prompt is required."
+    fi
+}
+
+ask_optional() {
+    # ask_optional <variable> <prompt>
+    local var="$1" prompt="$2"
+    printf "${BOLD}%s${RESET} (leave empty to skip): " "$prompt"
+    read -r input
+    printf -v "$var" '%s' "${input:-}"
+}
+
+confirm() {
+    # confirm <prompt> — returns 0 for yes, 1 for no
+    printf "${BOLD}%s${RESET} [Y/n]: " "$1"
+    read -r ans
+    [[ "${ans:-y}" =~ ^[Yy]$ ]]
+}
+
+fetch() {
+    # fetch <url> <dest>
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$1" -o "$2"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$2" "$1"
+    else
+        die "Neither curl nor wget found. Please install one and retry."
+    fi
+}
+
+# ── Dependency check ───────────────────────────────────────────────────────────
+
+for cmd in docker openssl; do
+    command -v "$cmd" >/dev/null 2>&1 || die "'$cmd' is required but not found in PATH."
+done
+docker compose version >/dev/null 2>&1 || die "Docker Compose plugin is not available."
+docker info >/dev/null 2>&1           || die "Docker daemon is not running."
+
+# ── Header ─────────────────────────────────────────────────────────────────────
+
+printf "\n"
+printf "${BOLD}Spielplatzkarte — Production Installer${RESET}\n"
+printf "Playground map powered by OpenStreetMap\n"
+printf "https://github.com/mfuhrmann/spielplatzkarte\n\n"
+
+# ── Deployment directory ───────────────────────────────────────────────────────
+
+ask DEPLOY_DIR "Deployment directory" "./spielplatzkarte"
+mkdir -p "$DEPLOY_DIR/db"
+
+if [[ -f "$DEPLOY_DIR/.env" ]]; then
+    warn ".env already exists in $DEPLOY_DIR"
+    confirm "Overwrite it?" || die "Aborted."
+fi
+
+# ── Region configuration ───────────────────────────────────────────────────────
+
+printf "\n${BOLD}── Region ──────────────────────────────────────────────────────${RESET}\n"
+printf "Find the OSM relation ID: https://nominatim.openstreetmap.org\n"
+printf "Find a PBF extract:       https://download.geofabrik.de\n\n"
+
+ask OSM_RELATION_ID "OSM relation ID of your region (e.g. 62700 = Landkreis Fulda)"
+ask PBF_URL         "Geofabrik PBF URL covering your region" \
+    "https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf"
+
+# ── Optional UI links ──────────────────────────────────────────────────────────
+
+printf "\n${BOLD}── Optional: UI links ──────────────────────────────────────────${RESET}\n"
+ask_optional REGION_PLAYGROUND_WIKI_URL "Wiki page for 'Contribute data' modal"
+ask_optional REGION_CHAT_URL           "Community chat URL shown in 'Contribute data' modal"
+
+# ── Optional: map display ──────────────────────────────────────────────────────
+
+printf "\n${BOLD}── Optional: map display ───────────────────────────────────────${RESET}\n"
+ask MAP_ZOOM      "Initial map zoom level"           "12"
+ask MAP_MIN_ZOOM  "Minimum zoom level"               "10"
+ask POI_RADIUS_M  "Nearby POI search radius (metres)" "5000"
+
+# ── Optional: infrastructure ──────────────────────────────────────────────────
+
+printf "\n${BOLD}── Optional: infrastructure ────────────────────────────────────${RESET}\n"
+ask APP_PORT          "Host port to expose the app on"          "8080"
+ask OSM2PGSQL_THREADS "CPU threads for the OSM import"          "4"
+
+# ── Generate password ──────────────────────────────────────────────────────────
+
+POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+success "Generated secure database password."
+
+# ── Download files ─────────────────────────────────────────────────────────────
+
+BASE_URL="https://raw.githubusercontent.com/mfuhrmann/spielplatzkarte/main"
+
+printf "\n"
+info "Downloading compose.prod.yml..."
+fetch "$BASE_URL/compose.prod.yml" "$DEPLOY_DIR/compose.yml"
+
+info "Downloading db/init.sql..."
+fetch "$BASE_URL/db/init.sql" "$DEPLOY_DIR/db/init.sql"
+
+success "Files downloaded."
+
+# ── Write .env ─────────────────────────────────────────────────────────────────
+
+cat > "$DEPLOY_DIR/.env" <<EOF
+# Generated by install.sh — $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ── Required: region ──────────────────────────────────────────────────────────
+OSM_RELATION_ID=${OSM_RELATION_ID}
+PBF_URL=${PBF_URL}
+
+# ── Optional: UI links ────────────────────────────────────────────────────────
+REGION_PLAYGROUND_WIKI_URL=${REGION_PLAYGROUND_WIKI_URL}
+REGION_CHAT_URL=${REGION_CHAT_URL}
+
+# ── Optional: map display ─────────────────────────────────────────────────────
+MAP_ZOOM=${MAP_ZOOM}
+MAP_MIN_ZOOM=${MAP_MIN_ZOOM}
+POI_RADIUS_M=${POI_RADIUS_M}
+
+# ── Optional: infrastructure ──────────────────────────────────────────────────
+APP_PORT=${APP_PORT}
+OSM2PGSQL_THREADS=${OSM2PGSQL_THREADS}
+
+# ── Database (auto-generated — do not edit) ───────────────────────────────────
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+EOF
+
+success "Configuration written to $DEPLOY_DIR/.env"
+
+# ── Pull images ────────────────────────────────────────────────────────────────
+
+printf "\n"
+if confirm "Pull Docker images now? (recommended, ~500 MB)"; then
+    info "Pulling images..."
+    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" pull
+    success "Images pulled."
+fi
+
+# ── Start stack ────────────────────────────────────────────────────────────────
+
+printf "\n"
+if confirm "Start the stack now?"; then
+    info "Starting db, PostgREST, and app..."
+    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" up -d
+    success "Stack started."
+
+    # ── Run import ─────────────────────────────────────────────────────────────
+    printf "\n"
+    warn "The map will be empty until you import OSM data."
+    if confirm "Run the OSM import now? (downloads the PBF and may take several minutes)"; then
+        info "Starting importer..."
+        docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" \
+            run --rm importer
+        success "Import complete."
+    else
+        printf "\nRun the import later with:\n"
+        printf "  ${CYAN}docker compose -f %s/compose.yml run --rm importer${RESET}\n" "$DEPLOY_DIR"
+    fi
+fi
+
+# ── Done ───────────────────────────────────────────────────────────────────────
+
+printf "\n${GREEN}${BOLD}Done!${RESET}\n\n"
+printf "  App:    ${CYAN}http://localhost:${APP_PORT}${RESET}\n"
+printf "  Dir:    ${CYAN}%s${RESET}\n\n" "$(realpath "$DEPLOY_DIR")"
+printf "Useful commands (run from ${CYAN}%s${RESET}):\n" "$DEPLOY_DIR"
+printf "  docker compose up -d                   # start the stack\n"
+printf "  docker compose down                    # stop the stack\n"
+printf "  docker compose run --rm importer       # re-import OSM data\n"
+printf "  docker compose logs -f postgrest        # watch PostgREST logs\n"

--- a/install.sh
+++ b/install.sh
@@ -198,8 +198,8 @@ fi
 
 printf "\n${GREEN}${BOLD}Done!${RESET}\n\n"
 printf "  App:    ${CYAN}http://localhost:${APP_PORT}${RESET}\n"
-printf "  Dir:    ${CYAN}%s${RESET}\n\n" "$(realpath "$DEPLOY_DIR")"
-printf "Useful commands (run from ${CYAN}%s${RESET}):\n" "$DEPLOY_DIR"
+printf "  Dir:    ${CYAN}%s${RESET}\n\n" "$(cd "$DEPLOY_DIR" && pwd)"
+printf "Useful commands (run from ${CYAN}%s${RESET}):\n" "$(cd "$DEPLOY_DIR" && pwd)"
 printf "  docker compose up -d                   # start the stack\n"
 printf "  docker compose down                    # stop the stack\n"
 printf "  docker compose run --rm importer       # re-import OSM data\n"


### PR DESCRIPTION
## Summary

- **`install.sh`** — interactive one-command installer for production deployments; no git clone needed:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spielplatzkarte/main/install.sh -o install.sh
  bash install.sh
  ```
  Walks through OSM relation ID, Geofabrik PBF URL, optional UI links, port, and thread count. Generates a hex-safe `POSTGRES_PASSWORD` (`openssl rand -hex 32`), downloads `compose.prod.yml` + `db/init.sql`, writes `.env`, and optionally pulls images, starts the stack, and runs the first import.

- **`compose.prod.yml`** — production compose file using only pre-built GHCR images (`ghcr.io/mfuhrmann/spielplatzkarte` and `spielplatzkarte-importer`). No local source required.

- **`build.yml`** — extended CI to also build and push `ghcr.io/mfuhrmann/spielplatzkarte-importer` on every release tag and `main` push, using the same tag strategy as the app image.

- **`Makefile`** — adds `make installer` target.

## Notes

- The hex password format prevents the URI-parsing bug found in the Heilbronn deployment (passwords with `/` break `PGRST_DB_URI`)
- `compose.prod.yml` is downloaded fresh on each install, so it always reflects the latest image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)