### PR TITLE
feat(install): add deployment mode selection (data-node / ui / data-node-ui)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ down: require-docker      ## Stop and remove containers
 	docker compose down
 
 import: require-docker    ## Download PBF and import OSM data into PostGIS (run once or to refresh)
-	docker compose run --rm importer
+	docker compose --profile data-node run --rm importer
 
 docker-build: require-docker  ## Rebuild and restart the Svelte app container (Dockerfile.app)
 	docker compose up -d --build app

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -4,8 +4,8 @@
 #   bash install.sh          # interactive first-time setup (recommended)
 #
 # Manual usage after install.sh has created your .env:
-#   docker compose -f compose.prod.yml up -d
-#   docker compose -f compose.prod.yml run --rm importer
+#   docker compose -f compose.prod.yml --profile data-node-ui up -d
+#   docker compose -f compose.prod.yml --profile data-node run --rm importer
 #
 # Images are published to ghcr.io on every tagged release and on every push
 # to main (tagged :latest). Pin to a specific version for reproducible deploys.
@@ -31,7 +31,7 @@ services:
     restart: unless-stopped
 
   # ── OSM importer (run manually; not started by default) ─────────────────────
-  # docker compose -f compose.prod.yml run --rm importer
+  # docker compose -f compose.prod.yml --profile data-node run --rm importer
   importer:
     image: ghcr.io/mfuhrmann/spielplatzkarte-importer:latest
     profiles: [data-node, data-node-ui]
@@ -80,8 +80,8 @@ services:
       MAP_ZOOM:                   ${MAP_ZOOM:-12}
       MAP_MIN_ZOOM:               ${MAP_MIN_ZOOM:-10}
       POI_RADIUS_M:               ${POI_RADIUS_M:-5000}
-      API_BASE_URL:               /api
-    restart: unless-stopped
+      API_BASE_URL:               ${API_BASE_URL:-/api}
+    restart: on-failure
 
 volumes:
   pgdata:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -15,6 +15,7 @@ services:
   # ── PostGIS database ────────────────────────────────────────────────────────
   db:
     image: postgis/postgis:16-3.4-alpine
+    profiles: [data-node, data-node-ui]
     environment:
       POSTGRES_DB:       osm
       POSTGRES_USER:     osm
@@ -33,6 +34,7 @@ services:
   # docker compose -f compose.prod.yml run --rm importer
   importer:
     image: ghcr.io/mfuhrmann/spielplatzkarte-importer:latest
+    profiles: [data-node, data-node-ui]
     depends_on:
       db:
         condition: service_healthy
@@ -47,12 +49,12 @@ services:
       OSM_RELATION_ID:   ${OSM_RELATION_ID}
     volumes:
       - pbf_cache:/data
-    profiles: [import]
     restart: "no"
 
   # ── PostgREST — auto-generates REST API from the api schema ─────────────────
   postgrest:
     image: postgrest/postgrest:v12.2.0
+    profiles: [data-node, data-node-ui]
     depends_on:
       db:
         condition: service_healthy
@@ -67,8 +69,7 @@ services:
   # ── Svelte app — serves the frontend and proxies /api/ to PostgREST ─────────
   app:
     image: ghcr.io/mfuhrmann/spielplatzkarte:rc
-    depends_on:
-      - postgrest
+    profiles: [ui, data-node-ui]
     ports:
       - "${APP_PORT:-8080}:80"
     environment:

--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,10 @@ fi
 # ── Deployment mode selection ──────────────────────────────────────────────────
 
 if [[ -n "$DEPLOY_MODE" ]]; then
+    case "$DEPLOY_MODE" in
+        data-node|ui|data-node-ui) ;;
+        *) die "DEPLOY_MODE='$DEPLOY_MODE' in existing .env is not valid. Edit it to one of: data-node, ui, data-node-ui." ;;
+    esac
     warn "Existing DEPLOY_MODE=${DEPLOY_MODE} detected — keeping it. (Re-run to change.)"
 elif [[ "$EXISTING_ENV" == "true" ]]; then
     # Old .env without DEPLOY_MODE — assume full stack for backward compatibility
