### PR TITLE
fix: improve sport pitch labels, show raw sport value for unknown types

### DIFF
--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -399,17 +399,31 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
 
     // Sportfeldnamen nach sport=* — Singular und Plural
     const pitchLabels = {
-        soccer:       ['Bolzplatz',          'Bolzplätze'],
-        basketball:   ['Basketballfeld',      'Basketballfelder'],
-        table_tennis: ['Tischtennisplatte',   'Tischtennisplatten'],
-        volleyball:   ['Volleyballfeld',      'Volleyballfelder'],
-        tennis:       ['Tennisfeld',          'Tennisfelder'],
-        handball:     ['Handballfeld',        'Handballfelder'],
-        badminton:    ['Badmintonfeld',       'Badmintonfelder'],
-        hockey:       ['Hockeyfeld',          'Hockeyfelder'],
-        boules:       ['Boulesbahn',          'Boulesanlagen'],
-        petanque:     ['Pétanquebahn',        'Pétanqueanlagen'],
-        bocce:        ['Bocciabahn',          'Bocciabahnen'],
+        soccer:          ['Bolzplatz',               'Bolzplätze'],
+        basketball:      ['Basketballfeld',           'Basketballfelder'],
+        table_tennis:    ['Tischtennisplatte',        'Tischtennisplatten'],
+        volleyball:      ['Volleyballfeld',           'Volleyballfelder'],
+        tennis:          ['Tennisfeld',               'Tennisfelder'],
+        handball:        ['Handballfeld',             'Handballfelder'],
+        badminton:       ['Badmintonfeld',            'Badmintonfelder'],
+        hockey:          ['Hockeyfeld',               'Hockeyfelder'],
+        field_hockey:    ['Hockeyfeld',               'Hockeyfelder'],
+        boules:          ['Boulesbahn',               'Boulesanlagen'],
+        petanque:        ['Pétanquebahn',             'Pétanqueanlagen'],
+        bocce:           ['Bocciabahn',               'Bocciabahnen'],
+        multi:           ['Mehrzweckspielfeld',       'Mehrzweckspielfelder'],
+        athletics:       ['Leichtathletikanlage',     'Leichtathletikanlagen'],
+        skateboard:      ['Skatepark',                'Skateparks'],
+        bmx:             ['BMX-Bahn',                 'BMX-Bahnen'],
+        climbing:        ['Kletteranlage',            'Kletteranlagen'],
+        beachvolleyball: ['Beachvolleyballfeld',      'Beachvolleyballfelder'],
+        fitness:         ['Fitnessbereich',           'Fitnessbereiche'],
+        archery:         ['Bogenschießanlage',        'Bogenschießanlagen'],
+        cycling:         ['Radsportanlage',           'Radsportanlagen'],
+        running:         ['Laufbahn',                 'Laufbahnen'],
+        gymnastics:      ['Turnanlage',               'Turnanlagen'],
+        chess:           ['Schachfeld',               'Schachfelder'],
+        nine_mens_morris:['Mühlespielfeld',           'Mühlespielfelder'],
     };
 
     // Pitches nach Sportart gruppieren
@@ -469,7 +483,8 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     // Sportfelder (pitches) mit farbigem Punkt in die Geräteliste einreihen
     const pitchColor = objColors['fallback'];
     for (const [sport, count] of Object.entries(pitchBySport)) {
-        const [singular, plural] = pitchLabels[sport] ?? ['Sportfeld', 'Sportfelder'];
+        const [singular, plural] = pitchLabels[sport]
+            ?? (sport ? [`Sportfeld (${sport})`, `Sportfelder (${sport})`] : ['Sportfeld', 'Sportfelder']);
         const label = count === 1 ? singular : `${count}× ${plural}`;
         device_string += `<li><span style="color:${pitchColor}">●</span> ${label}</li>`;
     }


### PR DESCRIPTION
Closes #23

## Summary

- Extended `pitchLabels` with 14 additional sport types: `multi`, `athletics`, `skateboard`, `bmx`, `climbing`, `beachvolleyball`, `fitness`, `field_hockey`, `archery`, `cycling`, `running`, `gymnastics`, `chess`, `nine_mens_morris`
- For sport values still not in the dictionary the raw OSM tag is now shown as `Sportfeld (<value>)` so the type is always visible rather than hidden behind a generic "Sportfeld" label
- Pitches with no `sport` tag at all still fall back to plain "Sportfeld"

## Test plan

- [ ] Playground with `sport=multi` pitch → shows "Mehrzweckspielfeld" (was: "Sportfeld")
- [ ] Playground with `sport=skateboard` pitch → shows "Skatepark"
- [ ] Playground with an unmapped sport value (e.g. `sport=archery`) → shows "Sportfeld (archery)"
- [ ] Playground with a pitch and no `sport` tag → shows "Sportfeld" as before
- [ ] Grezzbachpark → "Sportfeld" entry now has a meaningful label

🤖 Generated with [Claude Code](https://claude.com/claude-code)