### PR TITLE
fix: preserve database password when installer overwrites .env

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,8 +83,10 @@ printf "https://github.com/mfuhrmann/spielplatzkarte\n\n"
 ask DEPLOY_DIR "Deployment directory" "./spielplatzkarte"
 mkdir -p "$DEPLOY_DIR/db"
 
+EXISTING_PASSWORD=""
 if [[ -f "$DEPLOY_DIR/.env" ]]; then
     warn ".env already exists in $DEPLOY_DIR"
+    EXISTING_PASSWORD="$(grep '^POSTGRES_PASSWORD=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
     confirm "Overwrite it?" || die "Aborted."
 fi
 
@@ -119,8 +121,13 @@ ask OSM2PGSQL_THREADS "CPU threads for the OSM import"          "4"
 
 # ── Generate password ──────────────────────────────────────────────────────────
 
-POSTGRES_PASSWORD="$(openssl rand -hex 32)"
-success "Generated secure database password."
+if [[ -n "$EXISTING_PASSWORD" ]]; then
+    POSTGRES_PASSWORD="$EXISTING_PASSWORD"
+    success "Reusing existing database password (database volume already initialised)."
+else
+    POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+    success "Generated secure database password."
+fi
 
 # ── Download files ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Re-running `install.sh` generated a new random `POSTGRES_PASSWORD` and overwrote `.env`, but the existing `pgdata` volume was already initialised with the old password — causing `FATAL: password authentication failed for user "osm"` on the next import.

**Fix:** extract the current `POSTGRES_PASSWORD` from the existing `.env` before overwriting. A new password is only generated on a genuinely fresh install (no `.env` present).

Closes #95

## Test plan
- [ ] First-time install: new password is generated as before
- [ ] Re-run on existing `.env`: existing password is reused, import succeeds
- [ ] `"Reusing existing database password (database volume already initialised)."` shown on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)