@@ -181,18 +185,17 @@ fi
 
 # ── Optional: infrastructure ──────────────────────────────────────────────────
 
+APP_PORT=""
+OSM2PGSQL_THREADS=""
+
 printf "\n${BOLD}── Optional: infrastructure ────────────────────────────────────${RESET}\n"
 
 if [[ "$DEPLOY_MODE" != "data-node" ]]; then
     ask APP_PORT "Host port to expose the app on" "8080"
-else
-    APP_PORT=""
 fi
 
 if [[ "$DEPLOY_MODE" != "ui" ]]; then
     ask OSM2PGSQL_THREADS "CPU threads for the OSM import" "4"
-else
-    OSM2PGSQL_THREADS=""
 fi
 
 # ── Generate password (data-node and data-node-ui only) ───────────────────────
@@ -237,8 +240,8 @@ success "Files downloaded."
         printf "PBF_URL=%s\n\n" "$PBF_URL"
     fi
 
-    if [[ "$DEPLOY_MODE" == "ui" ]]; then
-        printf "# ── Remote data node ────────────────────────────────────────────\n"
+    if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+        printf "# ── API base URL ─────────────────────────────────────────────────\n"
         printf "API_BASE_URL=%s\n\n" "$API_BASE_URL"
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,24 @@ fetch() {
     fi
 }
 
+choose_mode() {
+    while true; do
+        printf "\n${BOLD}── Deployment mode ─────────────────────────────────────────────${RESET}\n"
+        printf "  ${BOLD}1)${RESET} data-node     — database + PostgREST only (no UI)\n"
+        printf "  ${BOLD}2)${RESET} ui            — frontend only (connects to a remote data node)\n"
+        printf "  ${BOLD}3)${RESET} data-node-ui  — full stack: database + PostgREST + UI\n\n"
+        printf "${BOLD}Select deployment mode${RESET} [1-3]: "
+        read -r choice
+        case "$choice" in
+            1) DEPLOY_MODE="data-node";    break ;;
+            2) DEPLOY_MODE="ui";           break ;;
+            3) DEPLOY_MODE="data-node-ui"; break ;;
+            *) warn "Invalid choice — please enter 1, 2, or 3." ;;
+        esac
+    done
+    success "Deployment mode: ${BOLD}${DEPLOY_MODE}${RESET}"
+}
+
 # ── Dependency check ───────────────────────────────────────────────────────────
 
 for cmd in docker openssl; do
@@ -84,49 +102,111 @@ ask DEPLOY_DIR "Deployment directory" "./spielplatzkarte"
 mkdir -p "$DEPLOY_DIR/db"
 
 EXISTING_PASSWORD=""
+DEPLOY_MODE=""
+EXISTING_ENV=false
 if [[ -f "$DEPLOY_DIR/.env" ]]; then
+    EXISTING_ENV=true
     warn ".env already exists in $DEPLOY_DIR"
     EXISTING_PASSWORD="$(grep '^POSTGRES_PASSWORD=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
+    DEPLOY_MODE="$(grep '^DEPLOY_MODE=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2 || true)"
     confirm "Overwrite it?" || die "Aborted."
 fi
 
-# ── Region configuration ───────────────────────────────────────────────────────
+# ── Deployment mode selection ──────────────────────────────────────────────────
 
-printf "\n${BOLD}── Region ──────────────────────────────────────────────────────${RESET}\n"
-printf "Find the OSM relation ID: https://nominatim.openstreetmap.org\n"
-printf "Find a PBF extract:       https://download.geofabrik.de\n\n"
+if [[ -n "$DEPLOY_MODE" ]]; then
+    warn "Existing DEPLOY_MODE=${DEPLOY_MODE} detected — keeping it. (Re-run to change.)"
+elif [[ "$EXISTING_ENV" == "true" ]]; then
+    # Old .env without DEPLOY_MODE — assume full stack for backward compatibility
+    DEPLOY_MODE="data-node-ui"
+    warn "No DEPLOY_MODE in existing .env — defaulting to data-node-ui for backward compatibility."
+else
+    choose_mode
+fi
 
