### PR TITLE
fix: Vor/Zurück-Buttons im Foto-Modal bei Einzelfoto ausblenden

### DIFF
--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -767,10 +767,11 @@ function openPanoramaxModal(index) {
     panoramaxModalIndex = ((index % panoramaxUuids.length) + panoramaxUuids.length) % panoramaxUuids.length;
     const uuid = panoramaxUuids[panoramaxModalIndex];
     el('panoramax-modal-iframe').src = panoramaxViewerUrl(uuid);
+    const multiPhoto = panoramaxUuids.length > 1;
     el('panoramax-modal-counter').textContent =
-        panoramaxUuids.length > 1 ? `${panoramaxModalIndex + 1} / ${panoramaxUuids.length}` : '';
-    el('panoramax-modal-prev').disabled = false;
-    el('panoramax-modal-next').disabled = false;
+        multiPhoto ? `${panoramaxModalIndex + 1} / ${panoramaxUuids.length}` : '';
+    el('panoramax-modal-prev').style.display = multiPhoto ? '' : 'none';
+    el('panoramax-modal-next').style.display = multiPhoto ? '' : 'none';
     Modal.getOrCreateInstance('#modalPanoramax').show();
 }
 


### PR DESCRIPTION
Closes #15

## Summary

- Bei nur einem Panoramax-Foto wurden die Navigationsschaltflächen „Vorheriges Foto" und „Nächstes Foto" trotzdem angezeigt
- Jetzt werden beide Buttons per `display:none` versteckt, wenn nur ein Foto vorhanden ist
- Der Zähler (z. B. „1 / 3") war bereits korrekt — diese Logik wird nun für die Buttons wiederverwendet

## Test plan

- [ ] Spielplatz mit einem Panoramax-Foto auswählen → Foto anklicken → Modal öffnet sich ohne Vor/Zurück-Buttons
- [ ] Spielplatz mit mehreren Panoramax-Fotos auswählen → Foto anklicken → Modal zeigt Vor/Zurück-Buttons und Zähler wie bisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)