### PR TITLE
fix: make search icon tappable and use mobile-friendly placeholder

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,6 +78,7 @@ ul {
     color: #9ca3af;
     font-size: 15px;
     flex-shrink: 0;
+    cursor: pointer;
 }
 
 .search-input {

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
         <div id="search-bar">
             <img src="./img/swing.png" alt="Logo" height="20" class="search-logo">
             <span id="app-version" class="search-version"></span>
-            <span id="inputSearchIcon" class="bi bi-search search-icon"></span>
-            <input id="inputSearch" type="text" class="search-input" placeholder="Doppel-Shift für Suche" data-i18n-placeholder="search.placeholder">
+            <span id="inputSearchIcon" class="bi bi-search search-icon" role="button" aria-label="Suche öffnen" data-i18n-aria-label="search.open"></span>
+            <input id="inputSearch" type="text" class="search-input" placeholder="Suchen …" data-i18n-placeholder="search.placeholder">
             <div class="search-nav-links">
                 <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalDatenErgaenzen" data-i18n="nav.addData">Daten ergänzen</a>
                 <a class="search-nav-link" href="#" data-bs-toggle="modal" data-bs-target="#modalUeberDasProjekt" data-i18n="nav.about">Über das Projekt</a>

--- a/js/main.js
+++ b/js/main.js
@@ -131,7 +131,12 @@ document.addEventListener('keydown', e => {
     }
 });
 
-// Double-Shift → focus search box
+// Search icon tap/click → focus search box (mobile-friendly)
+document.getElementById('inputSearchIcon').addEventListener('click', () => {
+    document.getElementById('inputSearch').focus();
+});
+
+// Double-Shift → focus search box (desktop shortcut)
 let lastShift = 0;
 document.addEventListener('keydown', e => {
     if (e.key !== 'Shift') { lastShift = 0; return; }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Mapa hřišť \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Dvojitý Shift pro vyhledávání",
+    "placeholder": "Hledat …",
     "found": "\"{{query}}\" v {{location}}",
     "foundGeneric": "\"{{query}}\" nalezeno",
     "notFound": "Žádné výsledky nenalezeny!"

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "{{regionName}}er Spielplatzkarte",
   "search": {
-    "placeholder": "Doppel-Shift für Suche",
+    "placeholder": "Suchen …",
     "found": "\u201e{{query}}\u201c in {{location}}",
     "foundGeneric": "\u201e{{query}}\u201c gefunden",
     "notFound": "Kein Suchergebnis gefunden!"

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "{{regionName}} Playground Map",
   "search": {
-    "placeholder": "Double-Shift to search",
+    "placeholder": "Search …",
     "found": "\"{{query}}\" in {{location}}",
     "foundGeneric": "\"{{query}}\" found",
     "notFound": "No results found!"

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Parques infantiles \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Doble-Shift para buscar",
+    "placeholder": "Buscar …",
     "found": "\"{{query}}\" en {{location}}",
     "foundGeneric": "\"{{query}}\" encontrado",
     "notFound": "\u00a1No se encontraron resultados!"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Aires de jeux \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Double-Shift pour rechercher",
+    "placeholder": "Rechercher …",
     "found": "\u00ab\u00a0{{query}}\u00a0\u00bb \u00e0 {{location}}",
     "foundGeneric": "\u00ab\u00a0{{query}}\u00a0\u00bb trouv\u00e9",
     "notFound": "Aucun r\u00e9sultat trouv\u00e9\u00a0!"

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Aree gioco \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Doppio-Shift per cercare",
+    "placeholder": "Cerca …",
     "found": "\"{{query}}\" a {{location}}",
     "foundGeneric": "\"{{query}}\" trovato",
     "notFound": "Nessun risultato trovato!"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "遊び場マップ \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Shiftキーを2回押して検索",
+    "placeholder": "検索 …",
     "found": "{{location}}で「{{query}}」",
     "foundGeneric": "「{{query}}」が見つかりました",
     "notFound": "結果が見つかりませんでした！"

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Speeltuinenkaart \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Dubbel-Shift om te zoeken",
+    "placeholder": "Zoeken …",
     "found": "\"{{query}}\" in {{location}}",
     "foundGeneric": "\"{{query}}\" gevonden",
     "notFound": "Geen resultaten gevonden!"

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Mapa placów zabaw \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Podwójny Shift, aby wyszukać",
+    "placeholder": "Szukaj …",
     "found": "\"{{query}}\" w {{location}}",
     "foundGeneric": "\"{{query}}\" znaleziono",
     "notFound": "Nie znaleziono wyników!"

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Mapa de parques infantis \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Duplo Shift para pesquisar",
+    "placeholder": "Pesquisar …",
     "found": "\"{{query}}\" em {{location}}",
     "foundGeneric": "\"{{query}}\" encontrado",
     "notFound": "Nenhum resultado encontrado!"

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Lekplatskarta \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Dubbel-Shift för att söka",
+    "placeholder": "Sök …",
     "found": "\"{{query}}\" i {{location}}",
     "foundGeneric": "\"{{query}}\" hittades",
     "notFound": "Inga resultat hittades!"

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -1,7 +1,7 @@
 {
   "appTitle": "Карта майданчиків \u2013 {{regionName}}",
   "search": {
-    "placeholder": "Подвійний Shift для пошуку",
+    "placeholder": "Пошук …",
     "found": "\"{{query}}\" у {{location}}",
     "foundGeneric": "\"{{query}}\" знайдено",
     "notFound": "Результатів не знайдено!"


### PR DESCRIPTION
Closes #26

## Summary

- **Search icon is now tappable**: clicking/tapping `#inputSearchIcon` focuses the search input and opens the on-screen keyboard on mobile. Previously it was a purely decorative `<span>`.
- **Placeholder updated in all 12 locales**: the keyboard-only "Double-Shift to search" hint is replaced with a short, neutral term ("Search …", "Suchen …", etc.) that makes sense on touch devices. The Double-Shift desktop shortcut is unchanged and still works.
- `cursor: pointer` added to `.search-icon` so the affordance is visible on desktop too.

## Files changed

- `index.html` — added `role="button"` to icon span
- `js/main.js` — click handler on `#inputSearchIcon` → `#inputSearch.focus()`
- `css/style.css` — `cursor: pointer` on `.search-icon`
- `locales/*.json` (12 files) — updated `search.placeholder`

## Test plan

- [ ] Mobile: tap the magnifying-glass icon → keyboard opens, search input is focused
- [ ] Mobile: placeholder reads "Suchen …" (or locale equivalent), not a keyboard hint
- [ ] Desktop: Double-Shift still focuses the search input as before
- [ ] Desktop: clicking the icon also focuses the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)