-ask OSM_RELATION_ID "OSM relation ID of your region (e.g. 62700 = Landkreis Fulda)"
-ask PBF_URL         "Geofabrik PBF URL covering your region" \
-    "https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf"
+# ── Region configuration (data-node and data-node-ui only) ────────────────────
 
-# ── Optional UI links ──────────────────────────────────────────────────────────
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    printf "\n${BOLD}── Region ──────────────────────────────────────────────────────${RESET}\n"
+    printf "Find the OSM relation ID: https://nominatim.openstreetmap.org\n"
+    printf "Find a PBF extract:       https://download.geofabrik.de\n\n"
 
-printf "\n${BOLD}── Optional: UI links ──────────────────────────────────────────${RESET}\n"
-ask_optional REGION_PLAYGROUND_WIKI_URL "Wiki page for 'Contribute data' modal"
-ask_optional REGION_CHAT_URL           "Community chat URL shown in 'Contribute data' modal"
+    ask OSM_RELATION_ID "OSM relation ID of your region (e.g. 62700 = Landkreis Fulda)"
+    ask PBF_URL         "Geofabrik PBF URL covering your region" \
+        "https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf"
+else
+    OSM_RELATION_ID=""
+    PBF_URL=""
+fi
 
-# ── Optional: map display ──────────────────────────────────────────────────────
+# ── Remote API URL (ui mode only) ─────────────────────────────────────────────
 
-printf "\n${BOLD}── Optional: map display ───────────────────────────────────────${RESET}\n"
-ask MAP_ZOOM      "Initial map zoom level"           "12"
-ask MAP_MIN_ZOOM  "Minimum zoom level"               "10"
-ask POI_RADIUS_M  "Nearby POI search radius (metres)" "5000"
+if [[ "$DEPLOY_MODE" == "ui" ]]; then
+    printf "\n${BOLD}── Remote data node ────────────────────────────────────────────${RESET}\n"
+    printf "Enter the base URL of the PostgREST API on your data node.\n\n"
+
+    while true; do
+        printf "${BOLD}Remote API base URL${RESET} (e.g. https://data.example.com/api): "
+        read -r API_BASE_URL
+        [[ -n "$API_BASE_URL" ]] && break
+        warn "Remote API base URL is required for UI mode."
+    done
+else
+    API_BASE_URL="/api"
+fi
+
+# ── Optional UI links (ui and data-node-ui only) ───────────────────────────────
+
+if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+    printf "\n${BOLD}── Optional: UI links ──────────────────────────────────────────${RESET}\n"
+    ask_optional REGION_PLAYGROUND_WIKI_URL "Wiki page for 'Contribute data' modal"
+    ask_optional REGION_CHAT_URL           "Community chat URL shown in 'Contribute data' modal"
+else
+    REGION_PLAYGROUND_WIKI_URL=""
+    REGION_CHAT_URL=""
+fi
+
+# ── Optional: map display (ui and data-node-ui only) ──────────────────────────
+
+if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+    printf "\n${BOLD}── Optional: map display ───────────────────────────────────────${RESET}\n"
+    ask MAP_ZOOM      "Initial map zoom level"           "12"
+    ask MAP_MIN_ZOOM  "Minimum zoom level"               "10"
+    ask POI_RADIUS_M  "Nearby POI search radius (metres)" "5000"
+else
+    MAP_ZOOM="12"
+    MAP_MIN_ZOOM="10"
+    POI_RADIUS_M="5000"
+fi
 
 # ── Optional: infrastructure ──────────────────────────────────────────────────
 
 printf "\n${BOLD}── Optional: infrastructure ────────────────────────────────────${RESET}\n"
-ask APP_PORT          "Host port to expose the app on"          "8080"
-ask OSM2PGSQL_THREADS "CPU threads for the OSM import"          "4"
 
-# ── Generate password ──────────────────────────────────────────────────────────
-
-if [[ -n "$EXISTING_PASSWORD" ]]; then
-    POSTGRES_PASSWORD="$EXISTING_PASSWORD"
-    success "Reusing existing database password (database volume already initialised)."
+if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+    ask APP_PORT "Host port to expose the app on" "8080"
 else
