### PR TITLE
fix: toast below search bar, 1.5s duration, lan-url IP fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ installer: require-docker ## Run the interactive production installer (no git cl
 ## ── Local / mobile testing ────────────────────────────────────────────────────
 
 lan-url:                  ## Print the LAN URLs to open the app on a phone (same WiFi)
-	@LAN_IP=$$(hostname -I 2>/dev/null | awk '{print $$1}') && \
+	@LAN_IP=$$(hostname -I 2>/dev/null | awk '{print $$1}'); \
+	  [ -z "$$LAN_IP" ] && LAN_IP=$$(ip route get 1 2>/dev/null | awk '{print $$7; exit}'); \
 	  APP_PORT=$${APP_PORT:-8080} && \
 	  if [ -z "$$LAN_IP" ]; then \
 	    printf '\n  \033[33mCould not detect LAN IP.\033[0m Run: ip route get 1 | awk '"'"'{print $$7; exit}'"'"'\n\n'; \

--- a/index.html
+++ b/index.html
@@ -381,8 +381,8 @@
         <!--------------------------->
         <!-- Toast (Notifications) -->
         <!--------------------------->
-        <div class="toast-container position-fixed" style="right: 14px; bottom: 120px; z-index: 200;">
-            <div id="toast" class="toast align-items-center border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="4000">
+        <div class="toast-container position-fixed" style="left: 14px; top: 70px; z-index: 200;">
+            <div id="toast" class="toast align-items-center border-0" role="alert" aria-live="assertive" aria-atomic="true" data-bs-delay="1500">
                 <div id="toast-text" class="toast-body"></div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- Toast notification repositioned to appear directly below the search bar (top-left, 70px from top) instead of mid/bottom screen
- Toast auto-dismiss shortened from 4s to 1.5s
- `make lan-url` now falls back to `ip route get 1` when `hostname -I` returns empty

## Test plan

- [ ] Search for a street → toast appears below search bar and fades after ~1.5s
- [ ] Run `make lan-url` → prints LAN IP and URLs correctly

Closes #36, #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)