### PR TITLE
fix: correct PanoramaxViewer modal rendering in Safari

### DIFF
--- a/app/src/components/PanoramaxViewer.svelte
+++ b/app/src/components/PanoramaxViewer.svelte
@@ -9,8 +9,8 @@
   const thumbUrl  = uuid => `https://api.panoramax.xyz/api/pictures/${uuid}/thumb.jpg`;
   const viewerUrl = uuid => `https://api.panoramax.xyz/?pic=${uuid}&nav=none&focus=pic`;
 
-  let fullscreen = false;
-  let modalIndex = 0;
+  let fullscreen = $state(false);
+  let modalIndex = $state(0);
 
   function openModal(i) {
     modalIndex = i;
@@ -33,6 +33,22 @@
     window.addEventListener('keydown', onKeydown, { capture: true });
     return () => window.removeEventListener('keydown', onKeydown, { capture: true });
   });
+
+  /**
+   * Svelte action to portal an element to document.body.
+   * This ensures the modal escapes the sidebar's stacking context
+   * and works correctly in all browsers including Safari.
+   */
+  function portal(node) {
+    document.body.appendChild(node);
+    return {
+      destroy() {
+        if (node.parentNode) {
+          node.parentNode.removeChild(node);
+        }
+      }
+    };
+  }
 </script>
 
 {#if uuids.length === 0}
@@ -83,10 +99,11 @@
 
 {/if}
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- Fullscreen modal: portaled to document.body to escape sidebar stacking context -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 {#if fullscreen}
-  <div class="panoramax-modal-backdrop" onclick={closeModal}>
+  <div use:portal class="panoramax-modal-backdrop" onclick={closeModal}>
     <div class="panoramax-modal" onclick={e => e.stopPropagation()}
          role="dialog" aria-modal="true" aria-label="Straßenfoto" tabindex="-1">
       <div class="panoramax-modal-header">

--- a/app/src/components/PanoramaxViewer.svelte
+++ b/app/src/components/PanoramaxViewer.svelte
@@ -1,10 +1,8 @@
 <script>
   import { onMount } from 'svelte';
 
-  /** @type {string[]} List of Panoramax UUIDs for this playground. */
-  export let uuids = [];
-  /** @type {string} MapComplete URL for the "add photo" link. */
-  export let mcUrl = '';
+  /** @type {{ uuids?: string[], mcUrl?: string }} */
+  let { uuids = [], mcUrl = '' } = $props();
 
   const thumbUrl  = uuid => `https://api.panoramax.xyz/api/pictures/${uuid}/thumb.jpg`;
   const viewerUrl = uuid => `https://api.panoramax.xyz/?pic=${uuid}&nav=none&focus=pic`;


### PR DESCRIPTION
## Summary

- Ports commit [`22b1d89`](https://github.com/no42-org/spielplatzkarte/pull/2/commits/22b1d89ccdf3ce28103a2a5a5dc45de7bcd75d41) from no42-org/spielplatzkarte#2
- Replaces `<svelte:body>` portal with a Svelte action (`use:portal`) for modal mounting
- Uses Svelte 5 `$state` runes for `fullscreen` and `modalIndex`
- Updates `svelte-ignore` comment syntax to Svelte 5 style (`a11y_` instead of `a11y-`)
- Fixes modal rendering in Safari where `<svelte:body>` could break stacking context

## Test plan

- [ ] Open a playground with Panoramax photos
- [ ] Click a photo to open the fullscreen modal — verify it covers the full viewport
- [ ] Test in Safari — modal should render correctly without z-index/stacking issues
- [ ] Verify keyboard navigation (Arrow keys, Escape) still works
- [ ] Verify modal closes on backdrop click

🤖 Generated with [Claude Code](https://claude.com/claude-code)