-    POSTGRES_PASSWORD="$(openssl rand -hex 32)"
-    success "Generated secure database password."
+    APP_PORT=""
+fi
+
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    ask OSM2PGSQL_THREADS "CPU threads for the OSM import" "4"
+else
+    OSM2PGSQL_THREADS=""
+fi
+
+# ── Generate password (data-node and data-node-ui only) ───────────────────────
+
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    if [[ -n "$EXISTING_PASSWORD" ]]; then
+        POSTGRES_PASSWORD="$EXISTING_PASSWORD"
+        success "Reusing existing database password (database volume already initialised)."
+    else
+        POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+        success "Generated secure database password."
+    fi
+else
+    POSTGRES_PASSWORD=""
 fi
 
 # ── Download files ─────────────────────────────────────────────────────────────
@@ -137,41 +217,59 @@ printf "\n"
 info "Downloading compose.prod.yml..."
 fetch "$BASE_URL/compose.prod.yml" "$DEPLOY_DIR/compose.yml"
 
-info "Downloading db/init.sql..."
-fetch "$BASE_URL/db/init.sql" "$DEPLOY_DIR/db/init.sql"
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    info "Downloading db/init.sql..."
+    fetch "$BASE_URL/db/init.sql" "$DEPLOY_DIR/db/init.sql"
+fi
 
 success "Files downloaded."
 
 # ── Write .env ─────────────────────────────────────────────────────────────────
 
-cat > "$DEPLOY_DIR/.env" <<EOF
-# Generated by install.sh — $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+{
+    printf "# Generated by install.sh — %s\n\n" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    printf "# ── Deployment mode ─────────────────────────────────────────────\n"
+    printf "DEPLOY_MODE=%s\n\n" "$DEPLOY_MODE"
 
-# ── Required: region ──────────────────────────────────────────────────────────
-OSM_RELATION_ID=${OSM_RELATION_ID}
-PBF_URL=${PBF_URL}
+    if [[ "$DEPLOY_MODE" != "ui" ]]; then
+        printf "# ── Required: region ────────────────────────────────────────────\n"
+        printf "OSM_RELATION_ID=%s\n" "$OSM_RELATION_ID"
+        printf "PBF_URL=%s\n\n" "$PBF_URL"
+    fi
 
-# ── Optional: UI links ────────────────────────────────────────────────────────
-REGION_PLAYGROUND_WIKI_URL=${REGION_PLAYGROUND_WIKI_URL}
-REGION_CHAT_URL=${REGION_CHAT_URL}
+    if [[ "$DEPLOY_MODE" == "ui" ]]; then
+        printf "# ── Remote data node ────────────────────────────────────────────\n"
+        printf "API_BASE_URL=%s\n\n" "$API_BASE_URL"
+    fi
 
-# ── Optional: map display ─────────────────────────────────────────────────────
-MAP_ZOOM=${MAP_ZOOM}
-MAP_MIN_ZOOM=${MAP_MIN_ZOOM}
-POI_RADIUS_M=${POI_RADIUS_M}
+    if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+        printf "# ── Optional: UI links ──────────────────────────────────────────\n"
+        printf "REGION_PLAYGROUND_WIKI_URL=%s\n" "$REGION_PLAYGROUND_WIKI_URL"
+        printf "REGION_CHAT_URL=%s\n\n" "$REGION_CHAT_URL"
 
-# ── Optional: Hub integration ─────────────────────────────────────────────────
-# Set to the Hub's full origin (e.g. https://hub.example.com) when embedding
-# this instance in a Spielplatzkarte Hub. Leave empty for standalone deployments.
-# PARENT_ORIGIN=
+        printf "# ── Optional: map display ───────────────────────────────────────\n"
+        printf "MAP_ZOOM=%s\n" "$MAP_ZOOM"
+        printf "MAP_MIN_ZOOM=%s\n" "$MAP_MIN_ZOOM"
+        printf "POI_RADIUS_M=%s\n\n" "$POI_RADIUS_M"
+    fi
 
