### PR TITLE
docs: update local development section for new project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ All common operations are available via `make`. Run `make help` to list all targ
 ### Frontend dev server
 
 ```bash
-make install      # install Node dependencies (only needed once)
+make install      # install Node dependencies for both root (Playwright) and app/ (Svelte) — only needed once
 make up           # start db + PostgREST + nginx (required backend)
 make dev          # dev server with hot-reload at http://localhost:5173
 ```
 
-> **Note:** `make dev` starts the Vite dev server, which serves the JS with instant hot-reload. The Docker stack (`make up`) must be running alongside it to provide the API — the app requires a live PostgREST backend.
+> **Note:** `make dev` starts the Vite dev server, which serves the Svelte app with instant hot-reload. The Docker stack (`make up`) must be running alongside it to provide the API — the app requires a live PostgREST backend.
 
 ### Rebuild the app container after code changes
 
@@ -242,6 +242,8 @@ make docker-build
 ```
 
 This runs the Vite build inside the container and replaces the nginx image without touching the database or PostgREST.
+
+> **Production deploys:** Use `compose.prod.yml` instead of `compose.yml` for production environments — it omits development-only overrides and is intended for use behind a reverse proxy.
 
 ### Applying database changes without a full rebuild
 


### PR DESCRIPTION
## Summary

- Updated `make install` description to note it installs both root (Playwright) and `app/` (Svelte) packages
- Added note about `compose.prod.yml` for production deploys
- Minor wording: "JS" → "Svelte app" in dev server note

Closes #85

## Test plan
- [ ] `make install` description reflects two-package install
- [ ] `compose.prod.yml` is mentioned in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)