### PR TITLE
feat: hub mode — registry loader, InstancePanel, wired HubApp

### DIFF
--- a/app/public/registry.json
+++ b/app/public/registry.json
@@ -1,0 +1,8 @@
+{
+  "instances": [
+    {
+      "url": "https://spielplatzkarte.example.com/api",
+      "name": "Beispiel-Region"
+    }
+  ]
+}

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -2,42 +2,28 @@
   import 'bootstrap/dist/css/bootstrap.min.css';
   import 'bootstrap-icons/font/bootstrap-icons.css';
 
-  import Map from '../components/Map.svelte';
-  import { selection } from '../stores/selection.js';
   import VectorSource from 'ol/source/Vector.js';
 
-  // Shared playground source populated by registry.js (added in PR 5)
+  import Map from '../components/Map.svelte';
+  import PlaygroundPanel from '../components/PlaygroundPanel.svelte';
+  import InstancePanel from './InstancePanel.svelte';
+  import { createRegistry } from './registry.js';
+  import { selection } from '../stores/selection.js';
+
   const sharedSource = new VectorSource();
+  const { backends, registryError } = createRegistry(sharedSource);
 </script>
 
 <div class="app-root">
+  <!-- Map fills the viewport; hub supplies the shared playground source -->
   <Map playgroundSource={sharedSource} />
 
-  <aside class="instance-panel">
-    <h6 class="instance-panel__title">
-      <i class="bi bi-map me-1"></i> Spielplatzkarte Hub
-    </h6>
-    <!-- InstancePanel component will be added in PR 5 -->
-    <p class="text-muted small px-2">
-      Instanzen werden in PR 5 geladen.
-    </p>
-  </aside>
+  <!-- Backend status sidebar (top-right) -->
+  <InstancePanel {backends} {registryError} />
 
