### PR TITLE
feat: standalone detail panel with equipment, POIs, search, and locate

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -1,0 +1,186 @@
+<script>
+  import { objDevices, objFitnessStation } from '../lib/objPlaygroundEquipment.js';
+  import { objColors } from '../lib/vectorStyles.js';
+  import { getEquipmentAttributesFromProps } from '../lib/equipmentAttributes.js';
+
+  /** @type {Array} GeoJSON features from fetchPlaygroundEquipment */
+  export let features = [];
+  /** @type {Object} Playground polygon properties (for playground:<key> fallback) */
+  export let playgroundAttr = {};
+
+  const pitchLabels = {
+    soccer:          ['Bolzplatz',          'Bolzplätze'],
+    basketball:      ['Basketballfeld',     'Basketballfelder'],
+    table_tennis:    ['Tischtennisplatte',  'Tischtennisplatten'],
+    volleyball:      ['Volleyballfeld',     'Volleyballfelder'],
+    tennis:          ['Tennisfeld',         'Tennisfelder'],
+    handball:        ['Handballfeld',       'Handballfelder'],
+    badminton:       ['Badmintonfeld',      'Badmintonfelder'],
+    boules:          ['Boulesbahn',         'Boulesanlagen'],
+    petanque:        ['Pétanquebahn',       'Pétanqueanlagen'],
+    multi:           ['Mehrzweckspielfeld', 'Mehrzweckspielfelder'],
+    skateboard:      ['Skatepark',          'Skateparks'],
+    bmx:             ['BMX-Bahn',           'BMX-Bahnen'],
+    climbing:        ['Kletteranlage',      'Kletteranlagen'],
+    fitness:         ['Fitnessbereich',     'Fitnessbereiche'],
+  };
+
+  $: deviceFeatures  = features.filter(f => f.properties.playground && f.properties.playground !== 'yes');
+  $: fitnessFeatures = features.filter(f => f.properties.leisure === 'fitness_station');
+  $: pitchFeatures   = features.filter(f => f.properties.leisure === 'pitch');
+  $: benchCount   = features.filter(f => f.properties.amenity === 'bench').length;
+  $: shelterCount = features.filter(f => f.properties.amenity === 'shelter').length;
+  $: picnicCount  = features.filter(f => f.properties.leisure === 'picnic_table').length;
+
+  // Fallback: playground:<key>=<count|yes> on the polygon itself
+  $: fallbackCounts = (() => {
+    if (deviceFeatures.length) return {};
+    const counts = {};
+    for (const [tag, val] of Object.entries(playgroundAttr)) {
+      if (!tag.startsWith('playground:')) continue;
+      const key = tag.replace('playground:', '');
+      const n = parseInt(val) || (val === 'yes' ? 1 : 0);
+      if (n > 0) counts[key] = n;
+    }
+    return counts;
+  })();
+
+  // Open/closed state per item (keyed by osm_id or random uid)
+  let openItems = new Set();
+  function toggleItem(uid) {
+    const next = new Set(openItems);
+    next.has(uid) ? next.delete(uid) : next.add(uid);
+    openItems = next;
+  }
+  function uid(f) {
+    return `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
+  }
+</script>
+
+{#if features.length === 0 && Object.keys(fallbackCounts).length === 0}
+  <ul><li><small class="text-muted">Keine Spielgeräte erfasst.</small></li></ul>
+  <p class="text-muted mt-2 mb-0" style="font-size:smaller">
+    Hilf mit und trage Spielgeräte auf
+    <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a> ein.
+  </p>
+{:else}
+  <!-- Summary counts -->
+  <ul>
+    {#if deviceFeatures.length}
+      <li>{deviceFeatures.length} Spielgerät{deviceFeatures.length !== 1 ? 'e' : ''}</li>
+    {/if}
+    {#if fitnessFeatures.length}
+      <li>{fitnessFeatures.length} Fitnessgerät{fitnessFeatures.length !== 1 ? 'e' : ''}</li>
+    {/if}
+    {#if benchCount}
+      <li>{benchCount} {benchCount !== 1 ? 'Sitzbänke' : 'Sitzbank'}</li>
+    {/if}
+    {#if shelterCount}
+      <li>{shelterCount} Unterstand{shelterCount !== 1 ? 'e' : ''}</li>
+    {/if}
+    {#if picnicCount}
+      <li>{picnicCount} Picknicktisch{picnicCount !== 1 ? 'e' : ''}</li>
+    {/if}
+  </ul>
+
+  <!-- Detailed device list (mapped individually) -->
+  {#if deviceFeatures.length || fitnessFeatures.length || pitchFeatures.length}
+    <ul class="mb-0 device-list">
+      {#each deviceFeatures as f (f.properties.osm_id)}
+        {@const key = f.properties.playground}
+        {@const name = objDevices[key]?.name_de ?? key}
+        {@const cat = objDevices[key]?.category ?? 'fallback'}
+        {@const color = objColors[cat] ?? objColors['fallback']}
+        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const id = uid(f)}
+        <li>
+          {#if detail}
+            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+              <span style="color:{color}">●</span> {name}
+              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+            </button>
+            {#if openItems.has(id)}
+              <div class="device-detail">{@html detail}</div>
+            {/if}
+          {:else}
+            <span style="color:{color}">●</span> {name}
+          {/if}
+        </li>
+      {/each}
+
+      {#each fitnessFeatures as f (f.properties.osm_id)}
+        {@const fsType = f.properties.fitness_station}
+        {@const name = (fsType && objFitnessStation[fsType]) ? objFitnessStation[fsType] : 'Fitnessgerät'}
+        {@const color = objColors['activity'] ?? objColors['fallback']}
+        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const id = uid(f)}
+        <li>
+          {#if detail}
+            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+              <span style="color:{color}">●</span> {name}
+              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+            </button>
+            {#if openItems.has(id)}
+              <div class="device-detail">{@html detail}</div>
+            {/if}
+          {:else}
+            <span style="color:{color}">●</span> {name}
+          {/if}
+        </li>
+      {/each}
+
+      {#each pitchFeatures as f (f.properties.osm_id)}
+        {@const sport = f.properties.sport ?? ''}
+        {@const label = (pitchLabels[sport]?.[0]) ?? (sport ? `Sportfeld (${sport})` : 'Sportfeld')}
+        {@const color = objColors['fallback']}
+        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const id = uid(f)}
+        <li>
+          {#if detail}
+            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+              <span style="color:{color}">●</span> {label}
+              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+            </button>
+            {#if openItems.has(id)}
+              <div class="device-detail">{@html detail}</div>
+            {/if}
+          {:else}
+            <span style="color:{color}">●</span> {label}
+          {/if}
+        </li>
+      {/each}
+    </ul>
+
+  <!-- Fallback: playground:<key> tags on the polygon itself -->
+  {:else if Object.keys(fallbackCounts).length}
+    <ul class="mb-0">
+      {#each Object.entries(fallbackCounts) as [key, count]}
+        {@const name = objDevices[key]?.name_de ?? key}
+        {@const cat  = objDevices[key]?.category ?? 'fallback'}
+        {@const color = objColors[cat] ?? objColors['fallback']}
+        <li>
+          <span style="color:{color}">●</span>
+          {count > 1 ? `${count}× ` : ''}{name}
+        </li>
+      {/each}
+    </ul>
+    <p class="text-muted mt-2 mb-0" style="font-size:smaller">
+      Hilf mit und trage Spielgeräte auf
+      <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a> ein.
+    </p>
+  {/if}
+{/if}
+
+<style>
+  .device-list { padding-left: 0; list-style: none; }
+  .device-list li { margin-bottom: 0.25rem; }
+  .device-toggle { cursor: pointer; user-select: none; }
+  .device-toggle:hover { text-decoration: underline; }
+  .device-chevron { font-size: 0.7rem; margin-left: 0.25rem; }
+  .device-detail {
+    margin: 0.25rem 0 0.5rem 1rem;
+    font-size: smaller;
+  }
+  .device-detail :global(ul) { padding-left: 1.2rem; margin-bottom: 0; }
+  .device-detail :global(img) { width: 100%; border-radius: 4px; margin-bottom: 0.25rem; }
+</style>

--- a/app/src/components/LocateButton.svelte
+++ b/app/src/components/LocateButton.svelte
@@ -1,0 +1,46 @@
+<script>
+  import { fromLonLat } from 'ol/proj';
+  import { mapStore } from '../stores/map.js';
+
+  let locating = false;
+  let error = '';
+
+  function locate() {
+    if (!navigator.geolocation) {
+      error = 'Geolocation nicht verfügbar.';
+      return;
+    }
+    locating = true;
+    error = '';
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        locating = false;
+        const coord = fromLonLat([pos.coords.longitude, pos.coords.latitude]);
+        $mapStore?.getView().animate({ center: coord, zoom: 16 });
+      },
+      err => {
+        locating = false;
+        error = err.code === 1 ? 'Standortzugriff verweigert.' : 'Standort nicht verfügbar.';
+      },
+      { timeout: 10000, maximumAge: 60000 }
+    );
+  }
+</script>
+
+<button
+  class="btn btn-sm btn-outline-secondary locate-btn"
+  onclick={locate}
+  disabled={locating}
+  title={error || 'Meinen Standort anzeigen'}
+  aria-label="Meinen Standort anzeigen"
+>
+  {#if locating}
+    <span class="spinner-border spinner-border-sm" role="status"></span>
+  {:else}
+    <span class="bi bi-geo-alt{error ? '-fill text-danger' : ''}"></span>
+  {/if}
+</button>
+
+<style>
+  .locate-btn { padding: 0.25rem 0.5rem; line-height: 1; }
+</style>

--- a/app/src/components/POIPanel.svelte
+++ b/app/src/components/POIPanel.svelte
@@ -1,0 +1,99 @@
+<script>
+  import { haversineDistance, formatDistance, bearingDeg, bearingToDir } from '../lib/playgroundHelpers.js';
+  import { poiRadiusM } from '../lib/config.js';
+
+  /** @type {Array} POI objects from fetchNearbyPOIs */
+  export let pois = [];
+  /** @type {number} Playground centre latitude (WGS84) */
+  export let centerLat = 0;
+  /** @type {number} Playground centre longitude (WGS84) */
+  export let centerLon = 0;
+
+  const CATEGORIES = [
+    {
+      icon: '🚻', label: 'Toiletten',
+      match: f => f.amenity === 'toilets',
+      fallback: 'Toiletten',
+    },
+    {
+      icon: '🚌', label: 'Bushaltestellen',
+      match: f => f.highway === 'bus_stop',
+      fallback: 'Bushaltestelle',
+      hint: (poi) => poi.tags.towards
+        ? `→ ${poi.tags.towards}`
+        : bearingToDir(bearingDeg(centerLat, centerLon, poi.lat, poi.lon)),
+    },
+    {
+      icon: '🍦', label: 'Eis',
+      match: f => f.amenity === 'ice_cream' || (f.cuisine && f.cuisine.includes('ice_cream')),
+      fallback: 'Eisdiele',
+    },
+    {
+      icon: '🛒', label: 'Einkaufen',
+      match: f => f.shop === 'supermarket' || f.shop === 'convenience',
+      fallback: 'Supermarkt',
+    },
+    {
+      icon: '🧴', label: 'Drogerie',
+      match: f => f.shop === 'chemist',
+      fallback: 'Drogerie',
+    },
+    {
+      icon: '🏥', label: 'Notaufnahme',
+      match: f => f.emergency === 'yes' || f['healthcare:speciality'] === 'emergency',
+      fallback: 'Notaufnahme',
+    },
+  ];
+
+  $: enriched = pois.map(p => ({
+    ...p,
+    dist: haversineDistance(centerLat, centerLon, p.lat, p.lon),
+  }));
+
+  $: sections = CATEGORIES.map(cat => {
+    const seen = new Set();
+    const matches = enriched
+      .filter(p => cat.match(p.tags))
+      .sort((a, b) => a.dist - b.dist)
+      .filter(p => {
+        const key = (p.tags.name || cat.fallback).toLowerCase();
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .slice(0, 2);
+    return { ...cat, matches };
+  }).filter(s => s.matches.length);
+</script>
+
+{#if sections.length === 0}
+  <small class="text-muted">
+    Keine nahegelegenen Einrichtungen im Umkreis von {(poiRadiusM / 1000).toFixed(0)} km gefunden.
+  </small>
+{:else}
+  {#each sections as cat}
+    <div class="mb-2">
+      <small class="text-muted fw-bold text-uppercase" style="font-size:0.7rem;">
+        {cat.icon} {cat.label}
+      </small>
+      {#each cat.matches as poi}
+        {@const name = poi.tags.name || cat.fallback}
+        {@const hint = cat.hint ? cat.hint(poi) : null}
+        {@const geoUrl = `geo:${poi.lat},${poi.lon}?q=${poi.lat},${poi.lon}(${encodeURIComponent(name)})`}
+        {@const osmUrl = `https://www.openstreetmap.org/directions?engine=fossgis_osrm_foot&route=${centerLat},${centerLon};${poi.lat},${poi.lon}`}
+        <div class="d-flex justify-content-between align-items-baseline mt-1">
+          <span style="font-size:smaller;">
+            {name}{#if hint}<span class="text-muted ms-1" style="font-size:0.7rem;">({hint})</span>{/if}
+          </span>
+          <span class="ms-2 text-nowrap">
+            <a href={geoUrl} class="text-muted text-decoration-none" style="font-size:smaller;"
+               title="In Navigations-App öffnen">{formatDistance(poi.dist)} ↗</a>
+            <a href={osmUrl} target="_blank" rel="noopener"
+               class="text-muted text-decoration-none ms-1" style="font-size:smaller;"
+               title="Im Browser navigieren">🗺</a>
+          </span>
+        </div>
+      {/each}
+    </div>
+  {/each}
+{/if}

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -1,0 +1,358 @@
+<script>
+  import { onMount } from 'svelte';
+  import OpeningHours from 'opening_hours';
+  import { transform } from 'ol/proj';
+
+  import { selection } from '../stores/selection.js';
+  import { fetchPlaygroundEquipment, fetchNearbyPOIs } from '../lib/api.js';
+  import { playgroundCompleteness } from '../lib/completeness.js';
+  import { poiRadiusM } from '../lib/config.js';
+  import { getPlaygroundTitle, getPlaygroundLocation } from '../lib/playgroundHelpers.js';
+  import { escapeHtml } from '../lib/utils.js';
+  import EquipmentList from './EquipmentList.svelte';
+  import POIPanel from './POIPanel.svelte';
+
+  // ── Derived state from selection store ────────────────────────────────────
+  $: feature    = $selection.feature;
+  $: backendUrl = $selection.backendUrl;
+  $: attr       = feature ? feature.getProperties() : null;
+
+  // ── Async data ────────────────────────────────────────────────────────────
+  let equipmentFeatures = [];
+  let pois = [];
+  let equipmentLoading = false;
+  let poisLoading = false;
+
+  // Centre of selected playground in WGS84
+  let centerLat = 0, centerLon = 0;
+
+  // Generation counter — incremented on each new selection so stale responses are discarded.
+  let loadGen = 0;
+
+  $: if (feature) {
+    loadData(feature, backendUrl);
+  } else {
+    equipmentFeatures = [];
+    pois = [];
+  }
+
+  async function loadData(feat, url) {
+    const geom = feat.getGeometry();
+    if (!geom) { equipmentFeatures = []; pois = []; return; }
+
+    const gen = ++loadGen;
+    const ext = geom.getExtent();
+    const [lon, lat] = transform(
+      [(ext[0] + ext[2]) / 2, (ext[1] + ext[3]) / 2],
+      'EPSG:3857', 'EPSG:4326'
+    );
+    centerLat = lat;
+    centerLon = lon;
+
+    equipmentLoading = true;
+    poisLoading = true;
+
+    try {
+      const geojson = await fetchPlaygroundEquipment(ext, feat.get('osm_id'), url);
+      if (gen === loadGen) equipmentFeatures = geojson.features ?? [];
+    } catch (err) {
+      console.warn('Equipment load failed:', err);
+      if (gen === loadGen) equipmentFeatures = [];
+    } finally {
+      if (gen === loadGen) equipmentLoading = false;
+    }
+
+    try {
+      const result = await fetchNearbyPOIs(lat, lon, poiRadiusM, feat.get('osm_id'), url);
+      if (gen === loadGen) pois = result;
+    } catch (err) {
+      console.warn('POI load failed:', err);
+      if (gen === loadGen) pois = [];
+    } finally {
+      if (gen === loadGen) poisLoading = false;
+    }
+  }
+
+  // ── ESC to close ──────────────────────────────────────────────────────────
+  function handleKeydown(e) {
+    if (e.key === 'Escape' && feature) selection.clear();
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
+
+  // ── Completeness badge ────────────────────────────────────────────────────
+  const COMPLETENESS = {
+    complete: { cls: 'completeness-badge--complete', label: 'Daten vollständig' },
+    partial:  { cls: 'completeness-badge--partial',  label: 'Daten teilweise erfasst' },
+    missing:  { cls: 'completeness-badge--missing',  label: 'Daten fehlen' },
+  };
+  $: completeness = attr ? COMPLETENESS[playgroundCompleteness(attr)] : null;
+
+  // ── Opening hours ─────────────────────────────────────────────────────────
+  function formatOpeningHours(ohStr) {
+    const fmt = d => d.toLocaleTimeString('de', { hour: '2-digit', minute: '2-digit' });
+    const dayLabel = (d, now) => {
+      if (d.toDateString() === now.toDateString()) return 'heute';
+      const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
+      if (d.toDateString() === tomorrow.toDateString()) return 'morgen';
+      const diff = Math.round((d - now) / 86400000);
+      if (diff <= 6) return d.toLocaleDateString('de', { weekday: 'long' });
+      return d.toLocaleDateString('de', { weekday: 'short', day: '2-digit', month: '2-digit' });
+    };
+    try {
+      const oh = new OpeningHours(ohStr, { address: { country_code: 'de' } });
+      const now = new Date();
+      const isOpen = oh.getState(now);
+      const next = oh.getNextChange(now);
+      if (ohStr.trim() === '24/7') return `<span style="color:#16a34a">● Immer geöffnet</span>`;
+      if (isOpen) {
+        const label = next ? `Geöffnet bis ${fmt(next)}` : 'Geöffnet';
+        return `<span style="color:#16a34a">● ${label}</span>`;
+      }
+      if (next) return `<span style="color:#dc2626">● Geschlossen</span> · Öffnet ${dayLabel(next, now)} um ${fmt(next)}`;
+      return `<span style="color:#dc2626">● Geschlossen</span>`;
+    } catch {
+      return `<code style="font-size:smaller">${escapeHtml(ohStr)}</code>`;
+    }
+  }
+
+  // ── Attribute helpers ─────────────────────────────────────────────────────
+  const surfaceLabels = {
+    sand:'Sand', grass:'Rasen', wood_chips:'Holzschnitzel', bark_mulch:'Rindenmulch',
+    rubber:'Gummigranulat', asphalt:'Asphalt', concrete:'Beton',
+    paving_stones:'Pflastersteine', tartan:'Tartan', artificial_turf:'Kunstgras',
+    gravel:'Kies', fine_gravel:'Feinkies', dirt:'Erde', compacted:'verdichtet',
+  };
+  const accessDict = {
+    yes:'öffentlich', private:'privat', customers:'nur für Gäste',
+    no:'nicht zugänglich', permissive:'öffentlich geduldet',
+    destination:'nur für Anlieger', residents:'nur für Anwohnende',
+  };
+  const privateDict = {
+    residents:'nur für Anwohnende', students:'nur für Schule',
+    employees:'nur für Mitarbeitende',
+  };
+
+  $: accessLabel = attr
+    ? (privateDict[attr.private] ?? accessDict[attr.access] ?? 'unbekannt')
+    : '';
+
+  $: descriptionParts = (() => {
+    if (!attr) return [];
+    const parts = [];
+    const desc = attr['description:de'] && attr.description !== attr['description:de']
+      ? (attr.description ? `${attr.description} | ${attr['description:de']}` : attr['description:de'])
+      : attr.description;
+    if (desc) parts.push(desc);
+    if (attr.note) parts.push(`✏ ${attr.note}`);
+    if (attr.fixme) parts.push(`🔧 ${attr.fixme}`);
+    return parts;
+  })();
+
+  $: mcOsmType = attr ? ({ W:'way', R:'relation', N:'node' }[attr.osm_type] ?? 'way') : 'way';
+  $: mcUrl = attr ? `https://mapcomplete.org/playgrounds.html#${mcOsmType}/${attr.osm_id}` : '';
+
+  // ── Accordion state ───────────────────────────────────────────────────────
+  let openSections = new Set(['equipment', 'pois']);
+  function toggleSection(id) {
+    const next = new Set(openSections);
+    next.has(id) ? next.delete(id) : next.add(id);
+    openSections = next;
+  }
+</script>
+
+{#if feature && attr}
+  <aside class="info-panel">
+    <div class="info-panel__header">
+      <div>
+        <div class="fw-semibold">{getPlaygroundTitle(attr)}</div>
+        {#if completeness}
+          <span class="completeness-badge {completeness.cls}">{completeness.label}</span>
+        {/if}
+      </div>
+      <button class="btn-close" aria-label="Schließen" onclick={() => selection.clear()}></button>
+    </div>
+
+    <div class="info-panel__body">
+
+      <!-- Location / description -->
+      {#if getPlaygroundLocation(attr)}
+        <p class="text-muted small mb-1"><i>{getPlaygroundLocation(attr)}</i></p>
+      {/if}
+      {#each descriptionParts as part}
+        <p class="small mb-1"><i>{part}</i></p>
+      {/each}
+
+      <!-- Key facts -->
+      <dl class="row small mb-2">
+        <dt class="col-5">Größe</dt>
+        <dd class="col-7">{attr.area > 0 ? `${Math.round(attr.area / 10) * 10 || attr.area} m²` : 'unbekannt'}</dd>
+
+        <dt class="col-5">Zugänglichkeit</dt>
+        <dd class="col-7">{accessLabel}</dd>
+
+        {#if attr.surface}
+          <dt class="col-5">Bodenbelag</dt>
+          <dd class="col-7">{surfaceLabels[attr.surface] ?? attr.surface}</dd>
+        {/if}
+
+        {#if attr.tree_count > 0}
+          <dt class="col-5">Bäume mind.</dt>
+          <dd class="col-7">{attr.tree_count}</dd>
+        {/if}
+
+        {#if attr.min_age || attr.max_age}
+          <dt class="col-5">Alter</dt>
+          <dd class="col-7">
+            {#if attr.min_age && attr.max_age}{attr.min_age}–{attr.max_age} Jahre
+            {:else if attr.min_age}ab {attr.min_age} Jahren
+            {:else}bis {attr.max_age} Jahre{/if}
+          </dd>
+        {/if}
+
+        {#if attr.opening_hours}
+          <dt class="col-5">Öffnungszeiten</dt>
+          <dd class="col-7">{@html formatOpeningHours(attr.opening_hours)}</dd>
+        {/if}
+
+        {#if attr.operator}
+          <dt class="col-5">Betreiber</dt>
+          <dd class="col-7">
+            {#if attr['operator:wikidata']}
+              <a href="https://www.wikidata.org/wiki/{attr['operator:wikidata']}"
+                 target="_blank" rel="noopener" class="link-secondary">{attr.operator}</a>
+            {:else}
+              {attr.operator}
+            {/if}
+          </dd>
+        {/if}
+
+        {#if attr['contact:email'] || attr.email || attr['contact:phone'] || attr.phone}
+          <dt class="col-5">Kontakt</dt>
+          <dd class="col-7">
+            {#if attr['contact:phone'] || attr.phone}
+              {@const phone = attr['contact:phone'] || attr.phone}
+              {#if /^\+?\d/.test(phone.trim())}
+                <a href="tel:{phone}" class="link-secondary">{phone}</a>
+              {:else}{phone}{/if}
+            {/if}
+            {#if (attr['contact:email'] || attr.email) && (attr['contact:phone'] || attr.phone)} · {/if}
+            {#if attr['contact:email'] || attr.email}
+              {@const email = attr['contact:email'] || attr.email}
+              {#if email.includes('@') && !/^javascript:/i.test(email.trim())}
+                <a href="mailto:{email}" class="link-secondary">{email}</a>
+              {:else}{email}{/if}
+            {/if}
+          </dd>
+        {/if}
+
+        <dt class="col-5">OSM ID</dt>
+        <dd class="col-7">
+          <a href="https://www.openstreetmap.org/{mcOsmType}/{attr.osm_id}"
+             target="_blank" rel="noopener" class="link-secondary">{attr.osm_id}</a>
+        </dd>
+      </dl>
+
+      <div class="mb-2">
+        <a href={mcUrl} target="_blank" rel="noopener" class="mc-add-link small">
+          <span class="bi bi-pencil"></span> Bei MapComplete bearbeiten
+        </a>
+      </div>
+
+      <!-- Equipment accordion -->
+      <div class="accordion-section">
+        <button class="accordion-toggle" onclick={() => toggleSection('equipment')}>
+          <span class="bi {openSections.has('equipment') ? 'bi-chevron-down' : 'bi-chevron-right'}"></span>
+          Ausstattung
+        </button>
+        {#if openSections.has('equipment')}
+          <div class="accordion-body">
+            {#if equipmentLoading}
+              <small class="text-muted"><i>Wird geladen …</i></small>
+            {:else}
+              <EquipmentList features={equipmentFeatures} playgroundAttr={attr} />
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <!-- POI accordion -->
+      <div class="accordion-section">
+        <button class="accordion-toggle" onclick={() => toggleSection('pois')}>
+          <span class="bi {openSections.has('pois') ? 'bi-chevron-down' : 'bi-chevron-right'}"></span>
+          Umfeld
+        </button>
+        {#if openSections.has('pois')}
+          <div class="accordion-body">
+            {#if poisLoading}
+              <small class="text-muted"><i>Wird geladen …</i></small>
+            {:else}
+              <POIPanel {pois} {centerLat} {centerLon} />
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+    </div>
+  </aside>
+{/if}
+
+<style>
+  .info-panel {
+    position: absolute;
+    top: 0; left: 0;
+    width: 360px;
+    height: 100%;
+    background: #fff;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.15);
+    z-index: 100;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .info-panel__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 1rem;
+    border-bottom: 1px solid #dee2e6;
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 1;
+  }
+
+  .info-panel__body {
+    padding: 1rem;
+    flex: 1;
+  }
+
+  .completeness-badge {
+    display: inline-block;
+    font-size: 0.7rem;
+    padding: 1px 6px;
+    border-radius: 999px;
+    margin-top: 2px;
+  }
+  .completeness-badge--complete { background: #dcfce7; color: #166534; }
+  .completeness-badge--partial  { background: #fef9c3; color: #854d0e; }
+  .completeness-badge--missing  { background: #fee2e2; color: #991b1b; }
+
+  .accordion-section { margin-bottom: 0.5rem; }
+  .accordion-toggle {
+    background: none; border: none; padding: 0.25rem 0;
+    font-weight: 600; font-size: 0.85rem; color: #495057;
+    cursor: pointer; display: flex; align-items: center; gap: 0.35rem;
+    width: 100%;
+  }
+  .accordion-toggle:hover { color: #212529; }
+  .accordion-body { padding: 0.5rem 0 0.25rem 0.75rem; }
+
+  .mc-add-link { color: #6c757d; text-decoration: none; }
+  .mc-add-link:hover { color: #343a40; text-decoration: underline; }
+</style>

--- a/app/src/components/SearchBar.svelte
+++ b/app/src/components/SearchBar.svelte
@@ -1,0 +1,85 @@
+<script>
+  import { fromLonLat } from 'ol/proj';
+  import { mapStore } from '../stores/map.js';
+
+  /** Bounding box [minLon, minLat, maxLon, maxLat] to restrict Nominatim search. */
+  export let regionExtent = null;
+
+  let query = '';
+  let searching = false;
+  let message = '';
+
+  async function search() {
+    const q = query.trim();
+    if (!q) return;
+    searching = true;
+    message = '';
+    try {
+      let url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&addressdetails=1&limit=1`;
+      if (regionExtent) {
+        const [minLon, minLat, maxLon, maxLat] = regionExtent;
+        url += `&viewbox=${minLon},${minLat},${maxLon},${maxLat}`;
+      }
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`Nominatim error: ${res.status}`);
+      const results = await res.json();
+      if (!results.length) {
+        message = `Kein Ergebnis für „${q}"`;
+        return;
+      }
+      const result = results[0];
+      const coord = fromLonLat([parseFloat(result.lon), parseFloat(result.lat)]);
+      $mapStore?.getView().animate({ center: coord, zoom: 17 });
+
+      const suburb = result.address?.suburb;
+      const city = result.address?.city || result.address?.town || result.address?.village;
+      const hint = suburb ? `${suburb}, ${city ?? ''}` : city;
+      message = hint ? `${q} — ${hint}` : q;
+    } catch (err) {
+      console.error('Search failed:', err);
+      message = 'Suche fehlgeschlagen.';
+    } finally {
+      searching = false;
+    }
+  }
+
+  function onKeydown(e) {
+    if (e.key === 'Enter') search();
+  }
+</script>
+
+<div class="search-bar">
+  <div class="input-group input-group-sm">
+    <input
+      type="text"
+      class="form-control"
+      placeholder="Ort suchen …"
+      bind:value={query}
+      onkeydown={onKeydown}
+      disabled={searching}
+      aria-label="Ortssuche"
+    />
+    <button class="btn btn-outline-secondary" onclick={search} disabled={searching} aria-label="Suchen">
+      {#if searching}
+        <span class="spinner-border spinner-border-sm" role="status"></span>
+      {:else}
+        <span class="bi bi-search"></span>
+      {/if}
+    </button>
+  </div>
+  {#if message}
+    <div class="search-hint">{message}</div>
+  {/if}
+</div>
+
+<style>
+  .search-bar { width: 240px; }
+  .search-hint {
+    font-size: 0.7rem;
+    color: #6c757d;
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+</style>

--- a/app/src/lib/equipmentAttributes.js
+++ b/app/src/lib/equipmentAttributes.js
@@ -1,0 +1,195 @@
+// Generates an HTML detail string for a single equipment feature.
+// Ported from js/popup.js → getEquipmentAttributes / getEquipmentAttributesFromProps.
+
+import { objDevices, objFitnessStation } from './objPlaygroundEquipment.js';
+import { escapeHtml } from './utils.js';
+
+const objMaterial = {
+    wood:'Holz', metal:'Metall', steel:'Stahl', aluminium:'Aluminium',
+    plastic:'Kunststoff', stone:'Stein', sandstone:'Sandstein', concrete:'Beton',
+    brick:'Ziegelstein', granite:'Granit', rope:'Seil', rubber:'Gummi',
+    chain:'Kette', sand:'Sand',
+};
+
+const objPlaygroundTheme = {
+    animal:'Tier', bicycle:'Fahrrad', boat:'Boot', camel:'Kamel', car:'Auto',
+    carrot:'Karotte', castle:'Burg', construction:'Baustelle', dragon:'Drache',
+    duck:'Ente', dungeon:'Burgverlies', elephant:'Elefant', farm:'Farm',
+    fish:'Fisch', flower:'Blume', helicopter:'Hubschrauber', horse:'Pferd',
+    house:'Haus', ice_cream:'Eis', jungle:'Jungle', lama:'Lama',
+    lighthouse:'Leuchtturm', locomotive:'Lokomotive', mammoth:'Mammut',
+    mushroom:'Pilz', ocean:'Ozean', plane:'Flugzeug', rainbow:'Regenbogen',
+    rock:'Felsen', seal:'Robbe', sheep:'Schaf', ship:'Schiff', snake:'Schlange',
+    sport:'Sport', tent:'Zelt', tower:'Turm', train:'Eisenbahn', water:'Wasser',
+    whale:'Wal', windmill:'Windmühle',
+};
+
+const objStatus = {
+    ok:'OK', broken:'kaputt', missing_beam:'kaputt',
+    out_of_order:'außer Betrieb', locked:'verschlossen', blocked:'blockiert',
+};
+
+const objSport = {
+    'soccer;basketball':'Fußball, Basketball', 'basketball;soccer':'Fußball, Basketball',
+    athletics:'Leichtathletik', beachvolleyball:'Beachvolleyball', bmx:'BMX',
+    boules:'Boule', chess:'Schach', climbing:'Klettern', field_hockey:'Hockey',
+    fitness:'Fitness', gymnastics:'Gymnastik', multi:'verschiedene',
+    nine_mens_morris:'Mühle', running:'Laufsport', skateboard:'Skateboarding',
+    table_soccer:'Tischfußball', tennis:'Tennis', toboggan:'Rodeln',
+    volleyball:'Volleyball',
+};
+
+const objSurface = {
+    acrylic:'Acrylharz', artificial_turf:'Kunstrasen', asphalt:'Asphalt',
+    clay:'Asche', cobblestone:'Kopfsteinpflaster', compacted:'verdichtet',
+    concrete:'Beton', dirt:'Erde', earth:'Erde', fine_gravel:'Splitt',
+    grass:'Gras', gravel:'Schotter', ground:'Erde', metal:'Metall',
+    mud:'Schlamm', paved:'versiegelt', paving_stones:'Pflastersteine',
+    pebblestone:'Kies', plastic:'Kunststoff', rock:'Stein', rubber:'Gummi',
+    sand:'Sand', tartan:'Tartan', unpaved:'unversiegelt', wood:'Holz',
+    woodchips:'Holzhackschnitzel',
+};
+
+const objGenus = {
+    Abies:'Tanne', Acer:'Ahorn', Aesculus:'Rosskastanie', Betula:'Birke',
+    Carpinus:'Hainbuche', Castanea:'Kastanie', Catalpa:'Trompetenbaum',
+    Fagus:'Buche', Fraxinus:'Esche', Ginkgo:'Ginkgo', Juglans:'Walnuss',
+    Larix:'Lärche', Malus:'Apfel', Picea:'Fichte', Pinus:'Kiefer',
+    Platanus:'Platane', Populus:'Pappel', Prunus:'Kirsche', Quercus:'Eiche',
+    Robinia:'Robinie', Salix:'Weide', Sorbus:'Mehlbeere', Taxus:'Eibe',
+    Tilia:'Linde',
+};
+
+const pitchImages = {
+    soccer:'File:Association football pitch imperial.svg',
+    basketball:'File:Basketball court dimensions in meters.svg',
+    table_tennis:'File:Table tennis table blue.jpg',
+    volleyball:'File:Volleyball court with dimensions.svg',
+    tennis:'File:Hard tennis court 1.jpg',
+    handball:'File:Handball court metric.svg',
+    badminton:'File:Badminton court 8shuttle.svg',
+    hockey:'File:Field Hockey Pitch Dimensions.svg',
+    field_hockey:'File:Field Hockey Pitch Dimensions.svg',
+    boules:'File:Boules-coloured.jpg',
+    petanque:'File:Boules-coloured.jpg',
+    multi:'File:Multi-use games area.jpg',
+    skateboard:'File:Skatepark Vienna Praterstern 2015.jpg',
+    bmx:'File:BMX track Canberra.jpg',
+    athletics:'File:Athletics track.jpg',
+    beachvolleyball:'File:BeachvolleyballAthens04.jpg',
+    climbing:'File:Outdoor bouldering wall.jpg',
+};
+
+/**
+ * Returns an HTML string with detail attributes for a single equipment item.
+ * @param {Object} props - plain GeoJSON feature properties object
+ * @returns {string} HTML (may be empty string)
+ */
+export function getEquipmentAttributesFromProps(props) {
+    const g = key => props[key];
+    const content = [];
+
+    const theme = g('playground:theme');
+    if (theme && theme !== 'playground')
+        content.push(`Motiv: ${objPlaygroundTheme[theme] ?? escapeHtml(theme)}`);
+
+    if (g('capacity'))       content.push(`Plätze: ${escapeHtml(String(g('capacity')))}`);
+    if (g('capacity:baby'))  content.push(`Babyplätze: ${escapeHtml(String(g('capacity:baby')))}`);
+
+    for (const [tag, label] of [['height','Höhe'],['width','Breite']]) {
+        let v = g(tag);
+        if (v) {
+            v = v.replace(' ', '').toLowerCase();
+            if (v.includes('cm')) { v = v.replace('cm',''); if (!isNaN(v)) v = v / 100; }
+            content.push((`${label}: ${escapeHtml(String(v))}` + (!isNaN(v) ? ' Meter' : '')).replace('.', ','));
+        }
+    }
+    const len = g('length');
+    if (len) content.push(`Länge: ${escapeHtml(String(len).replace('.', ','))} Meter`);
+
+    const pump_status = g('pump:status');
+    if (pump_status) content.push(`Status: ${objStatus[pump_status] ?? escapeHtml(pump_status)}`);
+
+    const covered = g('covered');
+    if (covered === 'yes') content.push('überdacht');
+    else if (covered === 'no') content.push('nicht überdacht');
+
+    const material = g('material');
+    if (material) content.push(`Material: ${objMaterial[material] ?? escapeHtml(material)}`);
+
+    if (g('baby') === 'yes') content.push('für Babys geeignet');
+    if (g('provided_for:toddler') === 'yes') content.push('für Kleinkinder geeignet');
+
+    const wc = g('wheelchair');
+    if (wc === 'yes') content.push('Rollstuhlgerecht');
+    else if (wc === 'limited') content.push('Eingeschränkt rollstuhlgerecht');
+    else if (wc === 'no') content.push('Nicht rollstuhlgerecht');
+
+    if (g('blind') === 'yes') content.push('Für sehbehinderte Personen geeignet');
+
+    if (pump_status && g('check_date')) content.push(`Zuletzt überprüft: ${escapeHtml(g('check_date'))}`);
+
+    const backrest = g('backrest');
+    if (backrest === 'yes') content.push('mit Rückenlehne');
+    else if (backrest === 'no') content.push('ohne Rückenlehne');
+
+    const sport = g('sport');
+    if (sport && !['table_tennis','soccer','basketball'].includes(sport))
+        content.push(`Sportart: ${objSport[sport] ?? escapeHtml(sport)}`);
+
+    const surface = g('surface');
+    if (surface) content.push(`Oberflächenbelag: ${objSurface[surface] ?? escapeHtml(surface)}`);
+
+    const genus = g('genus');
+    if (genus) content.push(`Baumart: ${objGenus[genus] ?? escapeHtml(genus)}`);
+
+    const diameter_crown = g('diameter_crown');
+    if (diameter_crown) content.push(`Kronendurchmesser: ${escapeHtml(String(diameter_crown))} Meter`);
+
+    // Find Panoramax UUID on the device
+    let panoramaxUuid = g('panoramax') || g('panoramax:0');
+    for (let pi = 1; pi <= 9 && !panoramaxUuid; pi++) panoramaxUuid = g(`panoramax:${pi}`);
+
+    const leisure  = g('leisure');
+    const osmType  = ({ N:'node', W:'way', R:'relation' })[g('osm_type')] ?? 'node';
+    const osmId    = g('osm_id');
+    const mcTheme  = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
+    const mcUrl    = `https://mapcomplete.org/${mcTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
+    const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
+
+    let html = '';
+    if (panoramaxUuid) {
+        const thumbUrl  = `https://api.panoramax.xyz/api/pictures/${panoramaxUuid}/thumb.jpg`;
+        const viewUrl   = `https://api.panoramax.xyz/?pic=${panoramaxUuid}&nav=none&focus=pic`;
+        html += `<a href="${viewUrl}" target="_blank" rel="noopener">` +
+            `<img src="${thumbUrl}" alt="Straßenfoto" style="object-fit:cover;aspect-ratio:16/9;width:100%"></a>` +
+            `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-camera"></span> Foto dieses Geräts</p>`;
+    }
+    if (content.length) {
+        html += '<ul>' + content.map(c => `<li>${c}</li>`).join('') + '</ul>';
+    }
+
+    // Fallback image when no photo and no attributes
+    if (!html) {
+        const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
+        const deviceKey = g('playground');
+        const sportRaw  = g('sport');
+        if (deviceKey && objDevices[deviceKey]?.image) {
+            const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
+            html = `<div class="device-img-wrap">` +
+                `<img src="https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800"` +
+                ` data-fallback="https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}"` +
+                ` alt="${escapeHtml(objDevices[deviceKey].name_de)}" style="object-fit:contain;width:100%" onerror="${onerror}">` +
+                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p></div>`;
+        } else if (leisure === 'pitch' && sportRaw && pitchImages[sportRaw]) {
+            const imgFile = pitchImages[sportRaw].replace(/^File:/, '').replace(/ /g, '_');
+            html = `<div class="device-img-wrap">` +
+                `<img src="https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800"` +
+                ` data-fallback="https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}"` +
+                ` alt="${escapeHtml(sportRaw)}" style="object-fit:contain;width:100%" onerror="${onerror}"></div>`;
+        }
+    }
+
+    if (!panoramaxUuid) html += addPhotoLink;
+    return html;
+}

--- a/app/src/lib/playgroundHelpers.js
+++ b/app/src/lib/playgroundHelpers.js
@@ -1,0 +1,58 @@
+// Pure helper functions for playground display logic.
+// Ported from js/selectPlayground.js.
+
+/** Build a display title from OSM name tags. */
+export function getPlaygroundTitle(attr) {
+    const parts = [attr.name, attr.alt_name, attr.loc_name, attr.official_name, attr.old_name, attr.short_name]
+        .filter(Boolean);
+    if (!parts.length) return 'Spielplatz';
+    if (parts.length === 1) return parts[0];
+    return `${parts[0]} (${parts.slice(1).join(', ')})`;
+}
+
+/** Build a human-readable location hint from nearest_highway or in_site tags. */
+export function getPlaygroundLocation(attr) {
+    if (attr.in_site) return attr.in_site;
+    const highway = attr.nearest_highway;
+    if (!highway) return '';
+
+    const am = ['weg', 'platz', 'damm', 'ring', 'ufer', 'steg', 'steig', 'pfad',
+                 'gestell', 'park', 'garten', 'bogen'];
+    const an_der = ['straße', 'allee', 'chaussee', 'promenade', 'gasse', 'brücke',
+                    'zeile', 'achse', 'schleife', 'aue', 'insel'];
+    const h = highway.toLowerCase();
+
+    if (am.some(s => h.endsWith(s) || h.startsWith(s)) && !highway.startsWith('Am '))
+        return `am ${highway}`;
+    if (an_der.some(s => h.endsWith(s) || h.startsWith(s)) && !highway.startsWith('An der '))
+        return `an der ${highway}`;
+    return `in der Nähe von ${highway}`;
+}
+
+/** Haversine distance in metres between two WGS84 points. */
+export function haversineDistance(lat1, lon1, lat2, lon2) {
+    const R = 6371000;
+    const φ1 = lat1 * Math.PI / 180, φ2 = lat2 * Math.PI / 180;
+    const Δφ = (lat2 - lat1) * Math.PI / 180, Δλ = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** Format a distance in metres for display. */
+export function formatDistance(m) {
+    if (m < 1000) return `~${Math.round(m / 10) * 10} m`;
+    return `~${(m / 1000).toLocaleString('de', { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km`;
+}
+
+/** Bearing in degrees (0 = N, 90 = E) between two points. */
+export function bearingDeg(lat1, lon1, lat2, lon2) {
+    const φ1 = lat1 * Math.PI / 180, φ2 = lat2 * Math.PI / 180;
+    const Δλ = (lon2 - lon1) * Math.PI / 180;
+    const y = Math.sin(Δλ) * Math.cos(φ2);
+    const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+    return (Math.atan2(y, x) * 180 / Math.PI + 360) % 360;
+}
+
+export function bearingToDir(deg) {
+    return ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'][Math.round(deg / 45) % 8];
+}

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -3,33 +3,38 @@
   import 'bootstrap-icons/font/bootstrap-icons.css';
 
   import Map from '../components/Map.svelte';
-  import { selection } from '../stores/selection.js';
+  import PlaygroundPanel from '../components/PlaygroundPanel.svelte';
+  import SearchBar from '../components/SearchBar.svelte';
+  import LocateButton from '../components/LocateButton.svelte';
   import { apiBaseUrl } from '../lib/config.js';
+  import { mapStore } from '../stores/map.js';
+  import { transformExtent } from 'ol/proj';
+
+  // Expose the current map extent in WGS84 to constrain Nominatim search.
+  let regionExtent = null;
+  $: if ($mapStore) {
+    const updateExtent = () => {
+      const size = $mapStore.getSize();
+      if (!size) return;
+      const ext = $mapStore.getView().calculateExtent(size);
+      regionExtent = transformExtent(ext, 'EPSG:3857', 'EPSG:4326');
+    };
+    $mapStore.on('moveend', updateExtent);
+    updateExtent();
+  }
 </script>
 
 <div class="app-root">
   <Map defaultBackendUrl={apiBaseUrl} />
 
-  {#if $selection.feature}
-    <aside class="info-panel">
-      <div class="info-panel__header">
-        <strong>{$selection.feature.get('name') ?? 'Spielplatz'}</strong>
-        <button
-          class="btn-close"
-          aria-label="Schließen"
-          onclick={() => selection.clear()}
-        ></button>
-      </div>
-      <div class="info-panel__body">
-        <!-- PlaygroundPanel component will be added in PR 3 -->
-        <p class="text-muted small">Detailansicht folgt in PR 3.</p>
-        <dl class="row small">
-          <dt class="col-5">OSM ID</dt>
-          <dd class="col-7">{$selection.feature.get('osm_id')}</dd>
-        </dl>
-      </div>
-    </aside>
-  {/if}
+  <!-- Toolbar: search + locate -->
+  <div class="map-toolbar">
+    <SearchBar {regionExtent} />
+    <LocateButton />
+  </div>
+
+  <!-- Full detail panel (manages its own visibility via selection store) -->
+  <PlaygroundPanel />
 </div>
 
 <style>
@@ -40,31 +45,19 @@
     overflow: hidden;
   }
 
-  .info-panel {
+  .map-toolbar {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 360px;
-    height: 100%;
-    background: #fff;
-    box-shadow: 2px 0 8px rgba(0,0,0,0.15);
-    z-index: 100;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .info-panel__header {
+    top: 0.75rem;
+    left: 50%;
+    transform: translateX(-50%);
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    padding: 1rem;
-    border-bottom: 1px solid #dee2e6;
-    font-size: 1rem;
-  }
-
-  .info-panel__body {
-    padding: 1rem;
-    flex: 1;
+    gap: 0.5rem;
+    z-index: 100;
+    background: rgba(255,255,255,0.92);
+    backdrop-filter: blur(4px);
+    padding: 0.35rem 0.5rem;
+    border-radius: 0.4rem;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.18);
   }
 </style>


### PR DESCRIPTION
## Summary

- **PlaygroundPanel**: full detail panel driven by the `selection` store — completeness badge, name, location, description, area, surface, trees, access/age, opening hours (via `opening_hours.js`), operator with optional Wikidata link, contact (phone/email), MapComplete edit link. Accordion sections for Ausstattung and Umfeld; ESC closes.
- **EquipmentList**: collapsible per-device rows for `playground=*`, `leisure=fitness_station`, `leisure=pitch`; falls back to `playground:<key>` tags on the polygon. Pure Svelte toggle state — no Bootstrap Collapse.
- **POIPanel**: toilets, bus stops, ice cream, shopping, drugstore, emergency within `poiRadiusM`; haversine distance, direction hint for bus stops, `geo:` deep link and OSM foot-routing link.
- **SearchBar**: Nominatim constrained to current map extent; animates map to result.
- **LocateButton**: Geolocation API, flies to user position.
- **`playgroundHelpers.js`**: pure functions ported from `selectPlayground.js` (`getPlaygroundTitle`, `getPlaygroundLocation`, haversine, bearing).
- **`equipmentAttributes.js`**: `getEquipmentAttributesFromProps` ported from `popup.js` — generates HTML detail string per equipment item including fallback Wikimedia images.

All 40+ DOM ID couplings from the legacy `selectPlayground.js` (1573 lines) are replaced with reactive Svelte state.

## Test plan

- [ ] `make app-dev` → open `http://localhost:5173` (needs running stack for API data, or Overpass fallback)
- [ ] Click a playground → detail panel opens with completeness badge, name, all fields
- [ ] Accordion toggles for Ausstattung and Umfeld work
- [ ] Equipment list shows individual devices with collapsible details
- [ ] POI section shows nearby toilets / bus stops with distance
- [ ] ESC closes the panel
- [ ] URL hash updates to `#W<osmId>` on selection; reload restores selection
- [ ] Search box finds a location and flies the map there
- [ ] Locate button flies to GPS position
- [ ] `make app-build` passes with no errors or a11y warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)