### PR TITLE
feat: add Svelte + Vite app scaffold in app/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 node_modules
 dist
-lib
+/lib
 .vite
 data/berlin-latest.osm.pbf
+
+# New Svelte app
+app/node_modules/
+app/dist/
 
 # Playwright
 test-results/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: install dev build serve test \
+        app-install app-dev app-build app-serve app-test \
         up down import docker-build db-apply db-shell \
         require-npm require-docker installer lan-url help
 
@@ -19,22 +20,39 @@ require-docker:
 	@docker info >/dev/null 2>&1 || \
 	  { printf '\033[31merror:\033[0m docker daemon is not running\n' >&2; exit 1; }
 
-## ── Frontend ──────────────────────────────────────────────────────────────────
+## ── Frontend (legacy — root-level Vite app) ───────────────────────────────────
 
-install: require-npm      ## Install Node dependencies
+install: require-npm      ## Install Node dependencies (legacy app)
 	npm ci
 
-dev: require-npm          ## Start Vite dev server (localhost:5173 + LAN, see make lan-url)
+dev: require-npm          ## Start Vite dev server for legacy app (localhost:5173)
 	npm start
 
-build: require-npm        ## Production build → dist/
+build: require-npm        ## Production build for legacy app → dist/
 	npm run build
 
-serve: require-npm        ## Preview production build locally
+serve: require-npm        ## Preview legacy production build locally
 	npm run serve
 
-test: require-npm         ## Run Playwright end-to-end tests against the production build
+test: require-npm         ## Run Playwright tests against legacy production build
 	npm test
