### PR TITLE
fix(importer): substitute OSM_RELATION_ID into api.sql at apply time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker-build: require-docker  ## Rebuild and restart the nginx/app container aft
 ## ── Database ──────────────────────────────────────────────────────────────────
 
 db-apply: require-docker  ## Apply importer/api.sql to the running database and reload PostgREST schema
-	docker compose exec -T db psql -U osm -d osm < importer/api.sql
+	set -a && . ./.env && set +a && envsubst '$$OSM_RELATION_ID' < importer/api.sql | docker compose exec -T db psql -U osm -d osm
 	docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
 
 db-shell: require-docker  ## Open a psql shell in the running database container

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     postgresql-client \
     ca-certificates \
+    gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 COPY import.sh /import.sh

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -18,7 +18,7 @@ GRANT USAGE ON SCHEMA api TO web_anon;
 -- =========================================================================
 DROP FUNCTION IF EXISTS api.get_playgrounds(bigint);
 
-CREATE OR REPLACE FUNCTION api.get_playgrounds(relation_id bigint DEFAULT 62700)
+CREATE OR REPLACE FUNCTION api.get_playgrounds(relation_id bigint DEFAULT ${OSM_RELATION_ID})
 RETURNS json
 LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, api
@@ -350,7 +350,7 @@ GRANT EXECUTE ON FUNCTION api.get_trees(float8, float8, float8, float8) TO web_a
 -- =========================================================================
 DROP FUNCTION IF EXISTS api.get_meta(bigint);
 
-CREATE OR REPLACE FUNCTION api.get_meta(relation_id bigint DEFAULT 62700)
+CREATE OR REPLACE FUNCTION api.get_meta(relation_id bigint DEFAULT ${OSM_RELATION_ID})
 RETURNS json
 LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, api

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -62,7 +62,8 @@ echo "[importer] osm2pgsql finished."
 # Create PostgREST API schema (views / functions)
 # --------------------------------------------------------------------------- #
 echo "[importer] Applying API schema..."
-psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /api.sql
+envsubst '$OSM_RELATION_ID' < /api.sql \
+    | psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"
 
 # --------------------------------------------------------------------------- #
 # Notify PostgREST to reload its schema cache


### PR DESCRIPTION
## Summary

- Replace hardcoded `62700` defaults in `api.get_playgrounds` and `api.get_meta` with `${OSM_RELATION_ID}`
- Pipe `api.sql` through `envsubst '$OSM_RELATION_ID'` before passing to psql — in both `import.sh` (importer container) and `make db-apply` (host path)
- Add `gettext-base` to the importer `Dockerfile` to provide `envsubst`

Fixes #12

## Test plan

- [ ] Copy `.env.example` to `.env`, set a different `OSM_RELATION_ID`
- [ ] Run `make import` — verify the deployed SQL functions have the correct default value (`\df+ api.get_playgrounds` in psql)
- [ ] Run `make db-apply` — same check
- [ ] Confirm `make db-apply` fails gracefully when `.env` is missing (existing behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)