### PR TITLE
feat: Ausstattungs-Übersicht optisch vom Gerätelist abheben

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -290,6 +290,22 @@ ul {
    Device List (Ausstattung)
    =========================== */
 
+/* Übersicht-Zusammenfassung (Anzahl Geräte, Bänke …) */
+#info-equipment ul {
+    background: var(--bs-tertiary-bg);
+    border-radius: 6px;
+    padding: 6px 10px;
+    margin-bottom: 0;
+    font-size: 0.875rem;
+}
+
+/* Trennlinie zwischen Übersicht und Einzelliste */
+#info-device-list:not(:empty) {
+    border-top: 1px solid var(--bs-border-color);
+    margin-top: 8px;
+    padding-top: 6px;
+}
+
 .device-list {
     list-style: none;
     padding-left: 0;


### PR DESCRIPTION
Closes #18

## Summary

- Die Zusammenfassung (Anzahl Spielgeräte, Bänke, Unterstände …) erhält einen leichten Hintergrund (`--bs-tertiary-bg`) und abgerundete Ecken — sie liest sich jetzt als „Auf einen Blick"-Block
- Eine feine Trennlinie (`border-top`) trennt die Übersicht von der darunter folgenden Einzelgeräteliste
- Rein CSS-seitige Änderung in `style.css`, kein HTML oder JS angefasst
- Nutzt Bootstrap CSS-Variablen, passt sich also automatisch an helles/dunkles Theme an

## Test plan

- [ ] Spielplatz mit mehreren Geräten auswählen → Übersicht erscheint als abgesetzter Block, darunter Trennlinie, dann Einzelliste
- [ ] Spielplatz ohne separate Geräte (nur Übersicht) → kein leerer Trennbereich sichtbar (`:not(:empty)`-Guard)
- [ ] Dark-Mode prüfen (falls aktiviert) → Hintergrund und Trennlinie passen sich an

🤖 Generated with [Claude Code](https://claude.com/claude-code)