### PR TITLE
docs: document new directories in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,19 @@ Then open `http://<that-ip>:8080` on your phone.
 
 All contributions are welcome — code, translations, bug reports, or documentation improvements. Here's how to get a change into the project:
 
+**Repository layout** (directories not covered elsewhere in this README):
+
+| Directory | Contents |
+|---|---|
+| `app/` | Svelte 5 frontend app (source in `app/src/`) |
+| `importer/` | osm2pgsql import scripts and PostgREST API SQL |
+| `db/` | PostgreSQL initialisation SQL |
+| `oci/` | Docker build contexts — `oci/app/` (Svelte app + nginx) and `oci/data-node/` |
+| `processing/` | OSM data pipeline scripts (Lua rules, SQL, shell) used during import |
+| `taginfo/` | [taginfo](https://taginfo.openstreetmap.org) metadata describing the OSM tags this project uses |
+| `locales/` | Translation files (`*.json`, one per language) — not yet active in the Svelte rewrite |
+| `deploy/` | Systemd unit files for automated weekly import on Linux servers |
+
 ### Step 1 — Create a GitHub issue
 
 Before writing code, open an issue on GitHub describing what you want to fix or add. This lets maintainers give early feedback and avoids duplicated effort. You can skip this for tiny fixes like typos.


### PR DESCRIPTION
## Summary

- Added a "Repository layout" table to the Contributing section listing all top-level directories and their purpose
- Covers `app/`, `importer/`, `db/`, `oci/`, `processing/`, `taginfo/`, `locales/`, `deploy/`

Closes #86

## Test plan
- [ ] Repository layout table appears in the Contributing section
- [ ] `oci/`, `processing/`, and `taginfo/` are described

🤖 Generated with [Claude Code](https://claude.com/claude-code)