### PR TITLE
fix: Gerätebild als Echtfoto oder Symbolbild kennzeichnen

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -458,7 +458,8 @@ function getEquipmentAttributes (feature) {
         const viewerUrl = `https://api.panoramax.xyz/?pic=${panoramaxUuid}&nav=none&focus=pic`;
         contentHtml += `<a href="${viewerUrl}" target="_blank" rel="noopener">` +
             `<img src="${thumbUrl}" alt="Straßenfoto" style="object-fit:cover; aspect-ratio:16/9;">` +
-            `</a>`;
+            `</a>` +
+            `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-camera"></span> Foto dieses Geräts</p>`;
     }
     if (content.length) {
         contentHtml += "<ul>";
@@ -475,7 +476,8 @@ function getEquipmentAttributes (feature) {
             const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
             const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
             contentHtml = `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}"
-                style="object-fit:contain;">`;
+                style="object-fit:contain;">` +
+                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>`;
         }
     }
 


### PR DESCRIPTION
Closes #20

## Summary

- Unter Panoramax-Fotos eines Geräts erscheint jetzt `📷 Foto dieses Geräts` (Bootstrap `bi-camera`-Icon)
- Unter Wikimedia-Symbolbildern erscheint `🖼 Symbolbild` (Bootstrap `bi-image`-Icon)
- Beide Labels sind in gedämpfter Farbe (`text-muted`) und kleiner Schrift — unauffällig, aber eindeutig
- Nur `js/popup.js` geändert, kein CSS oder HTML nötig

## Test plan

- [ ] Gerät mit Panoramax-Tag aufklappen → Foto + Label „Foto dieses Geräts" sichtbar
- [ ] Gerät ohne Panoramax, aber mit Wikimedia-Bild aufklappen → Bild + Label „Symbolbild" sichtbar
- [ ] Gerät ohne jegliches Bild → kein Label, keine leere Zeile

🤖 Generated with [Claude Code](https://claude.com/claude-code)