### PR TITLE
feat: show nearest playground suggestions after search/locate

### DIFF
--- a/app/src/components/LocateButton.svelte
+++ b/app/src/components/LocateButton.svelte
@@ -3,6 +3,9 @@
   import { mapStore } from '../stores/map.js';
   import { Navigation2, Loader2 } from 'lucide-svelte';
 
+  /** Called with (lat, lon) after a GPS fix is obtained. */
+  export let onlocation = null;
+
   let locating = false;
   let error = '';
 
@@ -16,8 +19,10 @@
     navigator.geolocation.getCurrentPosition(
       pos => {
         locating = false;
-        const coord = fromLonLat([pos.coords.longitude, pos.coords.latitude]);
+        const { latitude, longitude } = pos.coords;
+        const coord = fromLonLat([longitude, latitude]);
         $mapStore?.getView().animate({ center: coord, zoom: 16 });
+        if (onlocation) onlocation(latitude, longitude);
       },
       err => {
         locating = false;

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -15,6 +15,7 @@
   import { playgroundStyleFn, selectionStyle } from '../lib/vectorStyles.js';
   import { selection } from '../stores/selection.js';
   import { mapStore } from '../stores/map.js';
+  import { playgroundSourceStore } from '../stores/playgroundSource.js';
   import { filterStore, matchesFilters } from '../stores/filters.js';
   import { debounce } from '../lib/utils.js';
 
@@ -114,6 +115,7 @@
 
     // Standalone: fetch playgrounds and fit to region
     if (ownSource) {
+      playgroundSourceStore.set(ownSource);
       loadStandaloneData(ownSource, view);
     }
 
@@ -135,6 +137,7 @@
       olMap.setTarget(undefined);
       mapStore.set(null);
     }
+    playgroundSourceStore.set(null);
   });
 
   // Re-style the playground layer whenever filters change.

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { getCenter } from 'ol/extent';
+  import { transform } from 'ol/proj';
   import { playgroundSourceStore } from '../stores/playgroundSource.js';
   import { selection } from '../stores/selection.js';
   import { fetchNearestPlaygrounds } from '../lib/api.js';
@@ -17,13 +19,46 @@
     load(lat, lon);
   }
 
