### PR TITLE
fix: pass OSM_RELATION_ID to importer container environment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
       PBF_URL:           ${PBF_URL:-https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf}
       OSM2PGSQL_THREADS: ${OSM2PGSQL_THREADS:-4}
+      OSM_RELATION_ID:   ${OSM_RELATION_ID:-62700}
     volumes:
       - pbf_cache:/data   # PBF is re-downloaded on each run; this just avoids /tmp clutter
     profiles: [import]    # not started by "docker compose up"


### PR DESCRIPTION
## Summary

- The `importer` service in `compose.yml` was missing `OSM_RELATION_ID` in its environment block
- Without it, `envsubst` substituted an empty string, producing invalid SQL (`DEFAULT ` with no value)
- This caused `api.get_playgrounds` and `api.get_meta` to fail on every fresh `make import`

## Test plan

- [ ] Copy `.env.example` → `.env`, set `OSM_RELATION_ID` and `PBF_URL`
- [ ] Run `make up` then `make import`
- [ ] Confirm no `ERROR: syntax error at or near ")"` in importer output
- [ ] Confirm `api.get_playgrounds` and `api.get_meta` functions exist in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)