### PR TITLE
fix(install): address review findings from PR #118

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ down: require-docker      ## Stop and remove containers
 	docker compose down
 
 import: require-docker    ## Download PBF and import OSM data into PostGIS (run once or to refresh)
-	docker compose run --rm importer
+	docker compose --profile data-node run --rm importer
 
 docker-build: require-docker  ## Rebuild and restart the Svelte app container (Dockerfile.app)
 	docker compose up -d --build app

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -4,8 +4,8 @@
 #   bash install.sh          # interactive first-time setup (recommended)
 #
 # Manual usage after install.sh has created your .env:
-#   docker compose -f compose.prod.yml up -d
-#   docker compose -f compose.prod.yml run --rm importer
+#   docker compose -f compose.prod.yml --profile data-node-ui up -d
+#   docker compose -f compose.prod.yml --profile data-node run --rm importer
 #
 # Images are published to ghcr.io on every tagged release and on every push
 # to main (tagged :latest). Pin to a specific version for reproducible deploys.
@@ -31,7 +31,7 @@ services:
     restart: unless-stopped
 
   # ── OSM importer (run manually; not started by default) ─────────────────────
-  # docker compose -f compose.prod.yml run --rm importer
+  # docker compose -f compose.prod.yml --profile data-node run --rm importer
   importer:
     image: ghcr.io/mfuhrmann/spielplatzkarte-importer:latest
     profiles: [data-node, data-node-ui]
@@ -80,8 +80,8 @@ services:
       MAP_ZOOM:                   ${MAP_ZOOM:-12}
       MAP_MIN_ZOOM:               ${MAP_MIN_ZOOM:-10}
       POI_RADIUS_M:               ${POI_RADIUS_M:-5000}
-      API_BASE_URL:               /api
-    restart: unless-stopped
+      API_BASE_URL:               ${API_BASE_URL:-/api}
+    restart: on-failure
 
 volumes:
   pgdata:

--- a/install.sh
+++ b/install.sh
@@ -115,6 +115,10 @@ fi
 # ── Deployment mode selection ──────────────────────────────────────────────────
 
 if [[ -n "$DEPLOY_MODE" ]]; then
+    case "$DEPLOY_MODE" in
+        data-node|ui|data-node-ui) ;;
+        *) die "DEPLOY_MODE='$DEPLOY_MODE' in existing .env is not valid. Edit it to one of: data-node, ui, data-node-ui." ;;
+    esac
     warn "Existing DEPLOY_MODE=${DEPLOY_MODE} detected — keeping it. (Re-run to change.)"
 elif [[ "$EXISTING_ENV" == "true" ]]; then
     # Old .env without DEPLOY_MODE — assume full stack for backward compatibility
@@ -181,18 +185,17 @@ fi
 
 # ── Optional: infrastructure ──────────────────────────────────────────────────
 
+APP_PORT=""
+OSM2PGSQL_THREADS=""
+
 printf "\n${BOLD}── Optional: infrastructure ────────────────────────────────────${RESET}\n"
 
 if [[ "$DEPLOY_MODE" != "data-node" ]]; then
     ask APP_PORT "Host port to expose the app on" "8080"
-else
-    APP_PORT=""
 fi
 
 if [[ "$DEPLOY_MODE" != "ui" ]]; then
     ask OSM2PGSQL_THREADS "CPU threads for the OSM import" "4"
-else
-    OSM2PGSQL_THREADS=""
 fi
 
 # ── Generate password (data-node and data-node-ui only) ───────────────────────
@@ -237,8 +240,8 @@ success "Files downloaded."
         printf "PBF_URL=%s\n\n" "$PBF_URL"
     fi
 
-    if [[ "$DEPLOY_MODE" == "ui" ]]; then
-        printf "# ── Remote data node ────────────────────────────────────────────\n"
+    if [[ "$DEPLOY_MODE" != "data-node" ]]; then
+        printf "# ── API base URL ─────────────────────────────────────────────────\n"
         printf "API_BASE_URL=%s\n\n" "$API_BASE_URL"
     fi
 


### PR DESCRIPTION
## Summary

Follow-up fixes for review feedback on #118. Addresses all 5 items raised:

1. **`Makefile` + `compose.prod.yml` comments** — `make import` and manual usage examples now include `--profile data-node` so existing users aren't silently broken by the importer profile rename
2. **`app` startup ordering** — `restart: unless-stopped` → `restart: on-failure` so the container retries on first boot if PostgREST isn't ready yet (replaces the removed `depends_on`); `API_BASE_URL` is now read from env (`${API_BASE_URL:-/api}`) so the value written by the installer is actually used
3. **`DEPLOY_MODE` validation** — installer now validates the value read from an existing `.env` and calls `die` with a clear message if it's not one of the three known values
4. **`API_BASE_URL` in `.env`** — written for both `ui` and `data-node-ui` modes (was `ui`-only), making the file self-documenting for operators editing it manually
5. **Infrastructure section header** — initialise `APP_PORT`/`OSM2PGSQL_THREADS` to `""` upfront and remove the `else` branches; header always prints since every mode asks at least one question

## Test plan

- [ ] `make import` runs correctly with the new `--profile data-node` flag
- [ ] `data-node-ui` first boot: app container retries and comes up healthy once PostgREST is ready
- [ ] `data-node-ui` install: `.env` contains `API_BASE_URL=/api`
- [ ] Edit an existing `.env` to `DEPLOY_MODE=garbage` and re-run installer — verify it exits with a clear error
- [ ] All three modes: infrastructure header still appears with the correct question(s) beneath it

🤖 Generated with [Claude Code](https://claude.com/claude-code)