+  function haversineM(lat1, lon1, lat2, lon2) {
+    const R = 6371000;
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLon = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(dLat / 2) ** 2 +
+              Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+              Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  function nearestFromSource(lt, lg, maxResults = 5) {
+    const source = $playgroundSourceStore;
+    if (!source) return [];
+    return source.getFeatures()
+      .map(f => {
+        const [fLon, fLat] = transform(getCenter(f.getGeometry().getExtent()), 'EPSG:3857', 'EPSG:4326');
+        const props = f.getProperties();
+        return {
+          osm_id:     props.osm_id,
+          name:       props.name,
+          lat:        fLat,
+          lon:        fLon,
+          distance_m: haversineM(lt, lg, fLat, fLon),
+          tags:       props,
+        };
+      })
+      .sort((a, b) => a.distance_m - b.distance_m)
+      .slice(0, maxResults);
+  }
+
   async function load(lt, lg) {
     loading = true;
     items = [];
     try {
-      items = await fetchNearestPlaygrounds(lt, lg);
+      items = apiBaseUrl
+        ? await fetchNearestPlaygrounds(lt, lg)
+        : nearestFromSource(lt, lg);
     } catch (err) {
       console.error('Nearest playgrounds fetch failed:', err);
+      items = nearestFromSource(lt, lg);
     } finally {
       loading = false;
     }

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -1,0 +1,149 @@
+<script>
+  import { playgroundSourceStore } from '../stores/playgroundSource.js';
+  import { selection } from '../stores/selection.js';
+  import { fetchNearestPlaygrounds } from '../lib/api.js';
+  import { playgroundCompleteness } from '../lib/completeness.js';
+  import { apiBaseUrl } from '../lib/config.js';
+
+  export let lat;
+  export let lon;
+  /** Called when the panel should close (suggestion selected). */
+  export let ondismiss = null;
+
+  let items = [];
+  let loading = true;
+
+  $: if (lat != null && lon != null) {
+    load(lat, lon);
+  }
+
+  async function load(lt, lg) {
+    loading = true;
+    items = [];
+    try {
+      items = await fetchNearestPlaygrounds(lt, lg);
+    } catch (err) {
+      console.error('Nearest playgrounds fetch failed:', err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function formatDistance(m) {
+    if (m < 1000) return `${Math.round(m)} m`;
+    return `${(m / 1000).toFixed(1).replace('.', ',')} km`;
+  }
+
+  function completenessClass(tags) {
+    const c = playgroundCompleteness(tags);
+    if (c === 'complete') return 'dot-complete';
+    if (c === 'partial')  return 'dot-partial';
+    return 'dot-missing';
+  }
+
+  function selectSuggestion(item) {
+    const source = $playgroundSourceStore;
+    const feature = source?.getFeatures().find(f => f.get('osm_id') === item.osm_id);
+    if (feature) {
+      selection.select(feature, apiBaseUrl);
+    }
+    if (ondismiss) ondismiss();
+  }
+</script>
+
+<div class="nearby-card">
+  <div class="nearby-header">In der Nähe</div>
+  {#if loading}
+    <div class="nearby-loading">Wird geladen …</div>
+  {:else if items.length === 0}
+    <div class="nearby-loading">Keine Spielplätze gefunden.</div>
+  {:else}
+    <ul class="nearby-list">
+      {#each items as item}
+        <li>
+          <button class="nearby-item" onclick={() => selectSuggestion(item)}>
+            <span class="dot {completenessClass(item.tags)}"></span>
+            <span class="nearby-name">{item.name || 'Unbekannter Spielplatz'}</span>
+            <span class="nearby-dist">{formatDistance(item.distance_m)}</span>
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .nearby-card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    width: 300px;
+    max-width: calc(100vw - 5rem);
+  }
+
+  .nearby-header {
+    padding: 8px 14px 6px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #9aa0a6;
+    border-bottom: 1px solid #e8eaed;
+  }
+
+  .nearby-loading {
+    padding: 10px 14px;
+    font-size: 13px;
+    color: #9aa0a6;
+  }
+
+  .nearby-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .nearby-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 14px;
+    width: 100%;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s;
+  }
+
+  .nearby-item:hover {
+    background: #f1f3f4;
+  }
+
+  .dot {
+    flex-shrink: 0;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+
+  .dot-complete { background: #22c55e; }
+  .dot-partial  { background: #f59e0b; }
+  .dot-missing  { background: #ef4444; }
+
+  .nearby-name {
+    flex: 1;
+    font-size: 13px;
+    color: #202124;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .nearby-dist {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: #9aa0a6;
+  }
+</style>

--- a/app/src/components/SearchBar.svelte
+++ b/app/src/components/SearchBar.svelte
@@ -6,6 +6,8 @@
 
   /** Bounding box [minLon, minLat, maxLon, maxLat] to restrict Nominatim search. */
   export let regionExtent = null;
+  /** Called with (lat, lon) after a result is selected; called with (null, null) on clear. */
+  export let onlocation = null;
 
   let query = '';
   let searching = false;
@@ -41,10 +43,13 @@
   }
 
   function selectResult(result) {
-    const coord = fromLonLat([parseFloat(result.lon), parseFloat(result.lat)]);
+    const lat = parseFloat(result.lat);
+    const lon = parseFloat(result.lon);
+    const coord = fromLonLat([lon, lat]);
     $mapStore?.getView().animate({ center: coord, zoom: 17 });
     query = result.display_name.split(',')[0];
     showResults = false;
+    if (onlocation) onlocation(lat, lon);
   }
 
   function onKeydown(e) {
@@ -70,6 +75,7 @@
     results = [];
     showResults = false;
     inputEl?.focus();
+    if (onlocation) onlocation(null, null);
   }
 
   function onFocus() {

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -40,6 +40,16 @@ export async function fetchNearbyPOIs(lat, lon, radiusM = 500, osmId = null, bas
     return [];
 }
 
+// Nearest playgrounds to a given WGS84 point, ordered by distance.
+// Returns [] when apiBaseUrl is empty (Overpass / local dev mode).
+export async function fetchNearestPlaygrounds(lat, lon, baseUrl = defaultApiBaseUrl) {
+    if (!baseUrl) return [];
+    const params = new URLSearchParams({ lat, lon });
+    const res = await fetch(`${baseUrl}/rpc/get_nearest_playgrounds?${params}`);
+    if (res.ok) return res.json();
+    return [];
+}
+
 // Instance metadata (requires spielplatzkarte v0.2.1+).
 export async function fetchMeta(baseUrl = defaultApiBaseUrl) {
     const res = await fetch(`${baseUrl}/rpc/get_meta`);

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -7,7 +7,9 @@
   import FilterChips from '../components/FilterChips.svelte';
   import BottomSheet from '../components/BottomSheet.svelte';
   import HoverPreview from '../components/HoverPreview.svelte';
+  import NearbyPlaygrounds from '../components/NearbyPlaygrounds.svelte';
   import DataContributionModal from '../components/DataContributionModal.svelte';
+  import { onDestroy } from 'svelte';
   import { Pencil, Plus, Minus } from 'lucide-svelte';
   import { apiBaseUrl } from '../lib/config.js';
   import { mapStore } from '../stores/map.js';
@@ -28,6 +30,31 @@
   }
 
   let dataModalOpen = false;
+
+  // Nearest-playground suggestions panel
+  let nearbyLocation = null;  // { lat, lon } | null
+  let dismissUnsub = null;
+
+  function handleLocation(lat, lon) {
+    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+    if (lat === null) { nearbyLocation = null; return; }
+    if (!apiBaseUrl) return; // no PostgREST in Overpass mode
+    nearbyLocation = { lat, lon };
+    // Dismiss the panel on the next selection-store change (map click or playground select)
+    let first = true;
+    dismissUnsub = selection.subscribe(() => {
+      if (first) { first = false; return; }
+      nearbyLocation = null;
+      if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+    });
+  }
+
+  function dismissNearby() {
+    nearbyLocation = null;
+    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+  }
+
+  onDestroy(() => { if (dismissUnsub) dismissUnsub(); });
 
   // Responsive: track if we're on mobile
   let isMobile = false;
@@ -96,8 +123,11 @@
 
   <!-- Search bar: top-left, Google Maps style -->
   <div class="search-area">
-    <SearchBar {regionExtent} />
+    <SearchBar {regionExtent} onlocation={handleLocation} />
     <FilterChips />
+    {#if nearbyLocation}
+      <NearbyPlaygrounds lat={nearbyLocation.lat} lon={nearbyLocation.lon} ondismiss={dismissNearby} />
+    {/if}
   </div>
 
   <!-- Top-right controls: filter, edit -->
@@ -115,7 +145,7 @@
 
   <!-- Bottom-right controls: locate, zoom (Google Maps style) -->
   <div class="controls-bottom-right">
-    <LocateButton />
+    <LocateButton onlocation={handleLocation} />
     <div class="zoom-controls">
       <button
         class="zoom-btn zoom-in"

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -38,7 +38,6 @@
   function handleLocation(lat, lon) {
     if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
     if (lat === null) { nearbyLocation = null; return; }
-    if (!apiBaseUrl) return; // no PostgREST in Overpass mode
     nearbyLocation = { lat, lon };
     // Dismiss the panel on the next selection-store change (map click or playground select)
     let first = true;

--- a/app/src/stores/playgroundSource.js
+++ b/app/src/stores/playgroundSource.js
@@ -1,0 +1,4 @@
+// Exposes the standalone playground VectorSource so other components can
+// find features by osm_id without reaching into the Map component.
+import { writable } from 'svelte/store';
+export const playgroundSourceStore = writable(null);

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -471,6 +471,74 @@ GRANT EXECUTE ON FUNCTION api.get_meta(bigint) TO web_anon;
 CREATE INDEX IF NOT EXISTS idx_osm_point_natural ON planet_osm_point ("natural") WHERE "natural" IS NOT NULL;
 
 -- Spatial indexes to speed up bbox and radius queries (idempotent)
+-- =========================================================================
+-- 6. get_nearest_playgrounds(lat, lon, relation_id, max_results)
+--    Returns the nearest playgrounds to a given WGS84 point,
+--    ordered by distance ascending.
+-- =========================================================================
+DROP FUNCTION IF EXISTS api.get_nearest_playgrounds(float8, float8, bigint, int);
+
+CREATE OR REPLACE FUNCTION api.get_nearest_playgrounds(
+  lat          float8,
+  lon          float8,
+  relation_id  bigint DEFAULT ${OSM_RELATION_ID},
+  max_results  int    DEFAULT 5
+)
+RETURNS json
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, api
+AS $$
+  WITH center AS (
+    SELECT
+      ST_Transform(ST_SetSRID(ST_MakePoint(lon, lat), 4326), 3857)  AS geom_3857,
+      ST_SetSRID(ST_MakePoint(lon, lat), 4326)::geography            AS geog_4326
+  ),
+  region AS (
+    SELECT way FROM planet_osm_polygon WHERE osm_id = -relation_id LIMIT 1
+  ),
+  nearest AS (
+    SELECT
+      p.osm_id,
+      p.name,
+      p.operator,
+      p.access,
+      p.surface,
+      p.tags,
+      ST_Distance(ST_Transform(p.way, 4326)::geography, c.geog_4326)  AS distance_m,
+      ST_Y(ST_Transform(ST_Centroid(p.way), 4326))                    AS centroid_lat,
+      ST_X(ST_Transform(ST_Centroid(p.way), 4326))                    AS centroid_lon
+    FROM planet_osm_polygon p, center c, region r
+    WHERE p.leisure = 'playground'
+      AND ST_Within(p.way, r.way)
+    ORDER BY p.way <-> c.geom_3857
+    LIMIT max_results
+  )
+  SELECT COALESCE(
+    json_agg(
+      json_build_object(
+        'osm_id',      abs(osm_id),
+        'name',        name,
+        'lat',         centroid_lat,
+        'lon',         centroid_lon,
+        'distance_m',  round(distance_m::numeric),
+        'tags', (
+          jsonb_build_object(
+            'name',          name,
+            'operator',      operator,
+            'access',        access,
+            'surface',       surface
+          ) || COALESCE(hstore_to_jsonb(tags), '{}'::jsonb)
+        )
+      )
+      ORDER BY distance_m
+    ),
+    '[]'::json
+  )
+  FROM nearest;
+$$;
+
+GRANT EXECUTE ON FUNCTION api.get_nearest_playgrounds(float8, float8, bigint, int) TO web_anon;
+
 CREATE INDEX IF NOT EXISTS idx_osm_polygon_way  ON planet_osm_polygon USING GIST (way);
 CREATE INDEX IF NOT EXISTS idx_osm_point_way    ON planet_osm_point   USING GIST (way);
 CREATE INDEX IF NOT EXISTS idx_osm_polygon_lei  ON planet_osm_polygon (leisure) WHERE leisure IS NOT NULL;


### PR DESCRIPTION
## Summary
- After selecting a Nominatim search result or pressing the locate button, a panel appears below the search bar listing the 5 nearest playgrounds with name, distance, and a completeness dot (🟢/🟡/🔴)
- Clicking a suggestion selects that playground; the panel dismisses on any map interaction or new location
- When `apiBaseUrl` is set (Docker stack), distances come from a new `api.get_nearest_playgrounds` PostgREST function; in Overpass/dev mode distances are computed client-side via Haversine over the already-loaded OL features

Closes #106

## Notes
- Centering the map on suggestion click is intentionally left out — that will be handled by #104 (zoom on selection), which will cover all selection entry points uniformly

## Test plan
- [ ] Select a Nominatim search result → suggestions panel appears below search bar
- [ ] Press locate button → suggestions panel appears
- [ ] Click a suggestion → playground is selected, panel dismisses
- [ ] Click empty map area → panel dismisses
- [ ] Start a new search → panel from previous search is replaced
- [ ] Works at `:5173` (Overpass mode, client-side distances) and `:8080` (PostgREST mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)