### PR TITLE
fix: detect stale pgdata volume before starting stack

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,24 @@ fi
 
 printf "\n"
 if confirm "Start the stack now?"; then
+    # ── Check for stale pgdata volume ──────────────────────────────────────────
+    PROJECT_NAME="$(basename "$(cd "$DEPLOY_DIR" && pwd)")"
+    VOLUME_NAME="${PROJECT_NAME}_pgdata"
+    if docker volume ls --format '{{.Name}}' | grep -q "^${VOLUME_NAME}$"; then
+        warn "A database volume '${VOLUME_NAME}' already exists."
+        warn "This often means a previous install or a dev stack with the same"
+        warn "directory name already initialised the database with a different password."
+        warn "Starting without removing it will cause authentication failures."
+        printf "\n"
+        if confirm "Delete the existing volume and start fresh? (existing data will be lost)"; then
+            docker volume rm "$VOLUME_NAME" >/dev/null
+            success "Volume removed. Database will be initialised with the new password."
+        else
+            warn "Proceeding without removing the volume — authentication may fail."
+        fi
+        printf "\n"
+    fi
+
     info "Starting db, PostgREST, and app..."
     docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" up -d
     success "Stack started."


### PR DESCRIPTION
## Summary

Before starting the Docker stack, check whether a `<project>_pgdata` volume already exists. If it does, warn the user and offer to delete it.

**Why this matters:** Docker never re-initialises a non-empty data directory. If the volume was created by a previous install or a dev stack with the same directory name (same Docker project name), it holds a different password. Every connection attempt silently fails with `FATAL: password authentication failed`, and PostgREST enters a crash-restart loop.

The check derives the project name from the resolved deploy directory basename — matching how Docker Compose names volumes by default.

Closes #97

## Test plan
- [ ] Fresh install with no existing volume: no warning shown, stack starts normally
- [ ] Re-install with existing volume: warning shown, user offered delete-or-skip choice
- [ ] Choosing delete: volume removed, stack starts, db initialises with correct password, import succeeds
- [ ] Choosing skip: warning shown, proceed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)