+
+## ── Frontend (new Svelte app in app/) ─────────────────────────────────────────
+
+app-install: require-npm  ## Install Node dependencies for the new Svelte app
+	npm ci --prefix app
+
+app-dev: require-npm      ## Start Vite dev server for new Svelte app (localhost:5173)
+	npm run dev --prefix app
+
+app-build: require-npm    ## Production build for new Svelte app → app/dist/
+	npm run build --prefix app
+
+app-serve: require-npm    ## Preview new Svelte production build locally
+	npm run serve --prefix app
+
+app-test: require-npm     ## Run Playwright tests for new Svelte app
+	npm test --prefix app
 
 ## ── Docker Compose stack ──────────────────────────────────────────────────────
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spielplatzkarte</title>
+  <link rel="icon" type="image/x-icon" href="/img/favicon/favicon.ico" />
+  <!-- Runtime config injected by docker-entrypoint.app.sh; falls back to public/config.js defaults in dev -->
+  <script src="./config.js"></script>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,0 +1,1851 @@
+{
+  "name": "spielplatzkarte-app",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "spielplatzkarte-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.11.3",
+        "fetch-jsonp": "^1.3.0",
+        "i18next": "^24.0.0",
+        "ol": "^10.0.0",
+        "opening_hours": "^3.9.0",
+        "svelte": "^5.0.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
+      "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
+      "license": "MIT",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "1.4.3"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "license": "MIT"
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-jsonp": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.4.0.tgz",
+      "integrity": "sha512-SmOI6UshTUzQ1O+1CJDg31AE4VUIfAO4xfVAy/sH03h4Obml3BnuhTopdFaJMI21T94RfRvfTgTIvV0X8GnJ2A==",
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/geotiff": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.9.3",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "24.2.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-24.2.3.tgz",
+      "integrity": "sha512-lfbf80OzkocvX7nmZtu7nSTNbrTYR52sLWxPtlXX1zAhVw8WEnFk4puUkCR4B1dNQwbSpEHHHemcZu//7EcB7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/numcodecs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.0"
+      }
+    },
+    "node_modules/ol": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.8.0.tgz",
+      "integrity": "sha512-kLk7jIlJvKyhVMAjORTXKjzlM6YIByZ1H/d0DBx3oq8nSPCG6/gbLr5RxukzPgwbhnAqh+xHNCmrvmFKhVMvoQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^3.0.2",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0",
+        "zarrita": "^0.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/opening_hours": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/opening_hours/-/opening_hours-3.12.0.tgz",
+      "integrity": "sha512-8XVwJUyZVIDObb5OF2DoB+WShGL9RVZRKIevgHOqwPeu0acRx5akruOSmXHZZw2qUTqEjbneZG3REcyvr5yHiQ==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "i18next": "^25.8.13",
+        "suncalc": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/opening_hours/node_modules/i18next": {
+      "version": "25.10.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+    },
+    "node_modules/svelte": {
+      "version": "5.55.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
+      "integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.4",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/unzipit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip-module": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/uzip-module": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/zarrita": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.6.2.tgz",
+      "integrity": "sha512-8IV+2bWt5yiHNVK9GVEVK1tscpqDcJj8iz5cIKFOiWiWYUsK4V5njgMtnpkvKu6L7K+Og6zUShd8f+dwb6LvTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zarrita/storage": "^0.1.4",
+        "numcodecs": "^0.3.2"
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "license": "MIT AND BSD-3-Clause"
+    }
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "spielplatzkarte-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
+    "fetch-jsonp": "^1.3.0",
+    "i18next": "^24.0.0",
+    "ol": "^10.0.0",
+    "opening_hours": "^3.9.0",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/app/public/config.js
+++ b/app/public/config.js
@@ -1,0 +1,23 @@
+// Default configuration for local development.
+// In Docker, docker-entrypoint.app.sh overwrites this file at container startup.
+window.APP_CONFIG = {
+  // 'standalone' renders the full regional app; 'hub' renders the federation map.
+  appMode: 'standalone',
+
+  // --- Standalone mode ---
+  osmRelationId: 62700,
+  regionPlaygroundWikiUrl: 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground',
+  regionChatUrl: '',
+  mapZoom: 12,
+  mapMinZoom: 10,
+  poiRadiusM: 5000,
+  // Empty = use Overpass fallback (no PostgREST required for local dev)
+  apiBaseUrl: '',
+  parentOrigin: '',
+
+  // --- Hub mode ---
+  registryUrl: './registry.json',
+  hubPollInterval: 300,
+  // Hub uses a wider default zoom to show all registered regions
+  // mapZoom and mapMinZoom above are reused; override here if needed
+};

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -1,0 +1,147 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { Map, View } from 'ol';
+  import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer.js';
+  import VectorSource from 'ol/source/Vector.js';
+  import XYZ from 'ol/source/XYZ.js';
+  import GeoJSON from 'ol/format/GeoJSON.js';
+  import { transform, transformExtent } from 'ol/proj';
+  import { ScaleLine, defaults as defaultControls } from 'ol/control.js';
+  import { defaults as defaultInteractions } from 'ol/interaction/defaults';
+
+  import { mapZoom, mapMinZoom, osmRelationId, apiBaseUrl } from '../lib/config.js';
+  import { fetchPlaygrounds } from '../lib/api.js';
+  import { fetchRegionInfo } from '../lib/region.js';
+  import { playgroundStyleFn, selectionStyle } from '../lib/vectorStyles.js';
+  import { selection } from '../stores/selection.js';
+  import { mapStore } from '../stores/map.js';
+
+  // Props: optional overrides for hub mode (multiple backends feed into one shared source)
+  /** @type {VectorSource | null} - when provided, the map uses this source instead of creating one */
+  export let playgroundSource = null;
+  /** Backend URL used for selection — standalone passes apiBaseUrl, hub passes per-feature URL */
+  export let defaultBackendUrl = apiBaseUrl;
+
+  let mapContainer;
+  let olMap = null;
+  let ownSource = null; // only set when we own the source (standalone mode)
+
+  onMount(async () => {
+    // Use provided source (hub) or create our own (standalone)
+    const source = playgroundSource ?? (ownSource = new VectorSource());
+
+    const playgroundLayer = new VectorLayer({
+      source,
+      zIndex: 10,
+      style: playgroundStyleFn,
+    });
+
+    const basemap = new TileLayer({
+      source: new XYZ({
+        url: 'https://{a-d}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+        attributions:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
+          '| &copy; <a href="https://carto.com/attributions">CARTO</a>',
+      }),
+    });
+
+    const view = new View({
+      center: transform([10.5, 51.2], 'EPSG:4326', 'EPSG:3857'), // Germany fallback
+      zoom: mapZoom,
+      minZoom: mapMinZoom,
+    });
+
+    olMap = new Map({
+      target: mapContainer,
+      layers: [basemap, playgroundLayer],
+      view,
+      controls: defaultControls().extend([new ScaleLine({ units: 'metric' })]),
+      interactions: defaultInteractions({ altShiftDragRotate: false, pinchRotate: false }),
+    });
+
+    mapStore.set(olMap);
+
+    // Click handler: select playground on click
+    olMap.on('click', (evt) => {
+      const hit = olMap.forEachFeatureAtPixel(evt.pixel, (feature) => feature, {
+        layerFilter: (l) => l === playgroundLayer,
+      });
+      if (hit) {
+        // In hub mode the feature carries its own backend URL; fall back to prop
+        const backendUrl = hit.get('_backendUrl') ?? defaultBackendUrl;
+        selection.select(hit, backendUrl);
+      } else {
+        selection.clear();
+      }
+    });
+
+    // Pointer cursor on hover
+    olMap.on('pointermove', (evt) => {
+      const hit = olMap.hasFeatureAtPixel(evt.pixel, {
+        layerFilter: (l) => l === playgroundLayer,
+      });
+      mapContainer.style.cursor = hit ? 'pointer' : '';
+    });
+
+    // Standalone: fetch playgrounds and fit to region
+    if (ownSource) {
+      loadStandaloneData(ownSource, view);
+    }
+
+    // Restore selection from URL hash on load
+    const hash = window.location.hash;
+    const match = hash.match(/^#W(\d+)$/);
+    if (match) {
+      const osmId = parseInt(match[1], 10);
+      // Wait for features to load, then find and select
+      source.once('change', () => {
+        const feat = source.getFeatures().find(f => f.get('osm_id') === osmId);
+        if (feat) selection.select(feat, defaultBackendUrl);
+      });
+    }
+  });
+
+  onDestroy(() => {
+    if (olMap) {
+      olMap.setTarget(undefined);
+      mapStore.set(null);
+    }
+  });
+
+  async function loadStandaloneData(source, view) {
+    // Fetch region info for map extent fitting
+    try {
+      const region = await fetchRegionInfo(osmRelationId);
+      view.fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
+        padding: [20, 20, 20, 380], // leave room for the side panel on desktop
+        duration: 0,
+      });
+      document.title = `Spielplatzkarte ${region.name}`;
+    } catch (err) {
+      console.warn('Nominatim region fetch failed, using default extent:', err);
+    }
+
+    // Load playground polygons
+    try {
+      const geojson = await fetchPlaygrounds();
+      const features = new GeoJSON().readFeatures(geojson, {
+        dataProjection: 'EPSG:4326',
+        featureProjection: 'EPSG:3857',
+      });
+      source.addFeatures(features);
+    } catch (err) {
+      console.error('Playground data could not be loaded:', err);
+    }
+  }
+</script>
+
+<div bind:this={mapContainer} class="map-container"></div>
+
+<style>
+  .map-container {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    inset: 0;
+  }
+</style>

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -1,0 +1,101 @@
+<script>
+  import 'bootstrap/dist/css/bootstrap.min.css';
+  import 'bootstrap-icons/font/bootstrap-icons.css';
+
+  import Map from '../components/Map.svelte';
+  import { selection } from '../stores/selection.js';
+  import VectorSource from 'ol/source/Vector.js';
+
+  // Shared playground source populated by registry.js (added in PR 5)
+  const sharedSource = new VectorSource();
+</script>
+
+<div class="app-root">
+  <Map playgroundSource={sharedSource} />
+
+  <aside class="instance-panel">
+    <h6 class="instance-panel__title">
+      <i class="bi bi-map me-1"></i> Spielplatzkarte Hub
+    </h6>
+    <!-- InstancePanel component will be added in PR 5 -->
+    <p class="text-muted small px-2">
+      Instanzen werden in PR 5 geladen.
+    </p>
+  </aside>
+
+  {#if $selection.feature}
+    <aside class="info-panel">
+      <div class="info-panel__header">
+        <strong>{$selection.feature.get('name') ?? 'Spielplatz'}</strong>
+        <button
+          class="btn-close"
+          aria-label="Schließen"
+          onclick={() => selection.clear()}
+        ></button>
+      </div>
+      <div class="info-panel__body">
+        <!-- PlaygroundPanel (shared with standalone) will be wired in PR 5 -->
+        <p class="text-muted small">Quelle: {$selection.backendUrl}</p>
+      </div>
+    </aside>
+  {/if}
+</div>
+
+<style>
+  .app-root {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .instance-panel {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 280px;
+    max-height: calc(100vh - 2rem);
+    background: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    z-index: 100;
+    overflow-y: auto;
+    padding: 0.75rem 0;
+  }
+
+  .instance-panel__title {
+    padding: 0 0.75rem 0.5rem;
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #495057;
+  }
+
+  .info-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 360px;
+    height: 100%;
+    background: #fff;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.15);
+    z-index: 100;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .info-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  .info-panel__body {
+    padding: 1rem;
+    flex: 1;
+  }
+</style>

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -1,0 +1,48 @@
+// PostgREST API calls.
+// All functions accept an optional baseUrl parameter (defaults to the configured apiBaseUrl).
+// This allows the Hub to call per-backend URLs using the same functions.
+
+import { transformExtent } from 'ol/proj';
+import { osmRelationId, apiBaseUrl as defaultApiBaseUrl } from './config.js';
+
+// All playgrounds in the configured region as polygons (including geometry and tags).
+export async function fetchPlaygrounds(baseUrl = defaultApiBaseUrl) {
+    const res = await fetch(`${baseUrl}/rpc/get_playgrounds?relation_id=${osmRelationId}`);
+    if (res.ok) return res.json();
+    throw new Error(`get_playgrounds failed: ${res.status}`);
+}
+
+// Equipment and fixtures for a playground (bbox in EPSG:3857).
+// osmId is carried through for future query optimisation but currently unused server-side.
+export async function fetchPlaygroundEquipment(extentEPSG3857, osmId = null, baseUrl = defaultApiBaseUrl) {
+    const [minLon, minLat, maxLon, maxLat] = transformExtent(extentEPSG3857, 'EPSG:3857', 'EPSG:4326');
+    const params = new URLSearchParams({ min_lon: minLon, min_lat: minLat, max_lon: maxLon, max_lat: maxLat });
+    const res = await fetch(`${baseUrl}/rpc/get_equipment?${params}`);
+    if (res.ok) return res.json();
+    throw new Error(`get_equipment failed: ${res.status}`);
+}
+
+// Trees (natural=tree) within a bounding box.
+export async function fetchTrees(extentEPSG3857, baseUrl = defaultApiBaseUrl) {
+    const [minLon, minLat, maxLon, maxLat] = transformExtent(extentEPSG3857, 'EPSG:3857', 'EPSG:4326');
+    const params = new URLSearchParams({ min_lon: minLon, min_lat: minLat, max_lon: maxLon, max_lat: maxLat });
+    const res = await fetch(`${baseUrl}/rpc/get_trees?${params}`);
+    if (res.ok) return res.json();
+    return { type: 'FeatureCollection', features: [] };
+}
+
+// Nearby POIs (toilets, bus stops, ice cream, emergency rooms).
+// osmId is carried through for future use but currently unused server-side.
+export async function fetchNearbyPOIs(lat, lon, radiusM = 500, osmId = null, baseUrl = defaultApiBaseUrl) {
+    const params = new URLSearchParams({ lat, lon, radius_m: radiusM });
+    const res = await fetch(`${baseUrl}/rpc/get_pois?${params}`);
+    if (res.ok) return res.json();
+    return [];
+}
+
+// Instance metadata (requires spielplatzkarte v0.2.1+).
+export async function fetchMeta(baseUrl = defaultApiBaseUrl) {
+    const res = await fetch(`${baseUrl}/rpc/get_meta`);
+    if (res.ok) return res.json();
+    return null;
+}

--- a/app/src/lib/completeness.js
+++ b/app/src/lib/completeness.js
@@ -1,0 +1,22 @@
+// Shared data-completeness logic for playground features.
+// Returns 'complete' | 'partial' | 'missing'
+//
+// Criteria:
+//   hasPhoto — at least one panoramax / panoramax:* tag
+//   hasName  — name tag present
+//   hasInfo  — operator, opening_hours, surface, or a non-trivial access value
+//
+// complete = all three present
+// partial  = at least one present
+// missing  = none present
+
+export function playgroundCompleteness(props) {
+    const hasPhoto = Object.keys(props).some(k => k === 'panoramax' || k.startsWith('panoramax:'));
+    const hasName  = !!props.name;
+    const hasInfo  = !!(props.operator || props.opening_hours || props.surface ||
+                        (props.access && props.access !== 'yes'));
+
+    if (hasPhoto && hasName && hasInfo) return 'complete';
+    if (hasPhoto || hasName || hasInfo) return 'partial';
+    return 'missing';
+}

--- a/app/src/lib/config.js
+++ b/app/src/lib/config.js
@@ -1,0 +1,38 @@
+// Runtime configuration injected via window.APP_CONFIG (set by public/config.js or docker-entrypoint.app.sh).
+// Fallback values are used for local development without a container.
+const c = (typeof window !== 'undefined' && window.APP_CONFIG) || {};
+
+// 'standalone' | 'hub'
+export const appMode = c.appMode ?? 'standalone';
+
+// --- Standalone ---
+
+// OSM relation ID of the region to display.
+export const osmRelationId = c.osmRelationId ?? 62700;
+
+// Optional: shown in the "Daten ergänzen" modal.
+export const regionPlaygroundWikiUrl = c.regionPlaygroundWikiUrl ?? 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
+
+// Optional: community chat link shown in the "Daten ergänzen" modal. null to hide.
+export const regionChatUrl = c.regionChatUrl || null;
+
+export const mapZoom = c.mapZoom ?? 12;
+export const mapMinZoom = c.mapMinZoom ?? 10;
+
+// Search radius in metres for nearby POIs.
+export const poiRadiusM = c.poiRadiusM ?? 5000;
+
+// Base URL for the PostgREST API (e.g. "/api" in Docker, empty string for local dev).
+// When empty, the app falls back to Overpass for playground data.
+export const apiBaseUrl = c.apiBaseUrl || '';
+
+// Target origin for postMessage to a parent frame (hub embedding standalone via iframe — legacy).
+export const parentOrigin = c.parentOrigin || '*';
+
+// --- Hub ---
+
+// URL of the registry JSON file listing backends.
+export const registryUrl = c.registryUrl ?? './registry.json';
+
+// How often (seconds) to re-fetch playground data from all backends.
+export const hubPollInterval = c.hubPollInterval ?? 300;

--- a/app/src/lib/objPlaygroundEquipment.js
+++ b/app/src/lib/objPlaygroundEquipment.js
@@ -1,0 +1,671 @@
+// =============================================================================
+// objPlaygroundEquipment.js
+// =============================================================================
+//
+// This file is the single source of truth for all playground device types and
+// playground features that the app knows about. If a device or feature isn't
+// listed here, the app won't know how to display or label it.
+//
+// It exports two objects:
+//
+//   objDevices   — individual playground devices (swings, slides, climbing
+//                  frames, …). Each key is an OSM `playground=*` tag value.
+//
+//   objFeatures  — other characteristics of a playground (benches, fences,
+//                  toilets, …) that are not individual devices but are tagged
+//                  differently in OSM. Each key is an arbitrary identifier.
+//
+// -----------------------------------------------------------------------------
+// HOW TO ADD A NEW DEVICE — quick reference
+// -----------------------------------------------------------------------------
+//
+// 1. Find the correct OSM tag at:
+//    https://wiki.openstreetmap.org/wiki/Key:playground
+//
+// 2. Add a new key to objDevices using the OSM tag value as the key name:
+//
+//    mydevice: {
+//        name_de:     "German name",        // REQUIRED — shown in the detail panel
+//        image:       "File:Example.jpg",   // OPTIONAL — Wikimedia Commons filename
+//        category:    "stationary",         // OPTIONAL — groups the device in filters
+//        filterable:  true,                 // OPTIONAL — show in sidebar filter?
+//        filter_attr: ["length", "height"], // OPTIONAL — OSM sub-attributes to filter by
+//    },
+//
+// Field details:
+//
+//   name_de      (string, required)
+//                German display name shown in the collapsible device row.
+//                There is currently no i18n for device names — German is the
+//                primary language of the project.
+//
+//   image        (string, optional)
+//                A Wikimedia Commons filename in the format "File:Example.jpg".
+//                The app tries Commons first; if the image is not found there,
+//                it falls back to the OSM wiki. If the field is omitted entirely,
+//                no example image is shown — no broken icon appears.
+//                To find a good filename: search commons.wikimedia.org, open the
+//                image page, and copy the "File:" name from the page title.
+//
+//   category     (string, optional)
+//                Groups the device under a heading in the filter panel.
+//                Known values: "stationary", "structure_parts", "active".
+//                Omit if the device doesn't belong to a filter group.
+//
+//   filterable   (boolean, optional)
+//                When true, this device type appears as a checkbox in the
+//                sidebar filter so users can show/hide playgrounds that have it.
+//                Defaults to false when omitted.
+//
+//   filter_attr  (array of strings, optional)
+//                OSM sub-attributes of this device to expose as filter controls
+//                (e.g. ["length", "height"] for a slide). Only meaningful when
+//                filterable is true. Omit for devices with no useful numeric
+//                attributes.
+//
+// -----------------------------------------------------------------------------
+
+export const objDevices = {
+    slide: {
+        name_de: "Rutsche",
+        image: "File:Accessibleplay-Slide.jpg",
+        category: "stationary",
+        filterable: true,
+        filter_attr: ["length", "height"],
+    },
+    seesaw: {
+        name_de: "Wippe",
+        image: "File:Seesaw-aa.jpg",
+        category: "stationary",
+        filterable: true,
+    },
+    springy: {
+        name_de: "Federwipptier",
+        image: "File:Springy horse.jpg",
+        category: "stationary",
+    },
+    structure: {
+        name_de: "Spielstruktur",
+        image: "File:SunwardCohousingPlayStructure2005.jpg",
+        category: "structure_parts",
+    },
+    bridge: {
+        name_de: "Brücke",
+        image: "File:Playground in Muchall Park, Wolverhampton - geograph.org.uk - 2735437.jpg",
+        category: "structure_parts",
+    },
+    wobble_bridge: {
+        name_de: "Hängebrücke",
+        image: "File:Playground ropebridge Trusepark Berlin Neukölln.jpg",
+        category: "structure_parts",
+        filterable: true,
+        filter_attr: ["length"],
+    },
+    platform: {
+        name_de: "Plattform",
+        image: "File:Playground structure wood toddler.jpg",
+        category: "structure_parts",
+    },
+    steps: {
+        name_de: "Treppe",
+        image: "File:Playground steps wood step count 7 handrail.jpg",
+        category: "structure_parts",
+    },
+    ladder: {
+        name_de: "Leiter",
+        image: "File:Playground ladder.jpg",
+        category: "structure_parts",
+    },
+    swing: {
+        name_de: "Schaukel",
+        image: "File:Accessibleplay-Swing.jpg",
+        category: "swing",
+    },
+    baby_swing: {
+        name_de: "Babyschaukel",
+        image: "File:Baby-swings-2.jpg",
+        category: "swing",
+    },
+    basketswing: {
+        name_de: "Korbschaukel",
+        image: "File:Playground swing 03.jpg",
+        category: "swing",
+        filterable: true,
+    },
+    tire_swing: {
+        name_de: "Reifenschaukel",
+        image: "File:Tire swing, near Litchfield, Connecticut LCCN2012630791 (cropped).jpg",
+        category: "swing",
+    },
+    rope_swing: {
+        name_de: "Tampenschaukel",
+        image: "File:Playground rope swing Zoologischer Garten Berlin.jpg",
+        category: "swing",
+    },
+    agility_trail: {
+        name_de: "Bewegungsparcours",
+        image: "File:Agility_trail_for_kids.jpeg",
+        category: "balance",
+    },
+    balancebeam: {
+        name_de: "Balancierbalken",
+        image: "File:Playground Balance beam.jpg",
+        category: "balance",
+    },
+    rope_traverse: {
+        name_de: "Balancierseil",
+        image: "File:Playground balance rope handrail.jpg",
+        category: "balance",
+    },
+    stepping_stone: {
+        name_de: "Trittsteine",
+        image: "File:Marine Park td (2019-05-24) 062 - Lenape Playground.jpg",
+        category: "balance",
+    },
+    stepping_post: {
+        name_de: "Trittpfosten",
+        image: "File:Playground stepping poles Thomashöhe Berlin Neukölln.jpg",
+        category: "balance",
+    },
+    climbingframe: {
+        name_de: "Klettergerüst",
+        image: "File:DeimosXL1.jpg",
+        category: "climbing",
+        filterable: true,
+        filter_attr: ["height"],
+    },
+    climbingwall: {
+        name_de: "Kletterwand",
+        image: "File:Playground climbingwall.jpg",
+        category: "climbing",
+        filterable: true,
+        filter_attr: ["height"],
+    },
+    climbing_slope: {
+        name_de: "Kletterrampe",
+        image: "File:Playground rope ladder.jpg",
+        category: "climbing",
+    },
+    climbing_pole: {
+        name_de: "Kletterstange",
+        image: "File:Playground climbing pole height 2.jpg",
+        category: "climbing",
+    },
+    monkey_bars: {
+        name_de: "Hangelstrecke",
+        image: "File:Playground monkey bars, hoops.jpg",
+        category: "climbing",
+    },
+    roundabout: {
+        name_de: "Karussell",
+        image: "File:Manually powered carousel on a playground in Saint-Petersburg.JPG",
+        category: "rotating",
+    },
+    basketrotator: {
+        name_de: "Korbkarusell",
+        image: "File:Playground Basket-Rotator Berlin Germany.jpg",
+        category: "rotating",
+    },
+    aerialrotator: {
+        name_de: "Hängedrehkreisel",
+        image: "File:Hanging roundabout.jpg",
+        category: "rotating",
+    },
+    spinner: {
+        name_de: "Drehbrett",
+        image: "File:Playground equipment spinner Rollbergsiedlung Berlin-Neukölln.jpg",
+        category: "rotating",
+    },
+    spinning_disc: {
+        name_de: "Drehscheibe",
+        image: "File:Playground rotator Thomashöhe Berlin Neukölln.jpg",
+        category: "rotating",
+    },
+    spinning_circle: {
+        name_de: "Drehring",
+        image: "File:Spinning_circle.jpg",
+        category: "rotating",
+    },
+    spinner_bowl: {
+        name_de: "Drehschale",
+        image: "File:Spinner bowl in Springfield park, Guiseley (side view).jpg",
+        category: "rotating",
+    },
+    sandpit: {
+        name_de: "Sandkasten",
+        image: "File:Zandbakw.jpg",
+        category: "sand",
+    },
+    chute: {
+        name_de: "Sandrohr",
+        image: "File:Playground sand chute.jpg",
+        category: "sand",
+    },
+    sieve: {
+        name_de: "Sieb",
+        image: "File:Playground sand sieve.jpg",
+        category: "sand",
+    },
+    sand_wheel: {
+        name_de: "Sandrad",
+        image: "File:Playground sand wheel.jpg",
+        category: "sand",
+    },
+    sand_seesaw: {
+        name_de: "Sandwippe",
+        image: "File:Playground sand seesaw.jpg",
+        category: "sand",
+    },
+    sand_pulley: {
+        name_de: "Sandaufzug",
+        image: "File:Playground sand pulley Lichtenrader Straße Berlin Neukölln.jpg",
+        category: "sand",
+    },
+    excavator: {
+        name_de: "Spielbagger",
+        image: "File:Playground excavator, unpowered.jpg",
+        category: "sand",
+        filterable: true,
+    },
+    splash_pad: {
+        name_de: "Wasserspritzanlage",
+        image: "File:Urbeach-high-park-splashpad.jpg",
+        category: "water",
+    },
+    pump: {
+        name_de: "Wasserpumpe",
+        image: "File:Wasserspielplatz an der Schäferwiese 01.jpg",
+        category: "water",
+        filterable: true,
+    },
+    water_channel: {
+        name_de: "Wasserkanal",
+        image: "File:Playground water channels Schillerpromenade Berlin Neukölln.jpg",
+        category: "water",
+    },
+    water_stream: {
+        name_de: "Wasserlauf",
+        image: "File:Playground water flow.jpg",
+        category: "water",
+    },
+    water_seesaw: {
+        name_de: "Wasserwippe",
+        image: "File:Playground water seesaw Thomashöhe Berlin Neukölln.jpg",
+        category: "water",
+    },
+    water_basin: {
+        name_de: "Wasserbecken",
+        image: "File:Playground water basin with drain and plug.jpg",
+        category: "water",
+    },
+    water_barrier: {
+        name_de: "Wasserbarriere",
+        image: "File:Playground water barrier Berlin Neukoelln.jpg",
+        category: "water",
+    },
+    archimedes_screw: {
+        name_de: "Wasserschraube",
+        image: "File:Norden Archimedische Schraube.jpg",
+        category: "water",
+    },
+    water_wheel: {
+        name_de: "Wasserrad",
+        image: "File:Playground water wheel Ellricher Straße Berlin-Neukölln.jpg",
+        category: "water",
+    },
+    water_cannon: {
+        name_de: "Wasserkanone",
+        image: "File:Playground water cannon.jpg",
+        category: "water",
+    },
+    water_sprayer: {
+        name_de: "Wasserdüse",
+        image: "File:Farm Playground td (2018-10-30) 28.jpg",
+        category: "water",
+    },
+    horizontal_bar: {
+        name_de: "Reckstange",
+        image: "File:Rekstok.JPG",
+        category: "activity",
+    },
+    parallel_bars: {
+        name_de: "Barren",
+        image: "File:Shun Lee Estate Playground, Gym Zone and Basketball Court.jpg",
+        category: "activity",
+    },
+    bannister_bars: {
+        name_de: "Stangenrutsche",
+        image: "File:Playground parallel bars Mahlower Straße Berlin Neukölln.jpg",
+        category: "activity",
+    },
+    hamster_wheel: {
+        name_de: "Hamsterrolle",
+        image: "File:Kaiserslautern Volkspark Hamsterrolle.jpg",
+        category: "activity",
+    },
+    activitypanel: {
+        name_de: "Spielwand",
+        image: "File:Szwedy - plac zabaw - kółko i krzyżyk.jpg",
+        category: "other",
+    },
+    exercise: {
+        name_de: "Fitnessgerät",
+        image: "File:Outdoor gym in Parque de Bateria, Torremolinos.JPG",
+        category: "activity",
+    },
+    zipwire: {
+        name_de: "Seilbahn",
+        image: "File:Ropeway play.jpg",
+        category: "motion",
+        filterable: true,
+        filter_attr: ["length"],
+    },
+    trampoline: {
+        name_de: "Trampolin",
+        image: "File:playground_trampoline.jpg",
+        category: "motion",
+        filterable: true,
+    },
+    cushion: {
+        name_de: "Hüpfkissen",
+        image: "File:Hüpfkissen.jpg",
+        category: "motion",
+    },
+    belt_bridge: {
+        name_de: "Hüpfbandbrücke",
+        image: "File:Playground belt bridge.jpg",
+        category: "motion",
+    },
+    spring_board: {
+        name_de: "Wackelbrett",
+        image: "File:Playground springs in Obermenzing 05.jpg",
+        category: "motion",
+    },
+    playhouse: {
+        name_de: "Spielhaus",
+        image: "File:Playhouse.jpg",
+        category: "other",
+    },
+    teenshelter: {
+        name_de: "Unterstand",
+        image: "File:Teen shelter near former coastguard lookout, Watchet - geograph.org.uk - 1714960.jpg",
+        category: "other",
+    },
+    tunnel_tube: {
+        name_de: "Kriechtunnel",
+        image: "File:Example of tunnel tube on a playground.jpg",
+        category: "other",
+        filterable: true,
+    },
+    speaking_tube: {
+        name_de: "Sprechrohr",
+        image: "File:Speaking Tube - Garden Exhibit - NCSM - Kolkata 2016-06-02 4046.JPG",
+        category: "other",
+        filterable: true,
+    },
+    hopscotch: {
+        name_de: "Hüpfspiel",
+        image: "File:Hinkelbaan tegels.jpg",
+        category: "motion",
+    },
+    funnel_ball: {
+        name_de: "Trichterball",
+        image: "File:Funnel_ball.jpg",
+        category: "other",
+    },
+    ball_pool: {
+        name_de: "Bällebad",
+        image: "File:At children's level.jpg",
+        category: "other",
+    },
+    ride_on: {
+        name_de: "Sitztier",
+        image: "File:Playground riding animal Thomashöhe Berlin Neukölln.jpg",
+        category: "other",
+    },
+    track: {
+        name_de: "Rennstrecke",
+        image: "File:Playground track Buschkrugallee-Havermannstraße Berlin Britz.jpg",
+        category: "motion",
+    },
+    marble_run: {
+        name_de: "Murmelspiel",
+        image: "File:Rachau Wipfelwanderweg 75.jpg",
+        category: "other",
+    },
+    map: {
+        name_de: "Landkarte",
+        image: "File:Playground Map, Washington Elementary.jpg",
+        category: "other",
+    },
+    blackboard: {
+        name_de: "Tafel",
+        image: "File:Playground chalk board.jpg",
+        category: "other",
+    },
+    musical_instrument: {
+        name_de: "Musikinstrument",
+        image: "File:Play xylophone in a playground.jpeg",
+        category: "other",
+    },
+    table: {
+        name_de: "Spieltisch",
+        image: "File:Playground table Herrfurthstraße Berlin Neukölln.jpg",
+        category: "sand",
+    },
+    seat: {
+        name_de: "Sitz",
+        image: "File:Playground seat Hattenheimer Straße Berlin Tempelhof.jpg",
+        category: "other",
+    },
+    hammock: {
+        name_de: "Hängematte",
+        image: "File:Playground hammock.jpg",
+        category: "other",
+        filterable: true,
+    },
+    sledding: {
+        name_de: "Rodelstrecke",
+        image: "File:Prangli lapsed kelgutamas.jpg",
+        category: "motion",
+    },
+    youth_bench: {
+        name_de: "Jugendbank",
+        image: "File:Youth_bench.jpg",
+        category: "other",
+    },
+    mound: {
+        name_de: "Spielhügel",
+        image: "File:Hunters Point South Pk td (2019-06-10) 069 - Playground.jpg",
+        category: "topographical",
+    },
+    dome: {
+        name_de: "Halbkugel",
+        image: "File:Playground dome metal.jpg",
+        category: "topographical",
+    },
+    // OSM-Fallback-Values
+    balance: {
+        name_de: "Balanciergerät",
+        image: false,
+        category: "balance",
+    },
+    climbing: {
+        name_de: "Klettergerät",
+        image: false,
+        category: "climbing",
+    },
+    rotator: {
+        name_de: "Rotationsgerät",
+        image: false,
+        category: "rotating",
+    },
+    water: {
+        name_de: "Wasserspiele",
+        image: false,
+        category: "water",
+    },
+    sand: {
+        name_de: "Sandspielelement",
+        image: false,
+        category: "sand",
+    },
+}
+
+// Deutschen Namen für fitness_station=* Werte (leisure=fitness_station)
+export const objFitnessStation = {
+    horizontal_bar:    'Klimmzugstange',
+    parallel_bars:     'Barren',
+    push_up:           'Liegestützgerät',
+    sit_up:            'Bauchtrainer',
+    balance_beam:      'Balancierbalken',
+    elliptical_trainer:'Crosstrainer',
+    exercise_stairs:   'Treppenstufen',
+    rowing:            'Rudergerät',
+    bicycle:           'Radergometer',
+    sign:              'Informationsschild',
+    stepping_stone:    'Trittsteine',
+    training_wall:     'Trainingswall',
+    wall_bars:         'Sprossenwand',
+    dip:               'Dip-Station',
+    slalom_bars:       'Slalomstangen',
+    stretching:        'Streckgerät',
+    air_walker:        'Luftläufer',
+    chest_press:       'Brustpresse',
+    leg_press:         'Beinpresse',
+    rotary_torso:      'Rumpfrotation',
+    archery:           'Bogenschießen',
+};
+
+// Hinweis: Speziellere Features müssen sich in der Reihenfolge der Einträge immer _vor_ allgemeineren Features befinden, um korrekt differenziert zu werden
+// z.B. amenity=bench + backrest=yes vor amenity=bench, damit letzteres nur für Sitzbänke greift, die nicht mit backrest=yes getaggt sind
+export const objFeatures = {
+    artwork: {
+        tags: {
+            tourism: "artwork",
+        },
+        name_de: "Kunstwerk",
+        icon: "artwork",
+        size: 12,
+    },
+    bicycle_parking: {
+        tags: {
+            amenity: "bicycle_parking",
+        },
+        name_de: "Fahrradständer",
+        icon: "bicycle_parking",
+        size: 16,
+    },
+    bench_backrest: {
+        tags: {
+            amenity: "bench",
+            backrest: "yes",
+        },
+        name_de: "Sitzbank",
+        icon: "bench_backrest_yes",
+        size: 12,
+    },
+    bench: {
+        tags: {
+            amenity: "bench",
+        },
+        name_de: "Sitzbank",
+        icon: "bench_backrest_no",
+        size: 12,
+    },
+    gate: {
+        tags: {
+            barrier: "gate",
+        },
+        name_de: "Eingangstor",
+        icon: "gate",
+        size: 12,
+    },
+    shelter: {
+        tags: {
+            amenity: "shelter",
+        },
+        name_de: "Unterstand",
+        icon: "shelter",
+        size: 12,
+    },
+    picnic_table: {
+        tags: {
+            leisure: "picnic_table",
+        },
+        name_de: "Picknicktisch",
+        icon: "picnic_table",
+        size: 12,
+    },
+    table_tennis: {
+        tags: {
+            leisure: "pitch",
+            sport: "table_tennis",
+        },
+        name_de: "Tischtennisplatte",
+        icon: "table_tennis",
+        size: 12,
+        image: "File:Table tennis court.jpg",
+    },
+    soccer: {
+        tags: {
+            leisure: "pitch",
+            sport: "soccer",
+        },
+        name_de: "Bolzplatz",
+        icon: "soccer",
+        size: 12,
+        image: "File:Erding Bolzplatz Feldkirchener Str.jpg",
+    },
+    basketball: {
+        tags: {
+            leisure: "pitch",
+            sport: "basketball",
+        },
+        name_de: "Basketballfeld",
+        icon: "basketball",
+        size: 12,
+        image: "File:Basketball court.jpg",
+    },
+    pitch: {
+        tags: {
+            leisure: "pitch",
+        },
+        name_de: "Sportfeld",
+        icon: "pitch",
+        size: 20,
+    },
+    shrub: {
+        tags: {
+            natural: "shrub",
+        },
+        name_de: "Busch",
+        icon: "shrub",
+        size: 12,
+    },
+    tree_evergreen: {
+        tags: {
+            natural: "tree",
+            leaf_type: "needleleaved",
+        },
+        name_de: "Baum",
+        icon: "tree_needleleaved",
+        size: 12,
+    },
+    tree: {
+        tags: {
+            natural: "tree",
+        },
+        name_de: "Baum",
+        icon: "tree_broadleaved",
+        size: 12,
+    },
+    waste_basket: {
+        tags: {
+            amenity: "waste_basket",
+        },
+        name_de: "Abfallbehälter",
+        icon: "waste_basket",
+        size: 10,
+    },
+}

--- a/app/src/lib/panoramax.js
+++ b/app/src/lib/panoramax.js
@@ -1,0 +1,11 @@
+// Panoramax — helper functions for street-level photos.
+
+// Thumbnail URL for a Panoramax photo UUID (stable redirect to S3).
+export function panoramaxThumbUrl(uuid) {
+    return `https://api.panoramax.xyz/api/pictures/${uuid}/thumb.jpg`;
+}
+
+// Viewer URL for a Panoramax photo UUID.
+export function panoramaxViewerUrl(uuid) {
+    return `https://api.panoramax.xyz/?pic=${uuid}&nav=none&focus=pic`;
+}

--- a/app/src/lib/region.js
+++ b/app/src/lib/region.js
@@ -1,0 +1,13 @@
+// Fetch region metadata from Nominatim based on the OSM relation ID.
+export async function fetchRegionInfo(relationId) {
+    const url = `https://nominatim.openstreetmap.org/lookup?osm_ids=R${relationId}&format=json&accept-language=de`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Nominatim lookup failed: ${res.status}`);
+    const [result] = await res.json();
+    const [minLat, maxLat, minLon, maxLon] = result.boundingbox.map(Number);
+    return {
+        name: result.name,
+        extent: [minLon, minLat, maxLon, maxLat], // EPSG:4326 [minLon, minLat, maxLon, maxLat]
+        center: [(minLon + maxLon) / 2, (minLat + maxLat) / 2],  // EPSG:4326
+    };
+}

--- a/app/src/lib/utils.js
+++ b/app/src/lib/utils.js
@@ -1,0 +1,19 @@
+/**
+ * Escape a string for safe insertion into innerHTML.
+ *
+ * Any field sourced from crowd-sourced or third-party data (OSM tags,
+ * Mangrove review text, …) must be passed through this function before
+ * being interpolated into an HTML template string.
+ *
+ * @param {*} str - Value to escape. null/undefined are returned as ''.
+ * @returns {string} HTML-safe string.
+ */
+export function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/app/src/lib/vectorStyles.js
+++ b/app/src/lib/vectorStyles.js
@@ -1,0 +1,174 @@
+// OL vector styles for playground polygons and equipment points.
+// Ported from style/VectorStyles.js; import path updated for the new app layout.
+
+import { Icon, Style } from 'ol/style.js';
+import Fill from 'ol/style/Fill.js';
+import Stroke from 'ol/style/Stroke.js';
+import Circle from 'ol/style/Circle.js';
+
+import { objDevices, objFeatures } from './objPlaygroundEquipment.js';
+import { playgroundCompleteness } from './completeness.js';
+
+// ── Playground completeness colours ──────────────────────────────────────────
+
+function makeHatchPattern(color, bgColor) {
+    const size = 10;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = bgColor;
+    ctx.fillRect(0, 0, size, size);
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(0, size);
+    ctx.lineTo(size, 0);
+    ctx.stroke();
+    return ctx.createPattern(canvas, 'repeat');
+}
+
+// Lazily initialised — canvas only available in browser context
+let _hatchComplete, _hatchPartial, _hatchMissing;
+function getHatch(type) {
+    if (!_hatchComplete) {
+        _hatchComplete = makeHatchPattern('rgba(34,139,34,0.55)',  'rgba(34,139,34,0.08)');
+        _hatchPartial  = makeHatchPattern('rgba(180,130,0,0.55)',  'rgba(234,179,8,0.08)');
+        _hatchMissing  = makeHatchPattern('rgba(200,50,50,0.55)',  'rgba(239,68,68,0.06)');
+    }
+    return type === 'complete' ? _hatchComplete
+         : type === 'partial'  ? _hatchPartial
+         : _hatchMissing;
+}
+
+const _styleComplete = new Style({
+    fill: new Fill({ color: 'rgba(34, 139, 34, 0.22)' }),
+    stroke: new Stroke({ color: '#155215', width: 1.5 })
+});
+const _stylePartial = new Style({
+    fill: new Fill({ color: 'rgba(234, 179, 8, 0.22)' }),
+    stroke: new Stroke({ color: '#92400e', width: 1.5 })
+});
+const _styleMissing = new Style({
+    fill: new Fill({ color: 'rgba(239, 68, 68, 0.18)' }),
+    stroke: new Stroke({ color: '#991b1b', width: 1.5 })
+});
+
+function makeHatchStyle(type) {
+    const colors = {
+        complete: { stroke: '#155215' },
+        partial:  { stroke: '#92400e' },
+        missing:  { stroke: '#991b1b' },
+    };
+    return new Style({
+        fill: new Fill({ color: getHatch(type) }),
+        stroke: new Stroke({ color: colors[type].stroke, width: 1.5, lineDash: [6, 3] })
+    });
+}
+
+function isRestrictedAccess(props) {
+    return props.access === 'private' || props.access === 'customers';
+}
+
+/** Style function for the playground polygon layer. */
+export function playgroundStyleFn(feature) {
+    const props = feature.getProperties();
+    const c = playgroundCompleteness(props);
+    if (isRestrictedAccess(props)) return makeHatchStyle(c);
+    if (c === 'complete') return _styleComplete;
+    if (c === 'partial')  return _stylePartial;
+    return _styleMissing;
+}
+
+// ── Selected playground highlight ────────────────────────────────────────────
+
+export const selectionStyle = new Style({
+    fill: new Fill({ color: 'rgba(255, 0, 0, 0.15)' }),
+    stroke: new Stroke({ color: '#ff0000', width: 3 })
+});
+
+// ── Equipment point / polygon styles ─────────────────────────────────────────
+
+const circleRadius = 3.5;
+const strokeWidth  = 3.5;
+const fillAlpha    = 0.4;
+const strokeAlpha  = 1;
+const featureColor = '#394240';
+
+// Colours by equipment category
+export const objColors = {
+    stationary:       '#825c46',
+    structure_parts:  '#825c46',
+    sand:             '#d6a52c',
+    water:            '#0fa1fb',
+    swing:            '#ee4b9e',
+    motion:           '#ee4b9e',
+    balance:          '#5ab2ae',
+    climbing:         '#5ab2ae',
+    rotating:         '#5ab2ae',
+    activity:         '#5ab2ae',
+    fallback:         '#40474a',
+};
+
+const objOpacity = { sandpit: 0.3 };
+
+function hexToRgb(hex) {
+    hex = hex.replace('#', '');
+    const n = parseInt(hex, 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** Style function for equipment vector features (points and polygons). */
+export function styleFunction(feature, mode, isPoint) {
+    const playground = feature.get('playground');
+    let color = objColors.fallback;
+    let icon = null;
+    let icon_size = null;
+
+    if (mode === 'select') {
+        color = '#ff0000';
+    } else if (playground in objDevices) {
+        const cat = objDevices[playground].category;
+        if (cat in objColors) color = objColors[cat];
+    } else {
+        color = featureColor;
+        outer: for (const feat in objFeatures) {
+            const tags = objFeatures[feat].tags;
+            for (const key in tags) {
+                if (feature.get(key) !== tags[key]) continue outer;
+            }
+            icon = objFeatures[feat].icon;
+            icon_size = objFeatures[feat].size;
+            break;
+        }
+    }
+
+    const alpha = playground in objOpacity ? objOpacity[playground] : fillAlpha;
+    const [r, g, b] = hexToRgb(color);
+    const fill   = `rgba(${r},${g},${b},${alpha})`;
+    const stroke = `rgba(${r},${g},${b},${strokeAlpha})`;
+
+    let radius = circleRadius;
+    let width  = strokeWidth;
+    if (mode === 'select') { radius += 2; width += 2; }
+    if (playground === 'sandpit') width -= 1;
+
+    if (isPoint) {
+        if (icon) {
+            return new Style({
+                image: new Icon({ src: `/img/icons/${icon}.png`, width: icon_size })
+            });
+        }
+        return new Style({
+            image: new Circle({
+                radius,
+                fill: new Fill({ color: fill }),
+                stroke: new Stroke({ color: stroke, width })
+            })
+        });
+    }
+    return new Style({
+        fill: new Fill({ color: fill }),
+        stroke: new Stroke({ color: stroke, width })
+    });
+}

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,0 +1,12 @@
+import { mount } from 'svelte';
+import { appMode } from './lib/config.js';
+import StandaloneApp from './standalone/StandaloneApp.svelte';
+import HubApp from './hub/HubApp.svelte';
+
+const target = document.getElementById('app');
+
+if (appMode === 'hub') {
+  mount(HubApp, { target });
+} else {
+  mount(StandaloneApp, { target });
+}

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -1,0 +1,70 @@
+<script>
+  import 'bootstrap/dist/css/bootstrap.min.css';
+  import 'bootstrap-icons/font/bootstrap-icons.css';
+
+  import Map from '../components/Map.svelte';
+  import { selection } from '../stores/selection.js';
+  import { apiBaseUrl } from '../lib/config.js';
+</script>
+
+<div class="app-root">
+  <Map defaultBackendUrl={apiBaseUrl} />
+
+  {#if $selection.feature}
+    <aside class="info-panel">
+      <div class="info-panel__header">
+        <strong>{$selection.feature.get('name') ?? 'Spielplatz'}</strong>
+        <button
+          class="btn-close"
+          aria-label="Schließen"
+          onclick={() => selection.clear()}
+        ></button>
+      </div>
+      <div class="info-panel__body">
+        <!-- PlaygroundPanel component will be added in PR 3 -->
+        <p class="text-muted small">Detailansicht folgt in PR 3.</p>
+        <dl class="row small">
+          <dt class="col-5">OSM ID</dt>
+          <dd class="col-7">{$selection.feature.get('osm_id')}</dd>
+        </dl>
+      </div>
+    </aside>
+  {/if}
+</div>
+
+<style>
+  .app-root {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .info-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 360px;
+    height: 100%;
+    background: #fff;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.15);
+    z-index: 100;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .info-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+    border-bottom: 1px solid #dee2e6;
+    font-size: 1rem;
+  }
+
+  .info-panel__body {
+    padding: 1rem;
+    flex: 1;
+  }
+</style>

--- a/app/src/stores/map.js
+++ b/app/src/stores/map.js
@@ -1,0 +1,7 @@
+// Svelte store holding the OpenLayers Map instance.
+// Components that need to interact with the map (e.g. fit to extent, add layers)
+// import this store and call get(mapStore) after onMount.
+
+import { writable } from 'svelte/store';
+
+export const mapStore = writable(null);

--- a/app/src/stores/selection.js
+++ b/app/src/stores/selection.js
@@ -1,0 +1,38 @@
+// Reactive store for the currently selected playground.
+// Replaces the 40+ DOM ID coupling in the old selectPlayground.js with a single
+// writable store that all components can subscribe to.
+//
+// shape: { feature: OlFeature | null, backendUrl: string }
+//   feature    — the selected OpenLayers feature (null = nothing selected)
+//   backendUrl — the API base URL of the backend that owns this feature.
+//                In standalone mode this is always apiBaseUrl.
+//                In hub mode this is the per-backend URL from the registry.
+
+import { writable, derived } from 'svelte/store';
+
+function createSelectionStore() {
+    const { subscribe, set, update } = writable({ feature: null, backendUrl: '' });
+
+    return {
+        subscribe,
+        select(feature, backendUrl) {
+            set({ feature, backendUrl });
+            if (feature) {
+                const osmId = feature.get('osm_id');
+                if (osmId) history.replaceState(null, '', `#W${osmId}`);
+            }
+        },
+        clear() {
+            set({ feature: null, backendUrl: '' });
+            history.replaceState(null, '', window.location.pathname + window.location.search);
+        },
+    };
+}
+
+export const selection = createSelectionStore();
+
+// Derived: true when a playground is selected
+export const hasSelection = derived(selection, $s => $s.feature !== null);
+
+// Derived: the OSM ID of the selected playground (or null)
+export const selectedOsmId = derived(selection, $s => $s.feature?.get('osm_id') ?? null);

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    sourcemap: true,
+  },
+  server: {
+    host: true, // bind to 0.0.0.0 so the app is reachable on the local network
+  },
+});


