### PR TITLE
feat: auto-import and apply schema on first make up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ make test         # Run Playwright E2E tests
 
 ```bash
 cp .env.example .env   # configure OSM_RELATION_ID and PBF_URL
-make up                # start db + PostgREST + nginx/app
-make import            # one-time OSM data import (downloads PBF, runs osm2pgsql)
+make up                # start db + PostgREST + nginx/app; runs import + db-apply automatically on first launch
+make import            # download PBF and import OSM data (manual refresh only — first-time import runs via make up)
 make docker-build      # rebuild and restart only the nginx/app container
 make db-apply          # apply importer/api.sql to the running DB and reload PostgREST
 make db-shell          # open a psql shell in the running DB container

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,14 @@ test: require-npm         ## Run Playwright E2E tests
 
 ## ── Docker Compose stack ──────────────────────────────────────────────────────
 
-up: require-docker        ## Start db + PostgREST + nginx (detached)
-	docker compose up -d
+up: require-docker        ## Start stack; run import automatically on first launch
+	docker compose up -d --wait --timeout 300
+	@if ! docker compose exec -T db psql -U osm -d osm -tc \
+	    "SELECT 1 FROM information_schema.tables WHERE table_schema='api' LIMIT 1" \
+	    2>/dev/null | grep -q 1; then \
+	  printf '\033[36minfo:\033[0m first launch detected — importing OSM data…\n'; \
+	  $(MAKE) import; \
+	fi
 
 down: require-docker      ## Stop and remove containers
 	docker compose down


### PR DESCRIPTION
## Summary

- `make up` now runs `--wait` so all services are healthy before proceeding
- Checks whether the `api` schema has any tables; if not (first launch or after `make down -v`), automatically runs `make import` then `make db-apply`
- Subsequent `make up` calls just start the stack — no extra work
- Updated CLAUDE.md to reflect the new behaviour

## Test plan

- [ ] Fresh environment (`make down -v` + `make up`) — import and schema apply run automatically
- [ ] Existing environment (`make up` on a running stack) — no import triggered
- [ ] `make help` output still renders correctly