### PR TITLE
fix(mobile): nearby panel hidden by .info-more-hint CSS rule

### DIFF
--- a/js/locate.js
+++ b/js/locate.js
@@ -62,7 +62,15 @@ const geolocation = new Geolocation({
 });
 
 geolocation.on('error', function (error) {
-    console.log("Standortverfolgung nicht möglich.");
+    console.warn('Geolocation error:', error.message);
+    // Show a brief visible alert — most likely cause on mobile is non-HTTPS context
+    const btn = document.getElementById('btn-location');
+    if (btn) {
+        const original = btn.title;
+        btn.title = error.message || 'Standortzugriff nicht möglich';
+        btn.style.outline = '2px solid red';
+        setTimeout(() => { btn.style.outline = ''; btn.title = original; }, 4000);
+    }
 });
 
 const accuracyFeature = new Feature();

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -96,6 +96,7 @@ export function showNearbyPlaygrounds(lon, lat, label = t('nearby.thisLocation')
 
     html += '</div>';
     el('info-more').innerHTML = html;
+    el('info-more').style.display = 'block'; // override .info-more-hint { display:none } on mobile
     el('info').classList.add('panel-open');
 
     if (nearbyClickController) nearbyClickController.abort();


### PR DESCRIPTION
## Root cause

On mobile, `.info-more-hint { display: none }` hides `#info-more` at the CSS level. The `show()` helper only sets `style.display = ''` (clears inline style), which causes the element to fall back to the CSS class rule — remaining hidden. On desktop there is no such CSS rule, so it worked fine there.

`showNearbyPlaygrounds` never called `show()` at all, so `#info-more` was always hidden on mobile regardless.

## Fix

- Set `el('info-more').style.display = 'block'` explicitly in `showNearbyPlaygrounds` to override the CSS class
- Surface geolocation errors visually (red outline on the location button for 4 s) instead of only logging to console — helps diagnose permission or HTTPS issues on mobile

Fixes #34

## Test plan

- [ ] Open app on mobile, tap location button → nearby playgrounds list appears in the panel
- [ ] If geolocation is denied or unavailable → location button briefly shows a red outline
- [ ] Desktop behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)