### PR TITLE
test: rewrite E2E tests for Svelte app

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install app dependencies
+        run: npm --prefix app ci
+
       - name: Cache Playwright browsers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: playwright-cache

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -20,7 +20,9 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run build && npm run serve',
+    // Build and serve the Svelte app in app/. Requires app/ deps to be installed
+    // (npm --prefix app ci). CI handles this via a dedicated step in e2e.yml.
+    command: 'npm --prefix app run build && npm --prefix app run serve',
     url: 'http://localhost:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/tests/hash-restore.spec.js
+++ b/tests/hash-restore.spec.js
@@ -1,25 +1,14 @@
 import { test, expect } from '@playwright/test';
+import { injectApiConfig, stubApiRoutes } from './helpers.js';
 import fixture from './fixtures/playground.json' assert { type: 'json' };
 
 const OSM_ID = fixture.features[0].properties.osm_id;
-const OSM_TYPE = fixture.features[0].properties.osm_type;
 
 test.describe('URL hash restore', () => {
   test('loading with a hash opens the info panel for that playground', async ({ page }) => {
-    await page.route('**/rpc/get_playgrounds**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fixture) })
-    );
-    await page.route('**/rpc/get_equipment**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-    );
-    await page.route('**/rpc/get_trees**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-    );
-    await page.route('**/rpc/get_pois**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
-    );
-
-    await page.goto(`/#${OSM_TYPE}${OSM_ID}`);
-    await expect(page.locator('#info.panel-open')).toBeVisible({ timeout: 8000 });
+    await injectApiConfig(page);
+    await stubApiRoutes(page);
+    await page.goto(`/#W${OSM_ID}`);
+    await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
   });
 });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,46 @@
+// Shared test utilities for the Spielplatzkarte Svelte app.
+
+import fixture from './fixtures/playground.json' assert { type: 'json' };
+
+/**
+ * Intercept the runtime config.js so the app uses PostgREST mode (non-empty
+ * apiBaseUrl) instead of the Overpass fallback. Call before page.goto().
+ */
+export async function injectApiConfig(page) {
+  await page.route('**/config.js', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/javascript',
+      body: `window.APP_CONFIG = ${JSON.stringify({
+        appMode: 'standalone',
+        osmRelationId: 62700,
+        mapZoom: 12,
+        mapMinZoom: 10,
+        poiRadiusM: 5000,
+        apiBaseUrl: '/api',
+        parentOrigin: '',
+        registryUrl: './registry.json',
+        hubPollInterval: 300,
+      })};`,
+    })
+  );
+}
+
+/**
+ * Stub the four PostgREST endpoints used by the standalone app.
+ * Call before page.goto().
+ */
+export async function stubApiRoutes(page, playgrounds = fixture) {
+  await page.route('**/rpc/get_playgrounds**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(playgrounds) })
+  );
+  await page.route('**/rpc/get_equipment**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
+  );
+  await page.route('**/rpc/get_trees**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
+  );
+  await page.route('**/rpc/get_pois**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+}

--- a/tests/selection.spec.js
+++ b/tests/selection.spec.js
@@ -1,43 +1,33 @@
 import { test, expect } from '@playwright/test';
+import { injectApiConfig, stubApiRoutes } from './helpers.js';
 import fixture from './fixtures/playground.json' assert { type: 'json' };
 
 const OSM_ID = fixture.features[0].properties.osm_id;
-const OSM_TYPE = fixture.features[0].properties.osm_type;
 
-// Load the page with the fixture playground pre-selected via URL hash.
-// This avoids the need to click a specific pixel on the map canvas.
+// Navigate with the fixture playground pre-selected via URL hash and wait for
+// the panel. Using hash restore avoids the need to click a specific canvas pixel.
 async function loadWithSelection(page) {
-  await page.route('**/rpc/get_playgrounds**', route =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fixture) })
-  );
-  await page.route('**/rpc/get_equipment**', route =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-  );
-  await page.route('**/rpc/get_trees**', route =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-  );
-  await page.route('**/rpc/get_pois**', route =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
-  );
-  await page.goto(`/#${OSM_TYPE}${OSM_ID}`);
-  await expect(page.locator('#info.panel-open')).toBeVisible({ timeout: 8000 });
+  await injectApiConfig(page);
+  await stubApiRoutes(page);
+  await page.goto(`/#W${OSM_ID}`);
+  await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
 }
 
 test.describe('Playground selection', () => {
   test('info panel opens when playground is pre-selected via URL hash', async ({ page }) => {
     await loadWithSelection(page);
-    await expect(page.locator('#info.panel-open')).toBeVisible();
+    await expect(page.locator('aside.info-panel')).toBeVisible();
   });
 
   test('URL hash is set after selection', async ({ page }) => {
     await loadWithSelection(page);
-    await expect(page).toHaveURL(new RegExp(`#${OSM_TYPE}${OSM_ID}`));
+    await expect(page).toHaveURL(new RegExp(`#W${OSM_ID}`));
   });
 
   test('ESC key hides the info panel', async ({ page }) => {
     await loadWithSelection(page);
     await page.keyboard.press('Escape');
-    await expect(page.locator('#info.panel-open')).toBeHidden();
+    await expect(page.locator('aside.info-panel')).toBeHidden();
   });
 
   test('ESC key clears the URL hash', async ({ page }) => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,23 +1,18 @@
 import { test, expect } from '@playwright/test';
-
-// Stub Nominatim so the region name is deterministic regardless of CI environment.
-const NOMINATIM_STUB = [{ name: 'Spielplatzkarte', boundingbox: ['51.0', '52.0', '9.0', '10.0'] }];
-
-async function stubNominatim(page) {
-  await page.route('**/nominatim.openstreetmap.org/**', route =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(NOMINATIM_STUB) })
-  );
-}
+import { injectApiConfig, stubApiRoutes } from './helpers.js';
 
 test.describe('Smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectApiConfig(page);
+    await stubApiRoutes(page);
+  });
+
   test('map canvas is visible', async ({ page }) => {
-    await stubNominatim(page);
     await page.goto('/');
     await expect(page.locator('canvas')).toBeVisible();
   });
 
   test('page title contains Spielplatzkarte', async ({ page }) => {
-    await stubNominatim(page);
     await page.goto('/');
     await expect(page).toHaveTitle(/Spielplatzkarte/);
   });