-# ── Optional: infrastructure ──────────────────────────────────────────────────
-APP_PORT=${APP_PORT}
-OSM2PGSQL_THREADS=${OSM2PGSQL_THREADS}
+    printf "# ── Optional: Hub integration ───────────────────────────────────\n"
+    printf "# Set to the Hub's full origin (e.g. https://hub.example.com) when embedding\n"
+    printf "# this instance in a Spielplatzkarte Hub. Leave empty for standalone deployments.\n"
+    printf "# PARENT_ORIGIN=\n\n"
 
-# ── Database (auto-generated — do not edit) ───────────────────────────────────
-POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-EOF
+    if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+        printf "# ── Optional: infrastructure ────────────────────────────────────\n"
+        printf "APP_PORT=%s\n" "$APP_PORT"
+    fi
+
+    if [[ "$DEPLOY_MODE" != "ui" ]]; then
+        printf "OSM2PGSQL_THREADS=%s\n\n" "$OSM2PGSQL_THREADS"
+
+        printf "# ── Database (auto-generated — do not edit) ─────────────────────\n"
+        printf "POSTGRES_PASSWORD=%s\n" "$POSTGRES_PASSWORD"
+    fi
+} > "$DEPLOY_DIR/.env"
 
 success "Configuration written to $DEPLOY_DIR/.env"
 
@@ -180,7 +278,8 @@ success "Configuration written to $DEPLOY_DIR/.env"
 printf "\n"
 if confirm "Pull Docker images now? (recommended, ~500 MB)"; then
     info "Pulling images..."
-    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" pull
+    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" \
+        --profile "$DEPLOY_MODE" pull
     success "Images pulled."
 fi
 
@@ -188,49 +287,74 @@ fi
 
 printf "\n"
 if confirm "Start the stack now?"; then
-    # ── Check for stale pgdata volume ──────────────────────────────────────────
-    PROJECT_NAME="$(basename "$(cd "$DEPLOY_DIR" && pwd)")"
-    VOLUME_NAME="${PROJECT_NAME}_pgdata"
-    if docker volume ls --format '{{.Name}}' | grep -q "^${VOLUME_NAME}$"; then
-        warn "A database volume '${VOLUME_NAME}' already exists."
-        warn "This often means a previous install or a dev stack with the same"
-        warn "directory name already initialised the database with a different password."
-        warn "Starting without removing it will cause authentication failures."
-        printf "\n"
-        if confirm "Delete the existing volume and start fresh? (existing data will be lost)"; then
-            docker volume rm "$VOLUME_NAME" >/dev/null
-            success "Volume removed. Database will be initialised with the new password."
-        else
-            warn "Proceeding without removing the volume — authentication may fail."
+    if [[ "$DEPLOY_MODE" != "ui" ]]; then
+        # ── Check for stale pgdata volume ──────────────────────────────────────
+        PROJECT_NAME="$(basename "$(cd "$DEPLOY_DIR" && pwd)")"
+        VOLUME_NAME="${PROJECT_NAME}_pgdata"
+        if docker volume ls --format '{{.Name}}' | grep -q "^${VOLUME_NAME}$"; then
+            warn "A database volume '${VOLUME_NAME}' already exists."
+            warn "This often means a previous install or a dev stack with the same"
+            warn "directory name already initialised the database with a different password."
+            warn "Starting without removing it will cause authentication failures."
+            printf "\n"
+            if confirm "Delete the existing volume and start fresh? (existing data will be lost)"; then
+                docker volume rm "$VOLUME_NAME" >/dev/null
+                success "Volume removed. Database will be initialised with the new password."
+            else
+                warn "Proceeding without removing the volume — authentication may fail."
+            fi
+            printf "\n"
         fi
-        printf "\n"
     fi
 
-    info "Starting db, PostgREST, and app..."
-    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" up -d
+    case "$DEPLOY_MODE" in
+        data-node)    info "Starting db and PostgREST..." ;;
+        ui)           info "Starting app..." ;;
+        data-node-ui) info "Starting db, PostgREST, and app..." ;;
+    esac
+
+    docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" \
+        --profile "$DEPLOY_MODE" up -d
     success "Stack started."
 
