### PR TITLE
feat: zoom map to playground extent on selection

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -83,9 +83,13 @@
         layerFilter: (l) => l === playgroundLayer,
       });
       if (hit) {
-        // In hub mode the feature carries its own backend URL; fall back to prop
         const backendUrl = hit.get('_backendUrl') ?? defaultBackendUrl;
         selection.select(hit, backendUrl);
+        view.fit(hit.getGeometry().getExtent(), {
+          padding: [40, 40, 40, 420], // right/top/bottom clear; 420 = sidebar width + margin
+          maxZoom: 19,
+          duration: 400,
+        });
       } else {
         selection.clear();
       }

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -73,7 +73,16 @@
   // Sync bottom sheet with selection on mobile
   $: if (isMobile && $hasSelection) {
     bottomSheetOpen = true;
-    bottomSheetSnap = 'half';
+    bottomSheetSnap = 'peek';
+    // Fit map with bottom padding for the peek sheet (140 px) + a little breathing room
+    const feat = $selection.feature;
+    if (feat && $mapStore) {
+      $mapStore.getView().fit(feat.getGeometry().getExtent(), {
+        padding: [40, 40, 180, 40],
+        maxZoom: 19,
+        duration: 400,
+      });
+    }
   }
   $: if (isMobile && !$hasSelection) {
     bottomSheetOpen = false;


### PR DESCRIPTION
## Summary
- **Desktop**: after selecting a playground, `view.fit()` animates the map to the polygon extent with left padding (420 px) to keep the playground visible beside the side panel
- **Mobile**: bottom sheet now opens at `peek` (140 px, shows name + badge) instead of `half`; the map simultaneously fits the playground with bottom padding (180 px) for the peek sheet

Closes #104

## Test plan
- [ ] Desktop: click a playground → map zooms to fit it beside the side panel
- [ ] Desktop: the playground polygon is fully visible, not hidden behind the panel
- [ ] Mobile: tap a playground → map zooms, bottom sheet appears at peek height
- [ ] Mobile: swipe up → sheet expands to full
- [ ] Mobile: swipe down from full → snaps to peek
- [ ] Mobile: swipe down from peek → sheet closes, playground deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)