### PR TITLE
fix(security): escape OSM values, validate hrefs, add HTTP security headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ POI_RADIUS_M=5000
 MAP_ZOOM=12
 MAP_MIN_ZOOM=10
 
+# ── Optional: Hub integration ────────────────────────────────────────────────────
+
+# Origin of the parent frame allowed to receive postMessage events (e.g. the
+# Spielplatzkarte Hub). Only needed when embedding this instance in a Hub.
+# Must be a full origin: scheme + host + optional port (e.g. https://hub.example.com).
+# Leave empty (the default) for standalone deployments — postMessage is scoped to
+# the app's own origin in that case.
+# PARENT_ORIGIN=https://hub.example.com
+
 # ── Optional: infrastructure ─────────────────────────────────────────────────────
 
 # Port the app is exposed on the host

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ All variables can be set in `.env` (copy from `.env.example`).
 | `REGION_CHAT_URL` | *(hidden)* | Community chat link; leave empty to hide the button |
 | `MAP_ZOOM` | `12` | Initial map zoom level |
 | `MAP_MIN_ZOOM` | `10` | Minimum zoom level |
+| `PARENT_ORIGIN` | *(own origin)* | Allowed origin for `postMessage` events — set to the Hub's full origin (e.g. `https://hub.example.com`) when embedding in a Hub; leave empty for standalone deployments |
 | `APP_PORT` | `8080` | Host port the app is exposed on |
 | `POSTGRES_PASSWORD` | `change-me` | Database password — **change in production** |
 | `POI_RADIUS_M` | `5000` | Radius in metres for nearby POI search |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Sanitize string env vars that are interpolated directly into a JS string literal.
