### PR TITLE
feat: port light-theme and Bootstrap bump from no42-org#2

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "spielplatzkarte-app",
       "version": "0.1.6-rc",
       "dependencies": {
-        "bootstrap": "^5.3.3",
+        "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
         "clsx": "^2.1.1",
         "fetch-jsonp": "1.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "bootstrap": "^5.3.3",
+    "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
     "clsx": "^2.1.1",
     "fetch-jsonp": "1.4.0",

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -266,7 +266,7 @@
     bottom: 0;
     width: 380px;
     z-index: 200;
-    background: #ffffff;
+    background: var(--color-card);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
     overflow-y: auto;
     animation: slideInLeft 0.3s ease-out;

--- a/app/src/styles/app.css
+++ b/app/src/styles/app.css
@@ -102,25 +102,7 @@
   to { transform: scale(1); opacity: 1; }
 }
 
-/* ─── Dark Mode (optional, for future) ─────────────────────────────────────── */
-@media (prefers-color-scheme: dark) {
-  @theme {
-    --color-background: #1f2937;
-    --color-foreground: #f3f4f6;
-    --color-card: #111827;
-    --color-card-foreground: #f3f4f6;
-    --color-popover: #111827;
-    --color-popover-foreground: #f3f4f6;
-    --color-muted: #374151;
-    --color-muted-foreground: #9ca3af;
-    --color-border: #374151;
-    --color-input: #374151;
-    --color-secondary: #1e40af;
-    --color-secondary-foreground: #f3f4f6;
-    --color-accent: #92400e;
-    --color-accent-foreground: #f3f4f6;
-  }
-}
+/* Dark mode intentionally disabled — the app uses a light theme only. */
 
 /* ─── Base Styles ──────────────────────────────────────────────────────────── */
 * {


### PR DESCRIPTION
## Summary

Ports the relevant changes from [no42-org/spielplatzkarte#2](https://github.com/no42-org/spielplatzkarte/pull/2):

- **Bootstrap bump**: `^5.3.3` → `^5.3.8`
- **Dark mode removed**: drop the `@media (prefers-color-scheme: dark)` block from `app.css` — the app is light theme only
- **StandaloneApp sidebar**: use `var(--color-card)` instead of hardcoded `#ffffff` so the background respects the design token

## Not ported

- `PanoramaxViewer.svelte` — the `<svelte:body>` portal approach from the source PR is invalid in Svelte 5; already fixed correctly in #107
- `HoverPreview.svelte` — `.hover-card` class already present in main
- `scripts/sync-main.sh` — Vercel/v0-specific helper, not relevant here

## Test plan

- [x] Build passes (`make build`)
- [x] E2E tests pass
- [ ] Sidebar background renders correctly in light theme