### PR TITLE
ci: publish :rc tag on main merges, reserve :latest for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
@@ -80,7 +80,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-importer
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
@@ -81,6 +82,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-importer
           tags: |
             type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ Spielplatzkarte is an interactive web map for exploring playgrounds based on Ope
 - Branch naming: `<type>/<short-description>` (e.g. `feat/add-filter-panel`, `fix/popup-scroll`).
 - Use **Conventional Commits** for all commit messages: `<type>[optional scope]: <description>`. Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`. Breaking changes: append `!` after type/scope or add a `BREAKING CHANGE:` footer.
 - Releases are cut from version tags (e.g. `v0.2.3`). The tag drives both the app version (read from `package.json` at build time) and the container image tag — keep all three in sync when releasing.
+- **`main` always carries an `-rc` version.** The `version` field in `package.json` on `main` must always be one patch increment above the latest release tag and carry an `-rc` suffix (e.g. after releasing `v0.1.4` the branch version becomes `0.1.5-rc`). This version is what gets embedded in the `:rc` container image on every merge.
+
+### Release procedure
+
+1. **Bump version on `main`**: update `package.json` → remove `-rc`, e.g. `0.1.5-rc` → `0.1.5`. Commit: `chore: release v0.1.5`.
+2. **Tag**: `git tag v0.1.5 && git push origin v0.1.5`. The `build.yml` workflow publishes `:latest`, `:0.1.5`, and `:0.1` container images automatically.
+3. **Advance `main` to the next `-rc`**: update `package.json` → `0.1.6-rc`. Commit: `chore: bump version to 0.1.6-rc`.
 
 ## Development commands
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spielplatzkarte",
-  "version": "0.1.4",
+  "version": "0.1.5-rc",
   "scripts": {
     "start": "vite",
     "build": "vite build",


### PR DESCRIPTION
Closes #56

## Summary

- Swap `value=latest` → `value=rc` in the `meta` and `meta-importer` steps of `build.yml`
- Every PR merge to `main` now publishes `ghcr.io/<repo>:rc` and `ghcr.io/<repo>-importer:rc`
- `:latest` is no longer overwritten on main pushes — reserved exclusively for `v*` tag releases
- Short-SHA tag continues to be published on all pushes for traceability

## Test plan

- [ ] Workflow runs on this PR (build job passes)
- [ ] After merge: `ghcr.io/mfuhrmann/spielplatzkarte:rc` is published
- [ ] After merge: `:latest` is NOT updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)