### PR TITLE
fix: sync app version to 0.1.6-rc and pin ol + fetch-jsonp

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "spielplatzkarte-app",
-  "version": "0.1.0",
+  "version": "0.1.6-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spielplatzkarte-app",
-      "version": "0.1.0",
+      "version": "0.1.6-rc",
       "dependencies": {
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.13.1",
         "clsx": "^2.1.1",
-        "fetch-jsonp": "^1.3.0",
+        "fetch-jsonp": "1.4.0",
         "i18next": "^24.0.0",
         "lucide-svelte": "^0.469.0",
-        "ol": "^10.0.0",
+        "ol": "10.8.0",
         "opening_hours": "^3.9.0",
         "svelte": "^5.55.4",
         "tailwind-merge": "^2.6.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spielplatzkarte-app",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.6-rc",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,10 +12,10 @@
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.13.1",
     "clsx": "^2.1.1",
-    "fetch-jsonp": "^1.3.0",
+    "fetch-jsonp": "1.4.0",
     "i18next": "^24.0.0",
     "lucide-svelte": "^0.469.0",
-    "ol": "^10.0.0",
+    "ol": "10.8.0",
     "opening_hours": "^3.9.0",
     "svelte": "^5.55.4",
     "tailwind-merge": "^2.6.1",


### PR DESCRIPTION
## Summary

- **D1** — `app/package.json` version bumped from `0.1.0` → `0.1.6-rc` to match the main-branch `-rc` convention (latest release tag: v0.1.5)
- **D4** — `ol` pinned to exact `10.8.0` (was `^10.0.0`) to prevent silent breaking changes on fresh installs
- **D5** — `fetch-jsonp` pinned to exact `1.4.0` (was `^1.3.0`; lockfile already resolved to 1.4.0)
- **D6** — tracked as issue #76: upgrade i18next `^24` → `^25`

## Test plan
- [ ] `npm --prefix app run build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)