+# Only characters valid in an origin (scheme, host, port) are allowed; everything
+# else is stripped to prevent single-quote breakout / code injection.
+SAFE_PARENT_ORIGIN=$(printf '%s' "${PARENT_ORIGIN:-}" | tr -cd 'A-Za-z0-9:/.+-')
+
 cat > /usr/share/nginx/html/config.js << JSEOF
 window.APP_CONFIG = {
   osmRelationId: ${OSM_RELATION_ID:-62700},
@@ -10,7 +15,7 @@ window.APP_CONFIG = {
   mapMinZoom: ${MAP_MIN_ZOOM:-10},
   poiRadiusM: ${POI_RADIUS_M:-5000},
   apiBaseUrl: '${API_BASE_URL:-}',
-  parentOrigin: '${PARENT_ORIGIN:-}'
+  parentOrigin: '${SAFE_PARENT_ORIGIN}'
 };
 JSEOF
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ window.APP_CONFIG = {
   mapZoom: ${MAP_ZOOM:-12},
   mapMinZoom: ${MAP_MIN_ZOOM:-10},
   poiRadiusM: ${POI_RADIUS_M:-5000},
-  apiBaseUrl: '${API_BASE_URL:-}',
+  apiBaseUrl: '${API_BASE_URL:-}', // TODO: API_BASE_URL is interpolated raw — same injection risk as PARENT_ORIGIN was; sanitize in a follow-up
   parentOrigin: '${SAFE_PARENT_ORIGIN}'
 };
 JSEOF

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,8 @@ window.APP_CONFIG = {
   mapZoom: ${MAP_ZOOM:-12},
   mapMinZoom: ${MAP_MIN_ZOOM:-10},
   poiRadiusM: ${POI_RADIUS_M:-5000},
-  apiBaseUrl: '${API_BASE_URL:-}'
+  apiBaseUrl: '${API_BASE_URL:-}',
+  parentOrigin: '${PARENT_ORIGIN:-}'
 };
 JSEOF
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,9 +2,10 @@
 set -e
 
 # Sanitize string env vars that are interpolated directly into a JS string literal.
-# Only characters valid in an origin (scheme, host, port) are allowed; everything
+# Only characters valid in their respective value types are allowed; everything
 # else is stripped to prevent single-quote breakout / code injection.
-SAFE_PARENT_ORIGIN=$(printf '%s' "${PARENT_ORIGIN:-}" | tr -cd 'A-Za-z0-9:/.+-')
+SAFE_PARENT_ORIGIN=$(printf '%s' "${PARENT_ORIGIN:-}"  | tr -cd 'A-Za-z0-9:/.+-')
+SAFE_API_BASE_URL=$(printf '%s'  "${API_BASE_URL:-}"   | tr -cd 'A-Za-z0-9:/.+_%~-')
 
 cat > /usr/share/nginx/html/config.js << JSEOF
 window.APP_CONFIG = {
@@ -14,7 +15,7 @@ window.APP_CONFIG = {
   mapZoom: ${MAP_ZOOM:-12},
   mapMinZoom: ${MAP_MIN_ZOOM:-10},
   poiRadiusM: ${POI_RADIUS_M:-5000},
-  apiBaseUrl: '${API_BASE_URL:-}', // TODO: API_BASE_URL is interpolated raw — same injection risk as PARENT_ORIGIN was; sanitize in a follow-up
+  apiBaseUrl: '${SAFE_API_BASE_URL}',
   parentOrigin: '${SAFE_PARENT_ORIGIN}'
 };
 JSEOF

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,11 @@ MAP_ZOOM=${MAP_ZOOM}
 MAP_MIN_ZOOM=${MAP_MIN_ZOOM}
 POI_RADIUS_M=${POI_RADIUS_M}
 
+# ── Optional: Hub integration ─────────────────────────────────────────────────
+# Set to the Hub's full origin (e.g. https://hub.example.com) when embedding
+# this instance in a Spielplatzkarte Hub. Leave empty for standalone deployments.
+# PARENT_ORIGIN=
+
 # ── Optional: infrastructure ──────────────────────────────────────────────────
 APP_PORT=${APP_PORT}
 OSM2PGSQL_THREADS=${OSM2PGSQL_THREADS}

--- a/js/config.js
+++ b/js/config.js
@@ -33,6 +33,7 @@ export const poiRadiusM = c.poiRadiusM ?? 5000;
 export const apiBaseUrl = c.apiBaseUrl || null;
 
 // Target origin for postMessage calls to a parent iframe (e.g. Spielplatzkarte Hub).
-// Leave empty to use '*' (permissive, suitable for standalone deployments).
+// Defaults to window.location.origin (same-origin only) when PARENT_ORIGIN is not set.
+// Set PARENT_ORIGIN to the Hub's full origin (e.g. https://hub.example.com) in production.
 // Env var: PARENT_ORIGIN
-export const parentOrigin = c.parentOrigin || '*';
+export const parentOrigin = c.parentOrigin || window.location.origin;

--- a/js/config.js
+++ b/js/config.js
@@ -31,3 +31,8 @@ export const poiRadiusM = c.poiRadiusM ?? 5000;
 // When empty, the app falls back to Overpass (local dev only).
 // Env var: API_BASE_URL
 export const apiBaseUrl = c.apiBaseUrl || null;
+
+// Target origin for postMessage calls to a parent iframe (e.g. Spielplatzkarte Hub).
+// Leave empty to use '*' (permissive, suitable for standalone deployments).
+// Env var: PARENT_ORIGIN
+export const parentOrigin = c.parentOrigin || '*';

--- a/js/main.js
+++ b/js/main.js
@@ -52,7 +52,7 @@ import { applyRegionInfo } from './map.js';
 import { setCurrentDate } from './shadow.js';
 import { showLocation, hideLocation } from './locate.js';
 import { searchLocation } from './search.js';
-import { osmRelationId, regionPlaygroundWikiUrl, regionChatUrl } from './config.js';
+import { osmRelationId, regionPlaygroundWikiUrl, regionChatUrl, parentOrigin } from './config.js';
 import { fetchRegionInfo } from './region.js';
 import { restoreFromHash, clearSelection } from './selectPlayground.js';
 import { version } from '../package.json';
@@ -166,7 +166,7 @@ document.addEventListener('keydown', e => {
         clearSelection();
         // Forward ESC to parent frame (e.g. Spielplatzkarte Hub) so it can close the modal.
         if (window.parent !== window) {
-            window.parent.postMessage({ type: 'spielplatzkarte:escape' }, '*');
+            window.parent.postMessage({ type: 'spielplatzkarte:escape' }, parentOrigin);
         }
     }
 });

--- a/js/map.js
+++ b/js/map.js
@@ -260,7 +260,7 @@ const toast = document.getElementById('toast');
 const toastBootstrap = Toast.getOrCreateInstance(toast);
 
 export function showNotification(message) {
-    document.getElementById('toast-text').innerHTML = message;
+    document.getElementById('toast-text').textContent = message;
     toastBootstrap.show();
 }
 

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -76,6 +76,7 @@ const el = id => document.getElementById(id);
 const show = id => { el(id).style.display = ''; };
 const hide = id => { el(id).style.display = 'none'; };
 
+
 export var sourceSelected; // globale Variable, in der der jeweils ausgewählte Spielplatz enthalten ist
 var lastSelectedFeature = null; // zuletzt angeklicktes OpenLayers-Feature (für Overpass-Nachfrage)
 var currentArea = null; // Fläche des zuletzt ausgewählten Spielplatzes (für Ausstattungsanzeige)
@@ -125,7 +126,7 @@ export function showNearbyPlaygrounds(lon, lat, label = t('nearby.thisLocation')
     for (let i = 0; i < nearest.length; i++) {
         const { feature, dist } = nearest[i];
         const attr = feature.getProperties();
-        const name = getPlaygroundTitle(attr) || t('nearby.defaultName');
+        const name = escapeHtml(getPlaygroundTitle(attr) || t('nearby.defaultName'));
         html += `<div class="nearby-item" data-idx="${i}">
             <span class="nearby-name">${name}</span>
             <span class="nearby-dist">${formatDistance(dist)}</span>
@@ -482,7 +483,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     let device_string = '<ul class="mb-0 device-list">';
     for (const f of deviceFeatures) {
         const key = f.properties.playground;
-        const name = objDevices[key]?.name_de ?? key;
+        const name = objDevices[key]?.name_de ?? escapeHtml(key);
         const category = objDevices[key]?.category ?? 'fallback';
         const color = objColors[category] ?? objColors['fallback'];
         const detail = getEquipmentAttributesFromProps(f.properties);
@@ -519,7 +520,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     for (const f of pitchFeatures) {
         const sport = f.properties.sport ?? '';
         const [singular] = pitchLabels[sport]
-            ?? (sport ? [`Sportfeld (${sport})`, `Sportfelder (${sport})`] : ['Sportfeld', 'Sportfelder']);
+            ?? (sport ? [`Sportfeld (${escapeHtml(sport)})`, `Sportfelder (${escapeHtml(sport)})`] : ['Sportfeld', 'Sportfelder']);
         const detail = getEquipmentAttributesFromProps(f.properties);
         const uid = `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
         if (detail) {
@@ -547,7 +548,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
         if (Object.keys(fallbackCounts).length > 0) {
             let fallback_string = '<ul class="mb-0">';
             for (const [key, count] of Object.entries(fallbackCounts)) {
-                const name = objDevices[key]?.name_de ?? key;
+                const name = objDevices[key]?.name_de ?? escapeHtml(key);
                 const category = objDevices[key]?.category ?? 'fallback';
                 const color = objColors[category] ?? objColors['fallback'];
                 const countStr = count > 1 ? `${count}× ` : '';
@@ -982,7 +983,7 @@ function showPlaygroundInfo(json) {
 
     // Lagebeschreibung
     var location_str = getPlaygroundLocation(attr);
-    el('info-location').innerHTML = `<i>${location_str}</i>`;
+    el('info-location').innerHTML = `<i>${escapeHtml(location_str)}</i>`;
 
     // Beschreibung / Bemerkungen
     var description = attr["description"];
@@ -1032,7 +1033,7 @@ function showPlaygroundInfo(json) {
     };
     var surface = attr["surface"];
     if (surface) {
-        const surfaceLabel = surfaceLabels[surface] ?? surface;
+        const surfaceLabel = surfaceLabels[surface] ?? escapeHtml(surface);
         el('info-surface').innerHTML = `<span class="info-label">Bodenbelag</span> ${surfaceLabel}`;
         show('info-surface');
     } else {
@@ -1079,9 +1080,9 @@ function showPlaygroundInfo(json) {
     var minAge = attr["min_age"];
     var maxAge = attr["max_age"];
     if (minAge || maxAge) {
-        var ageStr = minAge && maxAge ? `${minAge}–${maxAge} Jahre`
-                   : minAge ? `ab ${minAge} Jahren`
-                   : `bis ${maxAge} Jahre`;
+        var ageStr = minAge && maxAge ? `${escapeHtml(minAge)}–${escapeHtml(maxAge)} Jahre`
+                   : minAge ? `ab ${escapeHtml(minAge)} Jahren`
+                   : `bis ${escapeHtml(maxAge)} Jahre`;
         el('info-age').innerHTML = `<span class="info-label">Alter</span> ${ageStr}`;
         show('info-age');
     } else {
@@ -1092,15 +1093,15 @@ function showPlaygroundInfo(json) {
     var operator = attr["operator"];
     var operatorWikidata = attr["operator:wikidata"];
     if (operatorWikidata) {
-        const wikidataUrl = `https://www.wikidata.org/wiki/${operatorWikidata}`;
+        const wikidataUrl = `https://www.wikidata.org/wiki/${encodeURIComponent(operatorWikidata)}`;
         if (operator) {
             el('info-operator').innerHTML =
-                `<span class="info-label">Betreiber</span> <a href="${wikidataUrl}" target="_blank" rel="noopener" class="link-secondary">${operator}</a>`;
+                `<span class="info-label">Betreiber</span> <a href="${wikidataUrl}" target="_blank" rel="noopener" class="link-secondary">${escapeHtml(operator)}</a>`;
             show('info-operator');
         } else {
             // Zeige Q-Nummer als Platzhalter, bis der Name von Wikidata geladen ist
             el('info-operator').innerHTML =
-                `<span class="info-label">Betreiber</span> <a href="${wikidataUrl}" target="_blank" rel="noopener" class="link-secondary" id="operator-wikidata-label">${operatorWikidata}</a>`;
+                `<span class="info-label">Betreiber</span> <a href="${wikidataUrl}" target="_blank" rel="noopener" class="link-secondary" id="operator-wikidata-label">${escapeHtml(operatorWikidata)}</a>`;
             show('info-operator');
             fetch(`https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${encodeURIComponent(operatorWikidata)}&props=labels&languages=de%7Cen&format=json&origin=*`)
                 .then(r => r.json())
@@ -1113,7 +1114,7 @@ function showPlaygroundInfo(json) {
                 .catch(() => { /* Platzhalter (Q-Nummer) bleibt stehen */ });
         }
     } else if (operator) {
-        el('info-operator').innerHTML = `<span class="info-label">Betreiber</span> ${operator}`;
+        el('info-operator').innerHTML = `<span class="info-label">Betreiber</span> ${escapeHtml(operator)}`;
         show('info-operator');
     } else {
         hide('info-operator');
@@ -1135,8 +1136,22 @@ function showPlaygroundInfo(json) {
     const mcOsmId = attr['osm_id'];
     const mcUrl = `https://mapcomplete.org/playgrounds.html#${mcOsmType}/${mcOsmId}`;
     var contactParts = [];
-    if (phone) contactParts.push(`<a href="tel:${phone}" class="link-secondary">${phone}</a>`);
-    if (email) contactParts.push(`<a href="mailto:${email}" class="link-secondary">${email}</a>`);
+    // Validate phone: must start with + or digit to prevent javascript: URI injection
+    if (phone) {
+        if (/^\+?\d/.test(phone.trim())) {
+            contactParts.push(`<a href="tel:${escapeHtml(phone)}" class="link-secondary">${escapeHtml(phone)}</a>`);
+        } else {
+            contactParts.push(escapeHtml(phone));
+        }
+    }
+    // Validate email: must contain @ to prevent javascript: URI injection
+    if (email) {
+        if (email.includes('@')) {
+            contactParts.push(`<a href="mailto:${escapeHtml(email)}" class="link-secondary">${escapeHtml(email)}</a>`);
+        } else {
+            contactParts.push(escapeHtml(email));
+        }
+    }
     const mcLink = `<div class="mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" class="mc-add-link"><span class="bi bi-pencil"></span> Bei MapComplete bearbeiten</a></div>`;
     el('info-contact').innerHTML = (contactParts.length ? contactParts.join(' · ') : '') + mcLink;
     show('info-contact');

--- a/js/selectPlayground.js
+++ b/js/selectPlayground.js
@@ -483,7 +483,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
     let device_string = '<ul class="mb-0 device-list">';
     for (const f of deviceFeatures) {
         const key = f.properties.playground;
-        const name = objDevices[key]?.name_de ?? escapeHtml(key);
+        const name = escapeHtml(objDevices[key]?.name_de ?? key);
         const category = objDevices[key]?.category ?? 'fallback';
         const color = objColors[category] ?? objColors['fallback'];
         const detail = getEquipmentAttributesFromProps(f.properties);
@@ -548,7 +548,7 @@ function updateEquipmentPanel(features, playgroundAttr = {}) {
         if (Object.keys(fallbackCounts).length > 0) {
             let fallback_string = '<ul class="mb-0">';
             for (const [key, count] of Object.entries(fallbackCounts)) {
-                const name = objDevices[key]?.name_de ?? escapeHtml(key);
+                const name = escapeHtml(objDevices[key]?.name_de ?? key);
                 const category = objDevices[key]?.category ?? 'fallback';
                 const color = objColors[category] ?? objColors['fallback'];
                 const countStr = count > 1 ? `${count}× ` : '';
@@ -1144,9 +1144,9 @@ function showPlaygroundInfo(json) {
             contactParts.push(escapeHtml(phone));
         }
     }
-    // Validate email: must contain @ to prevent javascript: URI injection
+    // Validate email: must contain @ and must not be a javascript: URI
     if (email) {
-        if (email.includes('@')) {
+        if (email.includes('@') && !/^javascript:/i.test(email.trim())) {
             contactParts.push(`<a href="mailto:${escapeHtml(email)}" class="link-secondary">${escapeHtml(email)}</a>`);
         } else {
             contactParts.push(escapeHtml(email));

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # HTTP security headers
+    add_header X-Content-Type-Options    "nosniff"                          always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin"  always;
+    add_header Permissions-Policy        "geolocation=(self)"               always;
+    add_header Content-Security-Policy
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://panoramax.xyz; connect-src 'self' https:; font-src 'self'; frame-ancestors 'self'"
+        always;
+
     # Use Docker's internal DNS resolver.
     # This prevents nginx from failing to start when "postgrest" is not yet
     # reachable (e.g. running the app container standalone).

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,8 +8,10 @@ server {
     add_header X-Content-Type-Options    "nosniff"                          always;
     add_header Referrer-Policy           "strict-origin-when-cross-origin"  always;
     add_header Permissions-Policy        "geolocation=(self)"               always;
+    # 'unsafe-inline' in style-src is required by Bootstrap and OpenLayers; remove when a nonce-based approach is adopted.
+    # frame-ancestors allows any HTTPS parent to embed this app (required for Spielplatzkarte Hub).
     add_header Content-Security-Policy
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://panoramax.xyz; connect-src 'self' https:; font-src 'self'; frame-ancestors 'self'"
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://panoramax.xyz; connect-src 'self' https:; font-src 'self'; frame-ancestors 'self' https:"
         always;
 
     # Use Docker's internal DNS resolver.

--- a/public/config.js
+++ b/public/config.js
@@ -7,5 +7,5 @@ window.APP_CONFIG = {
   mapMinZoom: 10,
   poiRadiusM: 5000,
   apiBaseUrl: '',
-  parentOrigin: ''
+  parentOrigin: ''  // leave empty — defaults to window.location.origin via js/config.js
 };

--- a/public/config.js
+++ b/public/config.js
@@ -6,5 +6,6 @@ window.APP_CONFIG = {
   mapZoom: 12,
   mapMinZoom: 10,
   poiRadiusM: 5000,
-  apiBaseUrl: ''
+  apiBaseUrl: '',
+  parentOrigin: ''
 };


### PR DESCRIPTION
Closes #45

## Summary

- **XSS prevention**: Added \`escapeHtml()\` utility in \`selectPlayground.js\` and applied it to ~20 \`innerHTML\` assignments that interpolate raw OSM tag values (description, note, fixme, operator, surface fallback, age, location, equipment/device names, nearby list, contact fields). Known remaining gaps tracked separately: POI names in \`updateUmfeldPanel\` (D2) and \`opening_hours\` fallback in \`formatOpeningHours\` (D3).
- **Protocol injection prevention**: \`phone\` values validated to start with \`+\` or a digit before \`tel:\` href is used; \`email\` values must contain \`@\` and not start with \`javascript:\` before \`mailto:\` href is used — invalid values rendered as plain escaped text
- **Toast XSS**: Switched \`showNotification()\` from \`innerHTML\` to \`textContent\` (user search queries were interpolated via i18next with \`escapeValue: false\`)
- **postMessage origin**: Target origin now reads from \`PARENT_ORIGIN\` env var; defaults to \`window.location.origin\` (same-origin) when unset, so Hub operators can scope it to their domain without opening a wildcard by default
- **HTTP security headers** added to nginx: \`Content-Security-Policy\`, \`X-Content-Type-Options: nosniff\`, \`Referrer-Policy: strict-origin-when-cross-origin\`, \`Permissions-Policy: geolocation=(self)\`; \`frame-ancestors\` set to \`'self' https:\` to allow Hub embedding while blocking HTTP parents

## Test plan

- [ ] Open the app at http://localhost:8080 and select a playground — detail panel renders correctly (name, operator, surface, contact, equipment)
- [ ] Verify headers: \`curl -I http://localhost:8080\` shows all four security headers
- [ ] Search for a location — toast notification appears with plain text (no HTML rendered)
- [ ] Select a playground, press ESC — URL hash clears, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)