### PR TITLE
fix: add api.panoramax.xyz to CSP frame-src directive

### DIFF
--- a/oci/app/nginx.conf
+++ b/oci/app/nginx.conf
@@ -14,7 +14,7 @@ server {
     # 'unsafe-inline' in style-src is required by Bootstrap and OpenLayers; remove when a nonce-based approach is adopted.
     # frame-ancestors allows any HTTPS parent to embed this app (required for the Hub).
     add_header Content-Security-Policy
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://panoramax.xyz; connect-src 'self' https:; font-src 'self'; frame-ancestors 'self' https:"
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; frame-src https://panoramax.xyz https://api.panoramax.xyz; connect-src 'self' https:; font-src 'self'; frame-ancestors 'self' https:"
         always;
 
     # ── config.js — written at container startup from env vars ──────────────────


### PR DESCRIPTION
## Summary

- Panoramax street-level photo iframes load from `https://api.panoramax.xyz`, not `https://panoramax.xyz`
- The missing subdomain caused the browser to block the iframe with a CSP violation
- Added `https://api.panoramax.xyz` alongside the existing `https://panoramax.xyz` in `frame-src`

## Test plan

- [ ] Run `make docker-build`
- [ ] Open a playground with a Panoramax photo and confirm the iframe loads without CSP errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)