+  <!-- Detail panel (left) — same component as standalone, uses per-backend URL -->
   {#if $selection.feature}
-    <aside class="info-panel">
-      <div class="info-panel__header">
-        <strong>{$selection.feature.get('name') ?? 'Spielplatz'}</strong>
-        <button
-          class="btn-close"
-          aria-label="Schließen"
-          onclick={() => selection.clear()}
-        ></button>
-      </div>
-      <div class="info-panel__body">
-        <!-- PlaygroundPanel (shared with standalone) will be wired in PR 5 -->
-        <p class="text-muted small">Quelle: {$selection.backendUrl}</p>
-      </div>
-    </aside>
+    <PlaygroundPanel />
   {/if}
 </div>
 
@@ -47,55 +33,5 @@
     width: 100vw;
     height: 100vh;
     overflow: hidden;
-  }
-
-  .instance-panel {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    width: 280px;
-    max-height: calc(100vh - 2rem);
-    background: #fff;
-    border-radius: 0.5rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-    z-index: 100;
-    overflow-y: auto;
-    padding: 0.75rem 0;
-  }
-
-  .instance-panel__title {
-    padding: 0 0.75rem 0.5rem;
-    border-bottom: 1px solid #dee2e6;
-    margin-bottom: 0.5rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: #495057;
-  }
-
-  .info-panel {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 360px;
-    height: 100%;
-    background: #fff;
-    box-shadow: 2px 0 8px rgba(0,0,0,0.15);
-    z-index: 100;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .info-panel__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1rem;
-    border-bottom: 1px solid #dee2e6;
-  }
-
-  .info-panel__body {
-    padding: 1rem;
-    flex: 1;
   }
 </style>

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -1,0 +1,120 @@
+<script>
+  /** @type {import('svelte/store').Readable<Array>} */
+  export let backends;
+  /** @type {import('svelte/store').Readable<string|null>} */
+  export let registryError;
+</script>
+
+<aside class="instance-panel">
+  <h6 class="instance-panel__title">
+    <i class="bi bi-map me-1"></i> Spielplatzkarte Hub
+  </h6>
+
+  {#if $registryError}
+    <p class="text-danger small px-2 mb-0">
+      <i class="bi bi-exclamation-triangle-fill me-1"></i>
+      Registry nicht erreichbar
+    </p>
+  {:else if $backends.length === 0}
+    <p class="text-muted small px-2 mb-0">
+      <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+      Instanzen werden geladen …
+    </p>
+  {:else}
+    <ul class="instance-list">
+      {#each $backends as b (b.url)}
+        <li class="instance-item">
+          <div class="instance-row">
+            <span class="instance-name">{b.name}</span>
+            {#if b.version}
+              <span class="badge instance-badge text-bg-secondary">{b.version}</span>
+            {/if}
+          </div>
+
+          {#if b.loading}
+            <div class="instance-status text-muted">
+              <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+              Wird geladen …
+            </div>
+          {:else if b.error}
+            <div class="instance-status text-danger">
+              <i class="bi bi-exclamation-triangle-fill me-1"></i>
+              Nicht erreichbar
+            </div>
+          {:else}
+            <div class="instance-status text-muted">
+              <i class="bi bi-geo-alt-fill me-1"></i>
+              {b.featureCount} Spielplätze
+            </div>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</aside>
+
+<style>
+  .instance-panel {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 240px;
+    max-height: calc(100vh - 2rem);
+    background: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    z-index: 100;
+    overflow-y: auto;
+    padding: 0.75rem 0;
+  }
+
+  .instance-panel__title {
+    padding: 0 0.75rem 0.5rem;
+    border-bottom: 1px solid #dee2e6;
+    margin-bottom: 0.4rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #495057;
+  }
+
+  .instance-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .instance-item {
+    padding: 0.35rem 0.75rem;
+    border-bottom: 1px solid #f1f3f5;
+    font-size: 0.8rem;
+  }
+
+  .instance-item:last-child {
+    border-bottom: none;
+  }
+
+  .instance-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.1rem;
+  }
+
+  .instance-name {
+    font-weight: 500;
+    color: #212529;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .instance-badge {
+    font-size: 0.65rem;
+    flex-shrink: 0;
+  }
+
+  .instance-status {
+    font-size: 0.75rem;
+  }
+</style>

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -1,0 +1,139 @@
+// Hub registry — loads the registry JSON, fetches playgrounds from each
+// backend in parallel, populates a shared OL VectorSource, and periodically
+// refreshes. Returns a Svelte readable store with per-backend status objects.
+
+import { readable, writable } from 'svelte/store';
+import GeoJSON from 'ol/format/GeoJSON.js';
+import { registryUrl, hubPollInterval } from '../lib/config.js';
+import { fetchMeta } from '../lib/api.js';
+
+const geojsonFormat = new GeoJSON();
+
+/**
+ * Backend status shape:
+ * {
+ *   url: string,
+ *   name: string,
+ *   loading: boolean,
+ *   error: string | null,
+ *   featureCount: number,
+ *   version: string | null,
+ *   region: string | null,
+ * }
+ */
+
+/**
+ * Creates a registry that loads backend status into a Svelte readable store
+ * and populates `vectorSource` with playground features (tagged with `_backendUrl`).
+ *
+ * @param {import('ol/source/Vector.js').default} vectorSource
+ * @returns {import('svelte/store').Readable<Array>}
+ */
+/**
+ * @returns {{ backends: import('svelte/store').Readable<Array>, registryError: import('svelte/store').Readable<string|null> }}
+ */
+export function createRegistry(vectorSource) {
+  let backends = [];
+  let pollTimer = null;
+  const registryError = writable(null);
+
+  const store = readable([], (set) => {
+    function notify() {
+      set([...backends]);
+    }
+
+    async function loadBackend(backend) {
+      backend.loading = true;
+      backend.error = null;
+      notify();
+
+      try {
+        const [meta, geojson] = await Promise.all([
+          fetchMeta(backend.url).catch(() => null),
+          fetchPlaygroundsHub(backend.url),
+        ]);
+
+        if (meta) {
+          backend.version = meta.version ?? null;
+          backend.region  = meta.name    ?? null;
+          if (!backend.name && backend.region) backend.name = backend.region;
+        }
+
+        // Parse first — only touch the map if parsing succeeds
+        const features = geojsonFormat.readFeatures(geojson, {
+          dataProjection:    'EPSG:4326',
+          featureProjection: 'EPSG:3857',
+        });
+        features.forEach(f => f.set('_backendUrl', backend.url));
+
+        // Atomic swap: remove stale then add new in the same JS turn
+        const stale = vectorSource.getFeatures().filter(f => f.get('_backendUrl') === backend.url);
+        if (stale.length) vectorSource.removeFeatures(stale);
+        vectorSource.addFeatures(features);
+
+        backend.featureCount = features.length;
+        backend.loading      = false;
+      } catch (err) {
+        backend.error   = err.message;
+        backend.loading = false;
+      }
+
+      notify();
+    }
+
+    async function loadAll() {
+      try {
+        const res = await fetch(registryUrl);
+        if (!res.ok) throw new Error(`Registry fetch failed: ${res.status}`);
+        const data = await res.json();
+
+        registryError.set(null);
+
+        // Support both { instances: [...] } and bare array formats
+        const entries = Array.isArray(data) ? data : (data.instances ?? []);
+        backends = entries.map(entry => ({
+          url:          entry.url,
+          name:         entry.name || entry.url,
+          loading:      true,
+          error:        null,
+          featureCount: 0,
+          version:      null,
+          region:       null,
+        }));
+        notify();
+
+        await Promise.all(backends.map(b => loadBackend(b)));
+      } catch (err) {
+        console.error('[registry] load failed:', err);
+        registryError.set(err.message);
+      }
+
+      schedulePoll();
+    }
+
+    function schedulePoll() {
+      if (pollTimer) clearTimeout(pollTimer);
+      pollTimer = setTimeout(async () => {
+        // Re-fetch each backend (registry list stays fixed between page loads)
+        await Promise.all(backends.map(b => loadBackend(b)));
+        schedulePoll();
+      }, hubPollInterval * 1000);
+    }
+
+    loadAll();
+
+    return () => {
+      if (pollTimer) clearTimeout(pollTimer);
+    };
+  });
+
+  return { backends: store, registryError };
+}
+
+/** Fetches all playgrounds from a backend without passing a relation_id —
+ *  the backend uses its own configured default. */
+async function fetchPlaygroundsHub(baseUrl) {
+  const res = await fetch(`${baseUrl}/rpc/get_playgrounds`);
+  if (res.ok) return res.json();
+  throw new Error(`get_playgrounds failed: ${res.status}`);
+}

--- a/oci/app/docker-entrypoint.sh
+++ b/oci/app/docker-entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$APP_MODE" = "hub" ]; then
 window.APP_CONFIG = {
   appMode:           'hub',
   registryUrl:       '${SAFE_REGISTRY_URL}',
-  hubPollInterval:   ${HUB_POLL_INTERVAL:-300000},
+  hubPollInterval:   ${HUB_POLL_INTERVAL:-300},
   mapZoom:           ${MAP_ZOOM:-6},
   mapMinZoom:        ${MAP_MIN_ZOOM:-4},
   parentOrigin:      '${SAFE_PARENT_ORIGIN}'


### PR DESCRIPTION
## Summary

- **`registry.js`** — loads the registry JSON, fetches each backend's playgrounds in parallel (no `relation_id` — each backend uses its own default), replaces stale OL features on refresh, and exposes a Svelte readable store of per-backend status objects
- **`InstancePanel.svelte`** — shows name, version badge, playground count, and error/loading state per backend
- **`HubApp.svelte`** — rewritten to wire `Map` (shared `VectorSource`), `InstancePanel`, and the existing `PlaygroundPanel` (which already resolves `backendUrl` from the selection store, so hub mode gets the correct PostgREST endpoint per click)
- **`app/public/registry.json`** — example registry for local hub-mode dev (`APP_MODE=hub` in `app/public/config.js`)
- **`oci/app/docker-entrypoint.sh`** — fix `hubPollInterval` default (`300000 ms` → `300 s`, matching `config.js`)

## Architecture notes

Features loaded from each backend are tagged with `_backendUrl` on the OL feature. The `Map` click handler already reads this property (`hit.get('_backendUrl') ?? defaultBackendUrl`) and stores it in the selection store. `PlaygroundPanel` reads `backendUrl` from the selection store, so all API calls (equipment, POIs, trees) go to the correct backend — no changes needed there.

## Test plan

- [ ] `APP_MODE=hub` in `app/public/config.js` → Vite dev server shows hub shell with `InstancePanel`
- [ ] Add a live backend URL to `app/public/registry.json` → playgrounds load on map
- [ ] Click a playground → `PlaygroundPanel` opens with equipment from that backend
- [ ] `APP_MODE=standalone` unchanged — regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)