--- a/tests/xss.spec.js
+++ b/tests/xss.spec.js
@@ -1,51 +1,39 @@
 import { test, expect } from '@playwright/test';
+import { injectApiConfig, stubApiRoutes } from './helpers.js';
 import fixture from './fixtures/playground.json' assert { type: 'json' };
 
 const OSM_ID = fixture.features[0].properties.osm_id;
-const OSM_TYPE = fixture.features[0].properties.osm_type;
 
 test.describe('XSS escaping', () => {
   test.beforeEach(async ({ page }) => {
     // Expose probe before navigation so any injected script execution is caught.
     await page.exposeFunction('__xssProbe', () => {});
-
-    await page.route('**/rpc/get_playgrounds**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fixture) })
-    );
-    await page.route('**/rpc/get_equipment**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-    );
-    await page.route('**/rpc/get_trees**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })
-    );
-    await page.route('**/rpc/get_pois**', route =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
-    );
-
-    await page.goto(`/#${OSM_TYPE}${OSM_ID}`);
-    await expect(page.locator('#info.panel-open')).toBeVisible({ timeout: 8000 });
+    await injectApiConfig(page);
+    await stubApiRoutes(page);
+    await page.goto(`/#W${OSM_ID}`);
+    await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
   });
 
   test('playground name with HTML characters is displayed as plain text', async ({ page }) => {
-    const nameEl = page.locator('#info-name');
+    const nameEl = page.locator('.info-panel__header .fw-semibold');
     await expect(nameEl).toBeVisible();
-    // The raw name contains <script>, < > & — they must appear as literal characters, not tags
     const text = await nameEl.textContent();
+    // Raw name contains <script>, < > & — must appear as literal characters, not tags.
     expect(text).toContain("<script>alert('xss')</script>");
     expect(text).toContain('<XSS & Friends>');
-    // No child elements should have been injected by the name
+    // No child elements should have been injected by the name.
     const childCount = await nameEl.evaluate(el => el.children.length);
     expect(childCount).toBe(0);
   });
 
   test('description with <script> tag does not execute and is shown as text', async ({ page }) => {
     const probeCallCount = await page.evaluate(() =>
-      typeof window.__xssProbe === 'function'
-        ? window.__xssProbe.__callCount ?? 0
-        : 0
+      typeof window.__xssProbe === 'function' ? window.__xssProbe.__callCount ?? 0 : 0
     );
 
-    const descEl = page.locator('#info-description');
+    // Description paragraphs use p.small without the text-muted class (which
+    // is reserved for the location line above them).
+    const descEl = page.locator('.info-panel__body p.small:not(.text-muted)').first();
     await expect(descEl).toBeVisible();
     const text = await descEl.textContent();
     expect(text).toContain("<script>alert('xss')</script>");
@@ -53,7 +41,8 @@ test.describe('XSS escaping', () => {
   });
 
   test('operator with & is displayed as plain text', async ({ page }) => {
-    const operatorEl = page.locator('#info-operator');
+    // Operator is rendered in a <dd> adjacent to <dt>Betreiber</dt>.
+    const operatorEl = page.locator('dt.col-5:has-text("Betreiber") + dd.col-7');
     await expect(operatorEl).toBeVisible();
     const text = await operatorEl.textContent();
     expect(text).toContain('Bezirksamt Mitte & Co.');


### PR DESCRIPTION
## Summary

- **`playwright.config.js`** — `webServer` now builds and serves `app/` (`npm --prefix app run build/serve`) instead of the legacy root Vite app
- **`e2e.yml`** — adds an _Install app dependencies_ step (`npm --prefix app ci`) so the webServer command finds `app/node_modules` at build time
- **`tests/helpers.js`** (new) — shared `injectApiConfig` (intercepts `config.js` to force PostgREST mode so route mocks work) and `stubApiRoutes` helpers
- **`tests/smoke.spec.js`** — wire helpers; no selector changes needed
- **`tests/hash-restore.spec.js`** — `#info.panel-open` → `aside.info-panel`; hardcoded `#W` prefix (Map.svelte only restores `#W<digits>` hashes)
- **`tests/selection.spec.js`** — same selector update; dropped `OSM_TYPE` variable
- **`tests/xss.spec.js`** — `#info-name` → `.info-panel__header .fw-semibold`, `#info-description` → `p.small:not(.text-muted)` (excludes location line), `#info-operator` → `dt:has-text("Betreiber") + dd`

Resolves deferred item D2 from the `ci/new-image-pipeline` code review.

## Test plan

- [x] `npx playwright test` — 10/10 pass locally against Svelte app build
- [ ] PR CI run: Playwright job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)