### PR TITLE
fix: review patches — XSS surface, cache key, stale dep, data-testid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: app/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
 
       - name: Install dependencies
         run: make install

--- a/app/package.json
+++ b/app/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview",
-    "test": "playwright test"
+    "serve": "vite preview"
   },
   "dependencies": {
     "bootstrap": "^5.3.3",
@@ -19,7 +18,6 @@
     "svelte": "^5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "vite": "^6.0.0"
   }

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -8,7 +8,6 @@
   import { playgroundCompleteness } from '../lib/completeness.js';
   import { poiRadiusM } from '../lib/config.js';
   import { getPlaygroundTitle, getPlaygroundLocation } from '../lib/playgroundHelpers.js';
-  import { escapeHtml } from '../lib/utils.js';
   import EquipmentList from './EquipmentList.svelte';
   import POIPanel from './POIPanel.svelte';
   import PanoramaxViewer from './PanoramaxViewer.svelte';
@@ -95,7 +94,10 @@
   $: completeness = attr ? COMPLETENESS[playgroundCompleteness(attr)] : null;
 
   // ── Opening hours ─────────────────────────────────────────────────────────
-  function formatOpeningHours(ohStr) {
+  // Returns { color, label, suffix, error } so the template can render without
+  // {@html}. label includes the ● bullet; suffix is trailing plain text (e.g.
+  // "· Öffnet morgen um 09:00") rendered outside the coloured span.
+  function openingHoursState(ohStr) {
     const fmt = d => d.toLocaleTimeString('de', { hour: '2-digit', minute: '2-digit' });
     const dayLabel = (d, now) => {
       if (d.toDateString() === now.toDateString()) return 'heute';
@@ -110,15 +112,15 @@
       const now = new Date();
       const isOpen = oh.getState(now);
       const next = oh.getNextChange(now);
-      if (ohStr.trim() === '24/7') return `<span style="color:#16a34a">● Immer geöffnet</span>`;
+      if (ohStr.trim() === '24/7') return { color: '#16a34a', label: '● Immer geöffnet', suffix: null, error: false };
       if (isOpen) {
-        const label = next ? `Geöffnet bis ${fmt(next)}` : 'Geöffnet';
-        return `<span style="color:#16a34a">● ${label}</span>`;
+        const label = next ? `● Geöffnet bis ${fmt(next)}` : '● Geöffnet';
+        return { color: '#16a34a', label, suffix: null, error: false };
       }
-      if (next) return `<span style="color:#dc2626">● Geschlossen</span> · Öffnet ${dayLabel(next, now)} um ${fmt(next)}`;
-      return `<span style="color:#dc2626">● Geschlossen</span>`;
+      const suffix = next ? ` · Öffnet ${dayLabel(next, now)} um ${fmt(next)}` : null;
+      return { color: '#dc2626', label: '● Geschlossen', suffix, error: false };
     } catch {
-      return `<code style="font-size:smaller">${escapeHtml(ohStr)}</code>`;
+      return { color: null, label: ohStr, suffix: null, error: true };
     }
   }
 
@@ -229,13 +231,20 @@
         {/if}
 
         {#if attr.opening_hours}
+          {@const oh = openingHoursState(attr.opening_hours)}
           <dt class="col-5">Öffnungszeiten</dt>
-          <dd class="col-7">{@html formatOpeningHours(attr.opening_hours)}</dd>
+          <dd class="col-7">
+            {#if oh.error}
+              <code style="font-size:smaller">{oh.label}</code>
+            {:else}
+              <span style:color={oh.color}>{oh.label}</span>{oh.suffix ?? ''}
+            {/if}
+          </dd>
         {/if}
 
         {#if attr.operator}
           <dt class="col-5">Betreiber</dt>
-          <dd class="col-7">
+          <dd class="col-7" data-testid="operator-value">
             {#if attr['operator:wikidata']}
               <a href="https://www.wikidata.org/wiki/{attr['operator:wikidata']}"
                  target="_blank" rel="noopener" class="link-secondary">{attr.operator}</a>

--- a/tests/xss.spec.js
+++ b/tests/xss.spec.js
@@ -34,8 +34,7 @@ test.describe('XSS escaping', () => {
   });
 
   test('operator with & is displayed as plain text', async ({ page }) => {
-    // Operator is rendered in a <dd> adjacent to <dt>Betreiber</dt>.
-    const operatorEl = page.locator('dt.col-5:has-text("Betreiber") + dd.col-7');
+    const operatorEl = page.locator('[data-testid="operator-value"]');
     await expect(operatorEl).toBeVisible();
     const text = await operatorEl.textContent();
     expect(text).toContain('Bezirksamt Mitte & Co.');

--- a/tests/xss.spec.js
+++ b/tests/xss.spec.js
@@ -6,8 +6,6 @@ const OSM_ID = fixture.features[0].properties.osm_id;
 
 test.describe('XSS escaping', () => {
   test.beforeEach(async ({ page }) => {
-    // Expose probe before navigation so any injected script execution is caught.
-    await page.exposeFunction('__xssProbe', () => {});
     await injectApiConfig(page);
     await stubApiRoutes(page);
     await page.goto(`/#W${OSM_ID}`);
@@ -27,17 +25,12 @@ test.describe('XSS escaping', () => {
   });
 
   test('description with <script> tag does not execute and is shown as text', async ({ page }) => {
-    const probeCallCount = await page.evaluate(() =>
-      typeof window.__xssProbe === 'function' ? window.__xssProbe.__callCount ?? 0 : 0
-    );
-
     // Description paragraphs use p.small without the text-muted class (which
     // is reserved for the location line above them).
     const descEl = page.locator('.info-panel__body p.small:not(.text-muted)').first();
     await expect(descEl).toBeVisible();
     const text = await descEl.textContent();
     expect(text).toContain("<script>alert('xss')</script>");
-    expect(probeCallCount).toBe(0);
   });
 
   test('operator with & is displayed as plain text', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Remove dead `__xssProbe` call-count check from `xss.spec.js` — the `textContent` assertion is the actual XSS guard
- Widen `cache-dependency-path` in `build.yml` to include root `package-lock.json` alongside `app/package-lock.json`
- Remove stale `@playwright/test` devDependency and `test` script from `app/package.json` (tests run from repo root)
- Decompose `formatOpeningHours` into `openingHoursState` returning `{ color, label, suffix, error }` — eliminates `{@html}` from `PlaygroundPanel.svelte` and the XSS surface with it; remove now-unused `escapeHtml` import
- Add `data-testid="operator-value"` to the operator `<dd>` and update the E2E selector from the brittle Bootstrap-class-plus-label-text form to `[data-testid="operator-value"]`

## Test plan

- [ ] E2E suite passes (`make test`)
- [ ] Opening hours renders correctly in the panel (green/red dot, next-change suffix, error fallback shows raw text in `<code>`)
- [ ] XSS tests pass with updated selectors
- [ ] CI build cache picks up both lock files

🤖 Generated with [Claude Code](https://claude.com/claude-code)