### PR TITLE
feat: show example images for sport pitches in device detail

### DIFF
--- a/js/objPlaygroundEquipment.js
+++ b/js/objPlaygroundEquipment.js
@@ -22,7 +22,7 @@
 export const objDevices = {
     slide: {
         name_de: "Rutsche",
-        image: "File:Slide_in_Bhutan.jpg",
+        image: "https://wiki.openstreetmap.org/wiki/Special:FilePath/Accessibleplay-Slide.jpg",
         category: "stationary",
         filterable: true,
         filter_attr: ["length", "height"],
@@ -217,7 +217,7 @@ export const objDevices = {
     },
     excavator: {
         name_de: "Spielbagger",
-        image: "File:Playground_digger_2,_Darland_Banks_-_geograph.org.uk_-_1588398.jpg",
+        image: "https://wiki.openstreetmap.org/wiki/Special:FilePath/Playground_excavator,_unpowered.jpg",
         category: "sand",
         filterable: true,
     },

--- a/js/objPlaygroundEquipment.js
+++ b/js/objPlaygroundEquipment.js
@@ -22,7 +22,7 @@
 export const objDevices = {
     slide: {
         name_de: "Rutsche",
-        image: "https://wiki.openstreetmap.org/wiki/Special:FilePath/Accessibleplay-Slide.jpg",
+        image: "File:Accessibleplay-Slide.jpg",
         category: "stationary",
         filterable: true,
         filter_attr: ["length", "height"],
@@ -217,7 +217,7 @@ export const objDevices = {
     },
     excavator: {
         name_de: "Spielbagger",
-        image: "https://wiki.openstreetmap.org/wiki/Special:FilePath/Playground_excavator,_unpowered.jpg",
+        image: "File:Playground excavator, unpowered.jpg",
         category: "sand",
         filterable: true,
     },

--- a/js/objPlaygroundEquipment.js
+++ b/js/objPlaygroundEquipment.js
@@ -22,7 +22,7 @@
 export const objDevices = {
     slide: {
         name_de: "Rutsche",
-        image: "File:Accessibleplay-Slide.jpg",
+        image: "File:Slide_in_Bhutan.jpg",
         category: "stationary",
         filterable: true,
         filter_attr: ["length", "height"],
@@ -217,7 +217,7 @@ export const objDevices = {
     },
     excavator: {
         name_de: "Spielbagger",
-        image: "File:Playground excavator, unpowered.jpg",
+        image: "File:Playground_digger_2,_Darland_Banks_-_geograph.org.uk_-_1588398.jpg",
         category: "sand",
         filterable: true,
     },

--- a/js/popup.js
+++ b/js/popup.js
@@ -469,41 +469,44 @@ function getEquipmentAttributes (feature) {
         contentHtml += "</ul>";
     }
 
+    const leisure = feature.get('leisure');
+    const osmTypeMap = { N: 'node', W: 'way', R: 'relation' };
+    const osmType = osmTypeMap[feature.get('osm_type')] || 'node';
+    const osmId = feature.get('osm_id');
+    const mapCompleteTheme = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
+    const mapCompleteUrl = `https://mapcomplete.org/${mapCompleteTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
+    const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mapCompleteUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
+
     // Kein Panoramax, kein Inhalt: Vorschaubild des Geräts aus Wikimedia Commons anzeigen
     if (!contentHtml) {
         const deviceKey = feature.get('playground');
-        const leisure = feature.get('leisure');
-        const sport = feature.get('sport');
-        const osmTypeMap = { N: 'node', W: 'way', R: 'relation' };
-        const osmType = osmTypeMap[feature.get('osm_type')] || 'node';
-        const osmId = feature.get('osm_id');
-        const mapCompleteTheme = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
-        const mapCompleteUrl = `https://mapcomplete.org/${mapCompleteTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
-        const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mapCompleteUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
+        const sportRaw = feature.get('sport');
+        const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
 
         if (deviceKey && deviceKey in objDevices && objDevices[deviceKey].image) {
             const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
             const commonsUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
             const osmWikiUrl = `https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}`;
-            const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
             contentHtml = `<div class="device-img-wrap">` +
                 `<img src="${commonsUrl}" data-fallback="${osmWikiUrl}" alt="${objDevices[deviceKey].name_de}" style="object-fit:contain;" onerror="${onerror}">` +
                 `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>` +
-                `</div>` +
-                addPhotoLink;
+                `</div>`;
         }
 
         // Sportfelder (leisure=pitch): sportartspezifisches Symbolbild anzeigen
-        if (leisure === 'pitch' && sport && sport in pitchImages) {
-            const imgFile = pitchImages[sport].replace(/^File:/, '').replace(/ /g, '_');
+        if (leisure === 'pitch' && sportRaw && sportRaw in pitchImages) {
+            const imgFile = pitchImages[sportRaw].replace(/^File:/, '').replace(/ /g, '_');
             const commonsUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
             const osmWikiUrl = `https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}`;
-            const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
             contentHtml = `<div class="device-img-wrap">` +
-                `<img src="${commonsUrl}" data-fallback="${osmWikiUrl}" alt="${sport}" style="object-fit:contain;" onerror="${onerror}">` +
-                `</div>` +
-                addPhotoLink;
+                `<img src="${commonsUrl}" data-fallback="${osmWikiUrl}" alt="${sportRaw}" style="object-fit:contain;" onerror="${onerror}">` +
+                `</div>`;
         }
+    }
+
+    // Foto-hinzufügen-Link anzeigen wenn kein eigenes Panoramax-Foto vorhanden
+    if (!panoramaxUuid) {
+        contentHtml += addPhotoLink;
     }
 
     return contentHtml;

--- a/js/popup.js
+++ b/js/popup.js
@@ -482,8 +482,10 @@ function getEquipmentAttributes (feature) {
         const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mapCompleteUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
 
         if (deviceKey && deviceKey in objDevices && objDevices[deviceKey].image) {
-            const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
-            const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
+            const raw = objDevices[deviceKey].image;
+            const imgUrl = raw.startsWith('http')
+                ? raw
+                : `https://commons.wikimedia.org/wiki/Special:FilePath/${raw.replace(/^File:/, '').replace(/ /g, '_')}?width=800`;
             contentHtml = `<div class="device-img-wrap">` +
                 `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}" style="object-fit:contain;" onerror="this.parentElement.style.display='none'">` +
                 `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>` +

--- a/js/popup.js
+++ b/js/popup.js
@@ -472,20 +472,33 @@ function getEquipmentAttributes (feature) {
     // Kein Panoramax, kein Inhalt: Vorschaubild des Geräts aus Wikimedia Commons anzeigen
     if (!contentHtml) {
         const deviceKey = feature.get('playground');
+        const leisure = feature.get('leisure');
+        const sport = feature.get('sport');
+        const osmTypeMap = { N: 'node', W: 'way', R: 'relation' };
+        const osmType = osmTypeMap[feature.get('osm_type')] || 'node';
+        const osmId = feature.get('osm_id');
+        const mapCompleteTheme = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
+        const mapCompleteUrl = `https://mapcomplete.org/${mapCompleteTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
+        const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mapCompleteUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
+
         if (deviceKey && deviceKey in objDevices && objDevices[deviceKey].image) {
             const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
             const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
-            contentHtml = `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}"
-                style="object-fit:contain;">` +
-                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>`;
+            contentHtml = `<div class="device-img-wrap">` +
+                `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}" style="object-fit:contain;" onerror="this.parentElement.style.display='none'">` +
+                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>` +
+                `</div>` +
+                addPhotoLink;
         }
 
         // Sportfelder (leisure=pitch): sportartspezifisches Symbolbild anzeigen
-        const sport = feature.get('sport');
-        if (feature.get('leisure') === 'pitch' && sport && sport in pitchImages) {
+        if (leisure === 'pitch' && sport && sport in pitchImages) {
             const imgFile = pitchImages[sport].replace(/^File:/, '').replace(/ /g, '_');
             const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
-            contentHtml = `<img src="${imgUrl}" alt="${sport}" style="object-fit:contain;">`;
+            contentHtml = `<div class="device-img-wrap">` +
+                `<img src="${imgUrl}" alt="${sport}" style="object-fit:contain;" onerror="this.parentElement.style.display='none'">` +
+                `</div>` +
+                addPhotoLink;
         }
     }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -482,12 +482,12 @@ function getEquipmentAttributes (feature) {
         const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mapCompleteUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
 
         if (deviceKey && deviceKey in objDevices && objDevices[deviceKey].image) {
-            const raw = objDevices[deviceKey].image;
-            const imgUrl = raw.startsWith('http')
-                ? raw
-                : `https://commons.wikimedia.org/wiki/Special:FilePath/${raw.replace(/^File:/, '').replace(/ /g, '_')}?width=800`;
+            const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
+            const commonsUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
+            const osmWikiUrl = `https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}`;
+            const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
             contentHtml = `<div class="device-img-wrap">` +
-                `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}" style="object-fit:contain;" onerror="this.parentElement.style.display='none'">` +
+                `<img src="${commonsUrl}" data-fallback="${osmWikiUrl}" alt="${objDevices[deviceKey].name_de}" style="object-fit:contain;" onerror="${onerror}">` +
                 `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p>` +
                 `</div>` +
                 addPhotoLink;
@@ -496,9 +496,11 @@ function getEquipmentAttributes (feature) {
         // Sportfelder (leisure=pitch): sportartspezifisches Symbolbild anzeigen
         if (leisure === 'pitch' && sport && sport in pitchImages) {
             const imgFile = pitchImages[sport].replace(/^File:/, '').replace(/ /g, '_');
-            const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
+            const commonsUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
+            const osmWikiUrl = `https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}`;
+            const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
             contentHtml = `<div class="device-img-wrap">` +
-                `<img src="${imgUrl}" alt="${sport}" style="object-fit:contain;" onerror="this.parentElement.style.display='none'">` +
+                `<img src="${commonsUrl}" data-fallback="${osmWikiUrl}" alt="${sport}" style="object-fit:contain;" onerror="${onerror}">` +
                 `</div>` +
                 addPhotoLink;
         }

--- a/js/popup.js
+++ b/js/popup.js
@@ -477,6 +477,14 @@ function getEquipmentAttributes (feature) {
             contentHtml = `<img src="${imgUrl}" alt="${objDevices[deviceKey].name_de}"
                 style="object-fit:contain;">`;
         }
+
+        // Sportfelder (leisure=pitch): sportartspezifisches Symbolbild anzeigen
+        const sport = feature.get('sport');
+        if (feature.get('leisure') === 'pitch' && sport && sport in pitchImages) {
+            const imgFile = pitchImages[sport].replace(/^File:/, '').replace(/ /g, '_');
+            const imgUrl = `https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800`;
+            contentHtml = `<img src="${imgUrl}" alt="${sport}" style="object-fit:contain;">`;
+        }
     }
 
     return contentHtml;
@@ -692,6 +700,27 @@ const objIssueFeatures = {
     tree: "Baum",
     building: "Gebäude",
 }
+
+// Symbolbilder für Sportfelder (leisure=pitch) nach sport=* — Wikimedia-Commons-Dateinamen
+const pitchImages = {
+    soccer:          'File:Association football pitch imperial.svg',
+    basketball:      'File:Basketball court dimensions in meters.svg',
+    table_tennis:    'File:Table tennis table blue.jpg',
+    volleyball:      'File:Volleyball court with dimensions.svg',
+    tennis:          'File:Hard tennis court 1.jpg',
+    handball:        'File:Handball court metric.svg',
+    badminton:       'File:Badminton court 8shuttle.svg',
+    hockey:          'File:Field Hockey Pitch Dimensions.svg',
+    field_hockey:    'File:Field Hockey Pitch Dimensions.svg',
+    boules:          'File:Boules-coloured.jpg',
+    petanque:        'File:Boules-coloured.jpg',
+    multi:           'File:Multi-use games area.jpg',
+    skateboard:      'File:Skatepark Vienna Praterstern 2015.jpg',
+    bmx:             'File:BMX track Canberra.jpg',
+    athletics:       'File:Athletics track.jpg',
+    beachvolleyball: 'File:BeachvolleyballAthens04.jpg',
+    climbing:        'File:Outdoor bouldering wall.jpg',
+};
 
 // Icons für Datenprobleme
 const objIssueIcons = {

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -412,12 +412,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
         bocce:        ['Bocciabahn',          'Bocciabahnen'],
     };
 
-    // Pitches nach Sportart gruppieren
-    const pitchBySport = {};
-    for (const f of features.filter(f => f.properties.leisure === 'pitch')) {
-        const sport = f.properties.sport ?? '';
-        pitchBySport[sport] = (pitchBySport[sport] || 0) + 1;
-    }
+    const pitchFeatures = features.filter(f => f.properties.leisure === 'pitch');
 
     let equipment_str = '<ul>';
     if (deviceCount)  equipment_str += `<li>${t('equipment.devices',  { count: deviceCount  })}</li>`;
@@ -466,12 +461,23 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
             device_string += `<li><span style="color:${fitnessColor}">●</span> ${name}</li>`;
         }
     }
-    // Sportfelder (pitches) mit farbigem Punkt in die Geräteliste einreihen
+    // Sportfelder (pitches) einzeln auflisten — jedes als aufklappbares Element mit Details
     const pitchColor = objColors['fallback'];
-    for (const [sport, count] of Object.entries(pitchBySport)) {
-        const [singular, plural] = pitchLabels[sport] ?? ['Sportfeld', 'Sportfelder'];
-        const label = count === 1 ? singular : `${count}× ${plural}`;
-        device_string += `<li><span style="color:${pitchColor}">●</span> ${label}</li>`;
+    for (const f of pitchFeatures) {
+        const sport = f.properties.sport ?? '';
+        const [singular] = pitchLabels[sport]
+            ?? (sport ? [`Sportfeld (${sport})`, `Sportfelder (${sport})`] : ['Sportfeld', 'Sportfelder']);
+        const detail = getEquipmentAttributesFromProps(f.properties);
+        const uid = `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
+        if (detail) {
+            device_string += `<li>` +
+                `<div class="device-toggle" data-bs-toggle="collapse" data-bs-target="#${uid}" role="button">` +
+                `<span style="color:${pitchColor}">●</span> ${singular}` +
+                ` <span class="bi bi-chevron-down device-chevron"></span></div>` +
+                `<div id="${uid}" class="collapse device-detail">${detail}</div></li>`;
+        } else {
+            device_string += `<li><span style="color:${pitchColor}">●</span> ${singular}</li>`;
+        }
     }
     device_string += '</ul>';
 


### PR DESCRIPTION
Closes #22

## Summary

- Sport pitches (`leisure=pitch`) are now listed as **individual collapsible items** in the device list, matching the behaviour of playground devices and fitness stations
- When a pitch has a `panoramax` tag, the real photo is shown (existing behaviour from the generic Panoramax handling)
- Otherwise a sport-specific example image from Wikimedia Commons is shown (soccer, basketball, table tennis, volleyball, tennis, handball, badminton, hockey, boules, multi, skateboard, bmx, athletics, beachvolleyball, climbing)
- Pitches with a sport type that has no image entry degrade gracefully to a plain list item without a chevron

## Changes

- `js/popup.js` — added `pitchImages` dict; `getEquipmentAttributes` now looks up pitch images as a fallback when `leisure=pitch`
- `js/selectPlayground.js` — replaced grouped `pitchBySport` counter with per-feature iteration using `getEquipmentAttributesFromProps`, same pattern as playground devices

## Notes

The Wikimedia Commons filenames in `pitchImages` are best-effort guesses — some may need adjustment if an image fails to load. The mechanism is solid; filenames are easy to correct.

## Test plan

- [ ] Playground with a `soccer` pitch → "Bolzplatz" is collapsible, shows a soccer field example image
- [ ] Playground with a `multi` pitch → "Mehrzweckspielfeld" is collapsible, shows an example image
- [ ] Playground with a pitch that has a `panoramax` tag → real photo shown
- [ ] Playground with a pitch type not in `pitchImages` (e.g. `archery`) → plain list item, no broken image
- [ ] Grezzbachpark → "Sportfeld" (or improved label from #23) is now collapsible

🤖 Generated with [Claude Code](https://claude.com/claude-code)