### PR TITLE
fix: open device photo in fullscreen modal instead of Panoramax page

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -55,6 +55,11 @@
   function uid(f) {
     return `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
   }
+
+  // Panoramax fullscreen modal for device photos
+  let modalUuid = null;
+  const thumbUrl  = uuid => `https://api.panoramax.xyz/api/pictures/${uuid}/thumb.jpg`;
+  const viewerUrl = uuid => `https://api.panoramax.xyz/?pic=${uuid}&nav=none&focus=pic`;
 </script>
 
 {#if features.length === 0 && Object.keys(fallbackCounts).length === 0}
@@ -94,13 +99,21 @@
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
         {@const id = uid(f)}
         <li>
-          {#if detail}
+          {#if detail.html || detail.panoramaxUuid}
             <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
               <span style="color:{color}">●</span> {name}
               <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
             {#if openItems.has(id)}
-              <div class="device-detail">{@html detail}</div>
+              <div class="device-detail">
+                {#if detail.panoramaxUuid}
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  </button>
+                {/if}
+                {@html detail.html}
+              </div>
             {/if}
           {:else}
             <span style="color:{color}">●</span> {name}
@@ -115,13 +128,21 @@
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
         {@const id = uid(f)}
         <li>
-          {#if detail}
+          {#if detail.html || detail.panoramaxUuid}
             <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
               <span style="color:{color}">●</span> {name}
               <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
             {#if openItems.has(id)}
-              <div class="device-detail">{@html detail}</div>
+              <div class="device-detail">
+                {#if detail.panoramaxUuid}
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  </button>
+                {/if}
+                {@html detail.html}
+              </div>
             {/if}
           {:else}
             <span style="color:{color}">●</span> {name}
@@ -136,13 +157,21 @@
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
         {@const id = uid(f)}
         <li>
-          {#if detail}
+          {#if detail.html || detail.panoramaxUuid}
             <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
               <span style="color:{color}">●</span> {label}
               <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
             {#if openItems.has(id)}
-              <div class="device-detail">{@html detail}</div>
+              <div class="device-detail">
+                {#if detail.panoramaxUuid}
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  </button>
+                {/if}
+                {@html detail.html}
+              </div>
             {/if}
           {:else}
             <span style="color:{color}">●</span> {label}
@@ -171,6 +200,26 @@
   {/if}
 {/if}
 
+{#if modalUuid}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div class="photo-modal-backdrop" onclick={() => modalUuid = null}>
+    <div class="photo-modal" onclick={e => e.stopPropagation()}
+         role="dialog" aria-modal="true" aria-label="Gerätefoto" tabindex="-1">
+      <div class="photo-modal-header">
+        <span class="photo-modal-title">Foto dieses Geräts</span>
+        <button type="button" class="btn-close" onclick={() => modalUuid = null} aria-label="Schließen"></button>
+      </div>
+      <iframe
+        src={viewerUrl(modalUuid)}
+        style="width:100%; flex:1; border:none;"
+        title="Gerätefoto"
+        allowfullscreen
+      ></iframe>
+    </div>
+  </div>
+{/if}
+
 <style>
   .device-list { padding-left: 0; list-style: none; }
   .device-list li { margin-bottom: 0.25rem; }
@@ -183,4 +232,60 @@
   }
   .device-detail :global(ul) { padding-left: 1.2rem; margin-bottom: 0; }
   .device-detail :global(img) { width: 100%; border-radius: 4px; margin-bottom: 0.25rem; }
+
+  .photo-thumb-btn {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    margin-bottom: 0.25rem;
+  }
+  .photo-thumb {
+    width: 100%;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+    border-radius: 4px;
+    display: block;
+  }
+  .photo-thumb-btn:hover .photo-thumb { opacity: 0.85; }
+  .photo-label {
+    display: block;
+    font-size: 0.75rem;
+    color: #6c757d;
+    margin-top: 2px;
+  }
+
+  .photo-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.7);
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .photo-modal {
+    background: #fff;
+    border-radius: 6px;
+    width: min(90vw, 1100px);
+    height: min(80vh, 700px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .photo-modal-header {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #dee2e6;
+    gap: 0.5rem;
+  }
+  .photo-modal-title {
+    flex: 1;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
 </style>

--- a/app/src/lib/equipmentAttributes.js
+++ b/app/src/lib/equipmentAttributes.js
@@ -81,9 +81,9 @@ const pitchImages = {
 };
 
 /**
- * Returns an HTML string with detail attributes for a single equipment item.
+ * Returns detail attributes for a single equipment item.
  * @param {Object} props - plain GeoJSON feature properties object
- * @returns {string} HTML (may be empty string)
+ * @returns {{ html: string, panoramaxUuid: string|null }}
  */
 export function getEquipmentAttributesFromProps(props) {
     const g = key => props[key];
@@ -158,19 +158,12 @@ export function getEquipmentAttributesFromProps(props) {
     const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
 
     let html = '';
-    if (panoramaxUuid) {
-        const thumbUrl  = `https://api.panoramax.xyz/api/pictures/${panoramaxUuid}/thumb.jpg`;
-        const viewUrl   = `https://api.panoramax.xyz/?pic=${panoramaxUuid}&nav=none&focus=pic`;
-        html += `<a href="${viewUrl}" target="_blank" rel="noopener">` +
-            `<img src="${thumbUrl}" alt="Straßenfoto" style="object-fit:cover;aspect-ratio:16/9;width:100%"></a>` +
-            `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-camera"></span> Foto dieses Geräts</p>`;
-    }
     if (content.length) {
         html += '<ul>' + content.map(c => `<li>${c}</li>`).join('') + '</ul>';
     }
 
-    // Fallback image when no photo and no attributes
-    if (!html) {
+    // Fallback image when no panoramax photo and no attributes
+    if (!html && !panoramaxUuid) {
         const onerror = `if(this.dataset.fallback){this.src=this.dataset.fallback;delete this.dataset.fallback}else{this.parentElement.style.display='none'}`;
         const deviceKey = g('playground');
         const sportRaw  = g('sport');
@@ -191,5 +184,5 @@ export function getEquipmentAttributesFromProps(props) {
     }
 
     if (!panoramaxUuid) html += addPhotoLink;
-    return html;
+    return { html, panoramaxUuid: panoramaxUuid || null };
 }


### PR DESCRIPTION
## Summary
- Device thumbnails (equipment with a `panoramax` tag) now open the same fullscreen iframe modal used for playground photos instead of navigating to the Panoramax website
- `getEquipmentAttributesFromProps` return type changed from `string` to `{ html, panoramaxUuid }` — `panoramaxUuid` is surfaced to the template so Svelte can handle the click event natively
- The thumbnail renders as a `<button>` in `EquipmentList.svelte`; clicking sets `modalUuid` and shows the fullscreen modal

Closes #112

## Test plan
- [ ] Open a playground with equipment that has a `panoramax` tag
- [ ] Click the device to expand its detail row — thumbnail appears
- [ ] Click the thumbnail → fullscreen modal opens with the Panoramax iframe
- [ ] Click backdrop or ✕ → modal closes
- [ ] Equipment without panoramax photos is unaffected (fallback symbol image / attribute list still shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)