### PR TITLE
fix(mobile): reset panel scroll on open — Bilder header always visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -587,12 +587,7 @@ ul {
         transform: rotate(180deg);
     }
 
-    /* Header sticks just below the drag handle */
-    #info.panel-open #info-base {
-        position: sticky;
-        top: 34px;
-        z-index: 1;
-    }
+    /* Header scrolls normally — no sticky, so it never overlaps accordion items */
 
     /* Hide search bar and FABs when panel is full-screen */
     body.sheet-expanded #search-bar,

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -1327,9 +1327,7 @@ function setPanelOpen() {
     info.classList.remove('panel-peek');
     info.classList.add('panel-open');
     document.body.classList.add('sheet-expanded');
-    // Reset scroll so the first accordion section (Bilder) is always visible.
-    // Without this, a non-zero scroll offset from a previous interaction causes
-    // the sticky #info-base header to cover the accordion's first button.
+    // Reset scroll so the first accordion section (Bilder) is always at the top.
     info.scrollTop = 0;
 }
 

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -1323,9 +1323,14 @@ el('accordion-btn-schattigkeit').addEventListener('click', function() {
 
 // Mobile: Panel-Zustand wechseln (Peek ↔ Vollbild ↔ Geschlossen)
 function setPanelOpen() {
-    el('info').classList.remove('panel-peek');
-    el('info').classList.add('panel-open');
+    const info = el('info');
+    info.classList.remove('panel-peek');
+    info.classList.add('panel-open');
     document.body.classList.add('sheet-expanded');
+    // Reset scroll so the first accordion section (Bilder) is always visible.
+    // Without this, a non-zero scroll offset from a previous interaction causes
+    // the sticky #info-base header to cover the accordion's first button.
+    info.scrollTop = 0;
 }
 
 function setPanelPeek() {


### PR DESCRIPTION
## Problem

On mobile, the \"Bilder\" accordion section title was missing in the detail panel (issue #39):
- Playgrounds **with** photos: photos visible, but the \"Bilder\" heading invisible
- Playgrounds **without** photos: both the heading and the \"Add photo\" buttons invisible

## Root cause

`#info-base` was `position: sticky; top: 34px` inside the `overflow-y: auto` panel. Any non-zero `scrollTop` — including small offsets triggered by the panoramax iframe finishing its load — caused the sticky header to slide over and cover the first accordion button (Bilder), while the content below it (photos) remained visible.

## Fix

- Remove `position: sticky` from `#info-base` in `panel-open` mode. The drag handle remains sticky so the panel can always be collapsed by dragging. The playground name scrolls normally and is always reachable by scrolling back up.
- Reset `info.scrollTop = 0` in `setPanelOpen()` so the first section is always at the top when the panel opens.

## Test plan

- [ ] Select a playground on mobile → swipe/tap to full screen → "Bilder" heading is visible
- [ ] Scroll down in the detail panel, then select a different playground → "Bilder" heading still visible (scroll reset)
- [ ] Select a playground without photos → "Bilder" heading and "Add photo" link both visible
- [ ] Desktop: detail panel unaffected

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)