### PR DESCRIPTION
## Summary

- Bootstraps `app/` as the new Svelte + Vite frontend — first step of the hub consolidation plan
- Migrates all reusable modules to `app/src/lib/` (api, completeness, vectorStyles, equipment catalog, etc.)
- Introduces Svelte writable stores (`selection`, `map`) to replace 40+ hardcoded DOM IDs in the legacy code
- `Map.svelte`: OL map with CartoDB Voyager basemap, completeness-coloured playground polygons, click-to-select
- `StandaloneApp.svelte` and `HubApp.svelte`: mode shells with placeholders for PR 3 and PR 5
- `main.js`: mounts the correct shell based on `APP_MODE` from `window.APP_CONFIG`
- Makefile gets `app-install / app-dev / app-build / app-serve / app-test` targets
- Fixed overly-broad `/lib` gitignore entry that was shadowing `app/src/lib/`

The legacy root-level Vite app is untouched — removed in PR 7 once the Svelte app reaches feature parity.

## Test plan

- [ ] `make app-install` completes without errors
- [ ] `make app-dev` loads Svelte app at localhost:5173 with completeness-coloured playground polygons
- [ ] Clicking a playground opens the side panel; URL hash updates to `#W<osmId>`
- [ ] `make app-build` produces `app/dist/` without errors
- [ ] `make dev` (legacy) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)