### PR TITLE
fix: add OSM_RELATION_ID to importer env in compose.prod.yml

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -44,6 +44,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}
       PBF_URL:           ${PBF_URL}
       OSM2PGSQL_THREADS: ${OSM2PGSQL_THREADS:-4}
+      OSM_RELATION_ID:   ${OSM_RELATION_ID}
     volumes:
       - pbf_cache:/data
     profiles: [import]


### PR DESCRIPTION
## Summary

`OSM_RELATION_ID` was present in the `app` service but missing from the `importer` service in `compose.prod.yml`. The importer's `import.sh` uses `envsubst '$OSM_RELATION_ID'` to inject the relation ID into `api.sql`; without it the substitution produces an empty string and the SQL is invalid.

**Symptom:** `get_playgrounds` and `get_meta` fail to create; the rest of the import succeeds; the app starts but shows no playground data.

Closes #99

## Test plan
- [ ] `docker compose run --rm importer` completes with no SQL errors
- [ ] `get_playgrounds` and `get_meta` functions exist in the database after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)