### PR TITLE
refactor: Makefile targets point at Svelte app; drop legacy frontend targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,10 @@ jobs:
           cache-dependency-path: app/package-lock.json
 
       - name: Install dependencies
-        run: make app-install
+        run: make install
 
       - name: Build
-        run: make app-build
+        run: make build
 
   # ── Docker images (matrix: app + data-node) ──────────────────────────────────
   docker:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,12 @@ Spielplatzkarte is an interactive web map for exploring playgrounds based on Ope
 All common operations are available via `make`. Run `make help` to list targets.
 
 ```bash
-make install      # npm ci
+make install      # npm ci (root) + npm --prefix app ci — installs all deps
 make dev          # Vite dev server at http://localhost:5173 (hot-reload)
-make build        # Production build → dist/
+make build        # Production build → app/dist/
 make serve        # Preview production build locally
+make test         # Run Playwright E2E tests
 ```
-
-No test framework is configured.
 
 ## Docker Compose stack
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .PHONY: install dev build serve test \
-        app-install app-dev app-build app-serve app-test \
         up down import docker-build db-apply db-shell \
         require-npm require-docker installer lan-url help
 
@@ -20,39 +19,23 @@ require-docker:
 	@docker info >/dev/null 2>&1 || \
 	  { printf '\033[31merror:\033[0m docker daemon is not running\n' >&2; exit 1; }
 
-## ── Frontend (legacy — root-level Vite app) ───────────────────────────────────
+## ── Frontend (Svelte app in app/) ─────────────────────────────────────────────
 
-install: require-npm      ## Install Node dependencies (legacy app)
+install: require-npm      ## Install Node dependencies (Svelte app + E2E test runner)
 	npm ci
+	npm --prefix app ci
 
-dev: require-npm          ## Start Vite dev server for legacy app (localhost:5173)
-	npm start
-
-build: require-npm        ## Production build for legacy app → dist/
-	npm run build
-
-serve: require-npm        ## Preview legacy production build locally
-	npm run serve
-
-test: require-npm         ## Run Playwright tests against legacy production build
-	npm test
-
-## ── Frontend (new Svelte app in app/) ─────────────────────────────────────────
-
-app-install: require-npm  ## Install Node dependencies for the new Svelte app
-	npm ci --prefix app
-
-app-dev: require-npm      ## Start Vite dev server for new Svelte app (localhost:5173)
+dev: require-npm          ## Start Vite dev server (localhost:5173, hot-reload)
 	npm run dev --prefix app
 
-app-build: require-npm    ## Production build for new Svelte app → app/dist/
+build: require-npm        ## Production build → app/dist/
 	npm run build --prefix app
 
-app-serve: require-npm    ## Preview new Svelte production build locally
+serve: require-npm        ## Preview production build locally
 	npm run serve --prefix app
 
-app-test: require-npm     ## Run Playwright tests for new Svelte app
-	npm test --prefix app
+test: require-npm         ## Run Playwright E2E tests
+	npm test
 
 ## ── Docker Compose stack ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **`install`** — now runs `npm ci` (root, for Playwright) then `npm --prefix app ci` (Svelte app deps)
- **`dev` / `build` / `serve`** — point at `app/` instead of the legacy root Vite app
- **`test`** — runs `npm test` from root (`playwright.config.js` lives at root)
- Legacy `app-*` prefixed targets removed; the canonical names now refer to the Svelte app
- **`build.yml`** — `make app-install` / `make app-build` → `make install` / `make build`
- **`CLAUDE.md`** — development commands section updated to reflect new target behaviour

## Test plan

- [ ] PR CI: `build-app` job passes (`make install && make build` succeeds)
- [ ] PR CI: Playwright job passes
- [ ] `make help` shows clean target list with no legacy entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)