-    # ── Run import ─────────────────────────────────────────────────────────────
-    printf "\n"
-    warn "The map will be empty until you import OSM data."
-    if confirm "Run the OSM import now? (downloads the PBF and may take several minutes)"; then
-        info "Starting importer..."
-        docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" \
-            run --rm importer
-        success "Import complete."
-    else
-        printf "\nRun the import later with:\n"
-        printf "  ${CYAN}docker compose -f %s/compose.yml run --rm importer${RESET}\n" "$DEPLOY_DIR"
+    # ── Run import (data-node and data-node-ui only) ───────────────────────────
+    if [[ "$DEPLOY_MODE" != "ui" ]]; then
+        printf "\n"
+        warn "The map will be empty until you import OSM data."
+        if confirm "Run the OSM import now? (downloads the PBF and may take several minutes)"; then
+            info "Starting importer..."
+            docker compose -f "$DEPLOY_DIR/compose.yml" --env-file "$DEPLOY_DIR/.env" \
+                --profile "$DEPLOY_MODE" run --rm importer
+            success "Import complete."
+        else
+            printf "\nRun the import later with:\n"
+            printf "  ${CYAN}docker compose -f %s/compose.yml --profile %s run --rm importer${RESET}\n" \
+                "$DEPLOY_DIR" "$DEPLOY_MODE"
+        fi
     fi
 fi
 
 # ── Done ───────────────────────────────────────────────────────────────────────
 
 printf "\n${GREEN}${BOLD}Done!${RESET}\n\n"
-printf "  App:    ${CYAN}http://localhost:${APP_PORT}${RESET}\n"
+
+if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+    printf "  App:    ${CYAN}http://localhost:${APP_PORT}${RESET}\n"
+fi
 printf "  Dir:    ${CYAN}%s${RESET}\n\n" "$(cd "$DEPLOY_DIR" && pwd)"
+
 printf "Useful commands (run from ${CYAN}%s${RESET}):\n" "$(cd "$DEPLOY_DIR" && pwd)"
-printf "  docker compose up -d                   # start the stack\n"
-printf "  docker compose down                    # stop the stack\n"
-printf "  docker compose run --rm importer       # re-import OSM data\n"
-printf "  docker compose logs -f postgrest        # watch PostgREST logs\n"
+printf "  docker compose --profile %s up -d        # start the stack\n" "$DEPLOY_MODE"
+printf "  docker compose --profile %s down         # stop the stack\n" "$DEPLOY_MODE"
+
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    printf "  docker compose --profile %s run --rm importer  # re-import OSM data\n" "$DEPLOY_MODE"
+fi
+
+if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+    printf "  docker compose logs -f app              # watch app logs\n"
+fi
+
+if [[ "$DEPLOY_MODE" != "ui" ]]; then
+    printf "  docker compose logs -f postgrest        # watch PostgREST logs\n"
+fi


### PR DESCRIPTION
## Summary

- Adds an interactive deployment mode selection step to `install.sh` so operators can choose `data-node` (DB + PostgREST only), `ui` (frontend only, remote API), or `data-node-ui` (full stack, previous default)
- `compose.prod.yml` gains Docker Compose profiles per service so only the relevant services start for the selected mode
- Questions, `.env` output, `docker compose` calls, and the done message are all conditionally scoped to the chosen mode; existing `.env` files without `DEPLOY_MODE` default to `data-node-ui` automatically

## Test plan

- [ ] Run `bash install.sh` and select `data-node-ui` — verify existing behaviour is unchanged end-to-end
- [ ] Run `bash install.sh` and select `data-node` — verify only region/PBF/threads questions appear, no app URL in done message, `docker compose --profile data-node config` shows only db/postgrest/importer
- [ ] Run `bash install.sh` and select `ui` — verify only remote API URL/UI-links/map questions appear, no import prompt, `API_BASE_URL` written to `.env`, `docker compose --profile ui config` shows only app
- [ ] Simulate re-run over existing `.env` with `DEPLOY_MODE` set — verify mode is kept without re-prompting
- [ ] Simulate re-run over old `.env` without `DEPLOY_MODE` — verify it defaults to `data-node-ui`
- [ ] Enter invalid choice (e.g. `5`) at mode prompt — verify menu re-displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)