### PR TITLE
fix(url): clear URL hash on playground deselect via all paths

### DIFF
--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -821,10 +821,9 @@ export function checkZoomDeselection() {
     }
 }
 
-// Spielplatz abwählen (z. B. per ESC) und URL-Hash leeren
+// Spielplatz abwählen (z. B. per ESC)
 export function clearSelection() {
     removeSelection(true);
-    history.replaceState(null, '', window.location.pathname + window.location.search);
 }
 
 // Spielplatzauswahl aufheben und seine Attribute im Infofenster ausblenden
@@ -837,6 +836,7 @@ function removeSelection(clearSource) {
     if (clearSource) {
         showAttributes(false);
         sourceSelected = null;
+        history.replaceState(null, '', window.location.pathname + window.location.search);
     }
 }
 


### PR DESCRIPTION
## Summary

- Closes #43
- Moves `history.replaceState` into `removeSelection(clearSource=true)` so the URL hash is cleared via **all** deselection paths: ESC, close button, map click (tap elsewhere), swipe-down, and zoom-out
- Previously `clearSelection()` cleared the hash, but direct calls to `removeSelection()` (map click and zoom-out) did not

## Test plan

- [ ] Select a playground — URL becomes `#W<id>`
- [ ] Tap elsewhere on the map — URL hash disappears
- [ ] Select again, press ESC — URL hash disappears
- [ ] Select again, swipe panel down — URL hash disappears
- [ ] Select again, click the × close button — URL hash disappears
- [ ] Select again, zoom way out — URL hash disappears
- [ ] Reload with a `#W<id>` hash — playground opens correctly (hash restore unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)