### PR TITLE
feat: enable LAN access for mobile testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,26 @@ make down              # stop all containers
 
 The importer is not started by `make up`. Run `make import` once before the app has any data.
 
+## Testing on mobile / LAN access
+
+To test the app on a phone (or any device on the same WiFi), run:
+
+```bash
+make lan-url
+```
+
+This prints your machine's LAN IP and the ready-to-use URLs:
+
+```
+  LAN IP:            192.168.1.42
+  Vite dev server:   http://192.168.1.42:5173
+  Docker stack:      http://192.168.1.42:8080
+```
+
+**Vite dev server** (`make dev`): binds to all interfaces automatically — open the printed Network URL on the phone. If the page doesn't load, check that port 5173 is not blocked by a firewall on the host.
+
+**Docker stack** (`make up`): already binds to `0.0.0.0` by default, so `http://<LAN-IP>:8080` (or `$APP_PORT`) works immediately without any extra config.
+
 ## Architecture
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install dev build serve \
         up down import docker-build db-apply db-shell \
-        require-npm require-docker installer help
+        require-npm require-docker installer lan-url help
 
 # Bail with a clear message when a required tool is missing.
 define require
@@ -24,7 +24,7 @@ require-docker:
 install: require-npm      ## Install Node dependencies
 	npm ci
 
-dev: require-npm          ## Start Vite dev server at http://localhost:5173
+dev: require-npm          ## Start Vite dev server (localhost:5173 + LAN, see make lan-url)
 	npm start
 
 build: require-npm        ## Production build → dist/
@@ -60,6 +60,19 @@ db-shell: require-docker  ## Open a psql shell in the running database container
 
 installer: require-docker ## Run the interactive production installer (no git clone required)
 	bash install.sh
+
+## ── Local / mobile testing ────────────────────────────────────────────────────
+
+lan-url:                  ## Print the LAN URLs to open the app on a phone (same WiFi)
+	@LAN_IP=$$(hostname -I 2>/dev/null | awk '{print $$1}') && \
+	  APP_PORT=$${APP_PORT:-8080} && \
+	  if [ -z "$$LAN_IP" ]; then \
+	    printf '\n  \033[33mCould not detect LAN IP.\033[0m Run: ip route get 1 | awk '"'"'{print $$7; exit}'"'"'\n\n'; \
+	  else \
+	    printf '\n  \033[36mLAN IP:\033[0m            %s\n' "$$LAN_IP" && \
+	    printf '  \033[36mVite dev server:\033[0m   http://%s:5173\n' "$$LAN_IP" && \
+	    printf '  \033[36mDocker stack:\033[0m      http://%s:%s\n\n' "$$LAN_IP" "$$APP_PORT"; \
+	  fi
 
 ## ── Help ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,25 @@ SQL changes to `importer/api.sql` (PostgREST functions, indexes) can be applied 
 make db-apply
 ```
 
+### Testing on a phone / LAN access
+
+To open the app on a phone or any other device on the same WiFi network:
+
+```bash
+make lan-url
+```
+
+This prints your machine's LAN IP and the ready-to-use URLs, for example:
+
+```
+  LAN IP:            192.168.1.42
+  Vite dev server:   http://192.168.1.42:5173
+  Docker stack:      http://192.168.1.42:8080
+```
+
+- **Vite dev server** (`make dev`): already binds to all interfaces — open the printed URL on the phone. If it doesn't load, check that port 5173 is not blocked by a firewall on the host.
+- **Docker stack** (`make up`): binds to `0.0.0.0` by default, so `http://<LAN-IP>:8080` works immediately without any extra configuration.
+
 ---
 
 ## License

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,8 @@
 export default {
   build: {
     sourcemap: true,
-  }
+  },
+  server: {
+    host: true,   // bind to 0.0.0.0 so the app is reachable on the local network
+  },
 }


### PR DESCRIPTION
Closes #28

## Summary

- **`vite.config.js`** — `server: { host: true }` added; Vite now binds to `0.0.0.0` and prints both the localhost and Network (LAN) URLs on startup
- **`Makefile`** — new `make lan-url` target prints the host LAN IP and ready-to-use URLs for both the Vite dev server (:5173) and Docker stack (:8080 / `$APP_PORT`); `lan-url` added to `.PHONY` and `make help`
- **`README.md`** — new "Testing on a phone / LAN access" subsection under "Local development"
- **`CLAUDE.md`** — new "Testing on mobile / LAN access" section with the same instructions

The Docker stack was already reachable on the LAN (`0.0.0.0` binding is Docker's default) — no Compose changes needed.

## Test plan

- [ ] Run `make dev`, confirm terminal prints a `Network:` URL alongside `Local:`
- [ ] Open the Network URL on a phone on the same WiFi → app loads
- [ ] Run `make lan-url` → prints LAN IP and both URLs
- [ ] Run `make up` → open `http://<LAN-IP>:8080` on phone → app loads
- [ ] `make help` → `lan-url` entry is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)