### PR TITLE
docs: set up MkDocs Material site and slim README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "docs/requirements.txt"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install docs dependencies
+        run: make docs-install
+
+      - name: Deploy to GitHub Pages
+        run: .venv/bin/mkdocs gh-deploy --force --strict

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ playwright-report/
 _bmad-output/
 _bmad/
 openspec/
+
+# MkDocs
+site/
+.venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+All contributions are welcome — code, translations, bug reports, or documentation improvements.
+
+## Repository layout
+
+| Directory | Contents |
+|---|---|
+| `app/` | Svelte 5 frontend app (source in `app/src/`) |
+| `importer/` | osm2pgsql import scripts and PostgREST API SQL |
+| `db/` | PostgreSQL initialisation SQL |
+| `oci/` | Docker build contexts — `oci/app/` (Svelte app + nginx) and `oci/data-node/` |
+| `processing/` | OSM data pipeline scripts (Lua rules, SQL, shell) used during import |
+| `taginfo/` | [taginfo](https://taginfo.openstreetmap.org) metadata describing the OSM tags this project uses |
+| `locales/` | Translation files (`*.json`, one per language) — not yet active in the Svelte rewrite |
+| `deploy/` | Systemd unit files for automated weekly import on Linux servers |
+
+## Step 1 — Create a GitHub issue
+
+Before writing code, open an issue describing what you want to fix or add. This lets maintainers give early feedback and avoids duplicated effort. Skip this for tiny fixes like typos.
+
+## Step 2 — Create a branch
+
+```bash
+git checkout main
+git pull
+git checkout -b fix/my-fix-name
+```
+
+**Branch naming:**
+
+| Prefix | Use for |
+|---|---|
+| `feat/` | New feature (e.g. `feat/add-balance-beam-device`) |
+| `fix/` | Bug fix (e.g. `fix/popup-scroll`) |
+| `docs/` | Documentation only (e.g. `docs/add-glossary`) |
+| `chore/` | Maintenance, dependency updates |
+
+## Step 3 — Make your change and test it
+
+For frontend changes, run `make dev` and verify the feature in your browser. For Docker stack changes, run `make docker-build` and test at `http://localhost:8080`.
+
+If you edited documentation, run `make docs-build` before pushing — the CI deploy uses `--strict` mode and will fail on broken links or missing nav entries.
+
+## Step 4 — Commit with a conventional commit message
+
+```bash
+git add app/src/lib/yourChangedFile.js
+git commit -m "feat: add balance_beam playground device"
+```
+
+**Format:** `<type>: <short description>`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `chore`, `ci`
+
+Examples:
+
+- `feat: add filtering by device height`
+- `fix: location button not showing nearby playgrounds on mobile`
+- `docs: add balance_beam to device how-to guide`
+
+## Step 5 — Push and open a pull request
+
+```bash
+git push -u origin fix/my-fix-name
+```
+
+GitHub will print a link to open a pull request. Write a short description of what you changed and why, and submit. A maintainer will review it.
+
+> **Never push directly to `main`.** All changes go through a branch and a pull request.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: install dev build serve test \
         up down import docker-build db-apply db-shell \
-        require-npm require-docker installer lan-url help
+        require-npm require-docker installer lan-url \
+        docs-install docs-serve docs-build docs-clean \
+        help
 
 # Bail with a clear message when a required tool is missing.
 define require
@@ -84,6 +86,21 @@ lan-url:                  ## Print the LAN URLs to open the app on a phone (same
 	    printf '  \033[36mVite dev server:\033[0m   http://%s:5173\n' "$$LAN_IP" && \
 	    printf '  \033[36mDocker stack:\033[0m      http://%s:%s\n\n' "$$LAN_IP" "$$APP_PORT"; \
 	  fi
+
+## ── Documentation ────────────────────────────────────────────────────────────
+
+docs-install:             ## Set up Python venv and install MkDocs dependencies
+	python3 -m venv .venv
+	.venv/bin/pip install --quiet -r docs/requirements.txt
+
+docs-serve:               ## Start MkDocs live-reload server at http://localhost:8000
+	.venv/bin/mkdocs serve
+
+docs-build:               ## Build static docs site into site/
+	.venv/bin/mkdocs build --strict
+
+docs-clean:               ## Remove site/ and .venv
+	rm -rf site/ .venv
 
 ## ── Help ──────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -4,58 +4,11 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 
 > **Origin:** This project is a further development of the original [Berliner Spielplatzkarte](https://github.com/SupaplexOSM/spielplatzkarte) by Alex Seidel.
 
----
-
-## Table of contents
-
-- [Features](#features)
-- [How the data flows](#how-the-data-flows)
-- [Tech stack](#tech-stack)
-- [Glossary](#glossary)
-- [Deploy for your region](#deploy-for-your-region)
-- [Configuration reference](#configuration-reference)
-- [Local development](#local-development)
-- [How-to: Add a playground device](#how-to-add-a-playground-device)
-- [How-to: Edit UI strings / add a language](#how-to-edit-ui-strings--add-a-language)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [Federation](#federation)
-- [External services](#external-services)
-- [License](#license)
+**[Documentation](https://mfuhrmann.github.io/spielplatzkarte/)**
 
 ---
 
-## Features
-
-**Map**
-- Display all playgrounds in a configured OSM region on an interactive map
-- Playground polygons coloured by data completeness (same logic used for polygon outline, hover tooltip dot, and detail panel badge):
-  - 🟢 **Vollständig** — has at least one Panoramax photo (`panoramax` / `panoramax:*` tag) **and** a `name` **and** at least one of `operator`, `opening_hours`, `surface`, or `access` (with a value other than `yes`)
-  - 🟡 **Teilweise erfasst** — has at least one of the above criteria but not all three
-  - 🔴 **Daten fehlen** — none of the above are present
-- Private and customers-only playgrounds (`access=private` / `access=customers`) shown with a diagonal hatch pattern and dashed border
-- Hover tooltip with playground name, key attributes, and completeness indicator
-
-**Playground detail panel**
-- Name, size (m²), surface (Bodenbelag), access restrictions, opening hours (parsed live), age restrictions, operator, contact info
-- Equipment list (Ausstattung): individual collapsible items with attributes; sport-specific labels for pitches (Fußball, Basketball, Volleyball, …); example images loaded from [Wikimedia Commons](https://commons.wikimedia.org) (OSM wiki as fallback); broken images are hidden automatically
-- Per-device **"Add photo"** link to [MapComplete](https://mapcomplete.org) when no real Panoramax photo exists (playground devices → `playgrounds` theme, fitness stations and sport pitches → `sports` theme)
-- Tree count: number of mapped `natural=tree` nodes in and around the playground, shown as a map layer when a playground is selected
-- Street photos via [Panoramax](https://panoramax.xyz) — inline viewer with fullscreen modal and keyboard navigation
-- Community reviews via [Mangrove.reviews](https://mangrove.reviews) — read ratings and submit your own (pseudonymous, no account required)
-- Nearby POIs within a configurable radius: toilets, bus stops, ice cream, supermarkets, drugstores, emergency rooms (`emergency=yes` or `healthcare:speciality=emergency`) — with approximate distance (~) and OSM foot routing
-- Permalink: every playground gets a shareable `#W<id>` URL; share button uses the Web Share API (mobile) or copies to clipboard
-- Add photos and equipment directly via [MapComplete](https://mapcomplete.org/playgrounds)
-
-**Navigation & UX**
-- Location search via [Nominatim](https://nominatim.openstreetmap.org) with nearby playground suggestions — focus with **Double-Shift**
-- Geolocation: show nearest playgrounds to current position
-- **ESC** deselects the active playground and clears the URL hash
-- Responsive layout: desktop (left sidebar card) and mobile (swipeable bottom sheet with drag-to-close)
-
----
-
-## How the data flows
+## Architecture
 
 ```
                   ┌─────────────────────────────────────────────────────┐
@@ -67,12 +20,7 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
                    proxies API    HTTP endpoints)     data)             │
                    requests)                                            │
                   └─────────────────────────────────────────────────────┘
-
 ```
-
-**In production**, your browser loads the app from nginx. When it needs playground data, it calls `/api/`, which nginx forwards to PostgREST. PostgREST runs a SQL function in PostgreSQL and returns the results as JSON — no custom server code needed. The database was pre-loaded with OpenStreetMap data by the osm2pgsql importer (a one-time step that you re-run whenever you want fresh data).
-
-**During local development**, the Vite dev server serves the JavaScript with instant hot-reload. The Docker stack (database + PostgREST + nginx) still needs to be running in the background to provide the API — `make up` handles this.
 
 ---
 
@@ -81,479 +29,73 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 | Component | Technology |
 |---|---|
 | Map | [OpenLayers](https://openlayers.org/) |
-| UI framework | [Bootstrap 5](https://getbootstrap.com/) + [Bootstrap Icons](https://icons.getbootstrap.com/) + [Tailwind CSS 4](https://tailwindcss.com/) |
-| Icons | [lucide-svelte](https://lucide.dev/) |
-| Opening hours parser | [opening_hours.js](https://github.com/opening-hours/opening_hours.js) |
+| UI / icons | [Bootstrap 5](https://getbootstrap.com/) + [Tailwind CSS 4](https://tailwindcss.com/) + [lucide-svelte](https://lucide.dev/) |
+| Language | [Svelte 5](https://svelte.dev/) |
 | Build tool | [Vite 6](https://vitejs.dev/) |
-| Internationalisation | [i18next](https://www.i18next.com/) (planned; not yet active in Svelte rewrite) |
-| Language | [Svelte 5](https://svelte.dev/) (ES Modules) |
 | Database | [PostgreSQL 16](https://www.postgresql.org/) + [PostGIS 3.4](https://postgis.net/) |
-| OSM import | [osm2pgsql](https://osm2pgsql.org/) (classic schema, `--hstore`) |
+| OSM import | [osm2pgsql](https://osm2pgsql.org/) |
 | API layer | [PostgREST v12](https://postgrest.org/) |
 | Web server | [nginx](https://nginx.org/) |
-| Container runtime | [Docker](https://www.docker.com/) / Docker Compose |
+| Container runtime | Docker / Docker Compose |
 
 ---
 
-## Glossary
+## Deploy
 
-These are the tools and concepts you'll encounter when working on this project. You don't need to be an expert in all of them — but knowing what they are makes the rest of this README much easier to follow.
-
-| Term | What it is |
-|---|---|
-| **OpenStreetMap (OSM)** | A free, editable world map built by volunteers — the source of all the playground data in this app. |
-| **OSM relation ID** | Every city, district, or region in OSM has a numeric ID. We use it to tell the app which area to show. Example: `62700` is Landkreis Fulda. |
-| **PBF file** | A compressed snapshot of OSM map data for a region, available for download from Geofabrik. The importer reads this file to populate the database. |
-| **Docker** | A tool that packages software and all its dependencies into isolated "containers" so it runs the same way on any machine. You don't need to install PostgreSQL, nginx, or PostgREST manually — Docker handles all of that. |
-| **Docker Compose** | A companion to Docker that lets you define and start multiple containers together with one command (`docker compose up`). Our stack has four: the database, the importer, the API layer, and the web server. |
-| **nginx** | A web server. In this project it serves the built frontend files (HTML/CSS/JS) and forwards API requests to PostgREST. Think of it as the front door of the app. |
-| **Vite** | A build tool for JavaScript. During development it serves your JS files with instant hot-reload. For production, it bundles and optimises everything into a single small file. You run it with `make dev`. |
-| **Node.js** | A JavaScript runtime that runs on your computer (not in the browser). Vite needs it. You install it once and then mostly forget about it. |
-| **PostgreSQL** | A relational database — where all the playground data lives once it's been imported. |
-| **PostGIS** | An extension to PostgreSQL that adds support for geographic data (points, polygons, distances). It's what lets us query "find all playgrounds within 500 m of this location". |
-| **osm2pgsql** | A tool that reads a PBF file and imports the OSM data into PostgreSQL. You run it once (via `make import`) to load the data, and again whenever you want to refresh it. |
-| **PostgREST** | A server that automatically turns your PostgreSQL database into a REST API. Instead of writing server-side code, you write SQL functions and PostgREST exposes them as HTTP endpoints. |
-| **Svelte** | A JavaScript UI framework that compiles components to efficient vanilla JS at build time — no virtual DOM. The entire frontend (`app/src/`) is written in Svelte 5. |
-| **Tailwind CSS** | A utility-first CSS framework. Instead of writing custom CSS classes, you compose styles inline using small utility classes like `p-4` or `flex`. Used alongside Bootstrap 5 in this project. |
-| **OpenLayers** | A JavaScript library for interactive maps. It handles rendering the map tiles, drawing the playground polygons, and responding to clicks. |
-| **i18next** | A JavaScript library for internationalisation (i18n). Listed as a dependency but not yet integrated in the Svelte rewrite — strings are currently hardcoded in German. |
-| **Overpass Turbo** | A web tool ([overpass-turbo.eu](https://overpass-turbo.eu)) for running ad-hoc queries against OpenStreetMap data. Useful for finding playgrounds with a specific device when testing your changes. |
-
----
-
-## Deploy for your region
-
-### Quick install (no git clone required)
-
-The easiest way to deploy is with the interactive installer. It downloads everything it needs, walks you through configuration, and optionally runs the first import.
-
-**Requirements:** Docker with the Compose plugin, `bash`, `openssl`
+The interactive installer downloads everything it needs and walks you through configuration:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spielplatzkarte/main/install.sh -o install.sh
 bash install.sh
 ```
 
-The installer will:
+**Requirements:** Docker with the Compose plugin, `bash`, `openssl`
 
-1. Ask for a deployment directory (default: `./spielplatzkarte`)
-2. Ask for your OSM relation ID and Geofabrik PBF URL
-3. Prompt for optional settings (port, UI links, zoom levels)
-4. Generate a secure database password automatically
-5. Download `compose.yml` and `db/init.sql` into the deployment directory
-6. Offer to pull images, start the stack, and run the first import
+The installer asks for a deployment mode (`data-node` / `ui` / `data-node-ui`), your OSM region, and optional settings, then generates a `.env`, pulls images, and optionally runs the first import.
 
-After setup, manage the stack from the deployment directory:
-
-```bash
-cd spielplatzkarte
-docker compose up -d                 # start
-docker compose run --rm importer     # re-import OSM data
-docker compose down                  # stop
-```
+For deploying from source, see [Manual Deploy](https://mfuhrmann.github.io/spielplatzkarte/ops/manual-deploy/).
 
 ---
 
-### Manual deploy (from source)
+## Configuration
 
-### 1. Find your region's OSM relation ID
+Key variables (full reference at [docs/ops/configuration](https://mfuhrmann.github.io/spielplatzkarte/ops/configuration/)):
 
-Search for your city, Kreis, or district on [Nominatim](https://nominatim.openstreetmap.org) or [openstreetmap.org](https://openstreetmap.org). The relation ID appears in the URL, e.g. `openstreetmap.org/relation/62700` → ID is `62700`.
-
-### 2. Find a Geofabrik PBF extract
-
-Browse [download.geofabrik.de](https://download.geofabrik.de) and find an extract that covers your region. German Bundesländer and many sub-regions are available. The PBF only needs to *contain* your region — a Bundesland extract works fine even if your region is just one Kreis within it.
-
-### 3. Configure
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` and set at minimum:
-
-```env
-OSM_RELATION_ID=62700   # your region's OSM relation ID
-PBF_URL=https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf
-```
-
-See `.env.example` for all available options (UI links, zoom levels, port, DB password).
-
-### 4. Start the stack and import data
-
-```bash
-# Start the database, API, and web server
-make up
-
-# Import OSM data (downloads PBF, runs osm2pgsql, sets up API functions)
-# Takes a few minutes depending on extract size and hardware
-make import
-```
-
-The app will be available at `http://localhost:8080` (or the port set in `APP_PORT`).
-
-### 5. Updating data
-
-Re-run the importer at any time to refresh from Geofabrik (extracts are updated daily):
-
-```bash
-make import
-```
-
----
-
-## Configuration reference
-
-All variables can be set in `.env` (copy from `.env.example`).
-
-| Variable | Default | Mode | Description |
-|---|---|---|---|
-| `APP_MODE` | `standalone` | both | App mode: `standalone` (regional map) or `hub` (aggregation map) |
-| `OSM_RELATION_ID` | `62700` | standalone | OSM relation ID of the region to display |
-| `PBF_URL` | Hessen extract | standalone | Geofabrik `.osm.pbf` download URL |
-| `REGION_PLAYGROUND_WIKI_URL` | Generic OSM wiki | standalone | Wiki page linked in the "Contribute" modal |
-| `REGION_CHAT_URL` | *(hidden)* | standalone | Community chat link; leave empty to hide the button |
-| `MAP_ZOOM` | `12` | both | Initial map zoom level |
-| `MAP_MIN_ZOOM` | `10` | both | Minimum zoom level |
-| `PARENT_ORIGIN` | *(own origin)* | standalone | Allowed origin for `postMessage` events — set to the Hub's full origin (e.g. `https://hub.example.com`) when embedding in a Hub; leave empty for standalone deployments |
-| `APP_PORT` | `8080` | both | Host port the app is exposed on |
-| `POSTGRES_PASSWORD` | `change-me` | standalone | Database password — **change in production** |
-| `POI_RADIUS_M` | `5000` | standalone | Radius in metres for nearby POI search |
-| `OSM2PGSQL_THREADS` | `4` | standalone | CPU threads for the import |
-| `GEOSERVER_URL` | *(disabled)* | standalone | Base URL of a GeoServer instance for the shadow WMS layer (e.g. `https://example.com`); leave empty to disable |
-| `GEOSERVER_WORKSPACE` | `spielplatzkarte` | standalone | GeoServer workspace name — only used when `GEOSERVER_URL` is set |
-| `HUB_POLL_INTERVAL` | `300` | hub | Seconds between Hub re-fetches of playground data from all registered instances |
+| Variable | Default | Description |
+|---|---|---|
+| `OSM_RELATION_ID` | `62700` | OSM relation ID of the region to display |
+| `PBF_URL` | Hessen extract | Geofabrik `.osm.pbf` download URL |
+| `APP_PORT` | `8080` | Host port the app is exposed on |
+| `MAP_ZOOM` | `12` | Initial map zoom level |
+| `POSTGRES_PASSWORD` | `change-me` | Database password — **change in production** |
 
 ---
 
 ## Local development
 
-**Requirements:** [Node.js](https://nodejs.org/) v18 or newer, [Docker](https://www.docker.com/) with Docker Compose
-
-All common operations are available via `make`. Run `make help` to list all targets.
-
-### Frontend dev server
+**Requirements:** Node.js v18+, Docker with Docker Compose
 
 ```bash
-make install      # install Node dependencies for both root (Playwright) and app/ (Svelte) — only needed once
-make up           # start db + PostgREST + nginx (required backend)
-make dev          # dev server with hot-reload at http://localhost:5173
+make install      # install Node dependencies (once)
+make up           # start db + PostgREST + nginx
+make dev          # Vite dev server with hot-reload at http://localhost:5173
 ```
 
-> **Note:** `make dev` starts the Vite dev server, which serves the Svelte app with instant hot-reload. The Docker stack (`make up`) must be running alongside it to provide the API — the app requires a live PostgREST backend.
-
-### Rebuild the app container after code changes
-
-```bash
-make docker-build
-```
-
-This runs the Vite build inside the container and replaces the nginx image without touching the database or PostgREST.
-
-> **Production deploys:** Use `compose.prod.yml` instead of `compose.yml` for production environments — it omits development-only overrides and is intended for use behind a reverse proxy.
-
-### Applying database changes without a full rebuild
-
-SQL changes to `importer/api.sql` (PostgREST functions, indexes) can be applied directly to the running database:
-
-```bash
-make db-apply
-```
-
-### Testing on a phone / LAN access
-
-To open the app on a phone or any other device on the same WiFi network:
-
-```bash
-make lan-url
-```
-
-This prints your machine's LAN IP and the ready-to-use URLs, for example:
-
-```
-  LAN IP:            192.168.1.42
-  Vite dev server:   http://192.168.1.42:5173
-  Docker stack:      http://192.168.1.42:8080
-```
-
-- **Vite dev server** (`make dev`): already binds to all interfaces — open the printed URL on the phone. If it doesn't load, check that port 5173 is not blocked by a firewall on the host.
-- **Docker stack** (`make up`): binds to `0.0.0.0` by default, so `http://<LAN-IP>:8080` works immediately without any extra configuration.
-
-> **Geolocation on mobile:** Browsers block the location API on plain HTTP (non-HTTPS) connections — including local IP addresses. If you need to test the location button on a phone, use Chrome and enable the "Insecure origins treated as secure" flag at `chrome://flags`, or test against the production HTTPS URL.
-
----
-
-## How-to: Add a playground device
-
-Every playground device that OSM can record — slides, swings, climbing frames, balance beams — is defined in one place: `app/src/lib/objPlaygroundEquipment.js`. Adding support for a new device type is a small, self-contained change.
-
-### Step 1 — Find the OSM tag
-
-OSM uses the tag `playground=<value>` to describe individual devices. The full list of documented values is at [wiki.openstreetmap.org/wiki/Key:playground](https://wiki.openstreetmap.org/wiki/Key:playground).
-
-For example, a balance beam is `playground=balance_beam`.
-
-### Step 2 — Add an entry to `objDevices`
-
-Open `app/src/lib/objPlaygroundEquipment.js` and add a new key to the `objDevices` object. Copy an existing entry as a template:
-
-```js
-balance_beam: {
-    name_de: "Balancierbalken",
-    image: "File:Playground balance beam.jpg",
-    category: "stationary",
-    filterable: false,
-},
-```
-
-**Field reference:**
-
-| Field | Required | What it does |
-|---|---|---|
-| `name_de` | Yes | German display name shown in the detail panel |
-| `image` | No | Wikimedia Commons filename for an example photo (see Step 3). Omit if no good image exists. |
-| `category` | No | Groups the device in the filter panel. Values: `stationary`, `structure_parts`, `active`. Omit to leave ungrouped. |
-| `filterable` | No | Set to `true` to make this device type appear as a filter option in the sidebar. |
-| `filter_attr` | No | Array of OSM sub-attributes to show as filter controls, e.g. `["length", "height"]`. Only meaningful when `filterable: true`. |
-
-### Step 3 — Find a Wikimedia Commons image
-
-1. Go to [commons.wikimedia.org](https://commons.wikimedia.org) and search for the device name in English.
-2. Find a clear, representative photo of the device.
-3. On the image page, copy the filename — it starts with `File:` (e.g. `File:Playground balance beam.jpg`).
-4. Paste that filename as the `image` value in your entry. The app first tries Wikimedia Commons, then falls back to the OSM wiki if the Commons image isn't found.
-
-If you can't find a suitable image, simply omit the `image` field. No broken icon will appear.
-
-### Step 4 — Verify locally
-
-```bash
-make dev
-```
-
-Open the app at `http://localhost:5173`, navigate to a playground that has the device you added (search for a street near such a playground, then click it), and expand the device's entry in the equipment list. You should see the German name, the example image, and any attributes.
-
-If you don't know a playground with that device, you can find one using [Overpass Turbo](https://overpass-turbo.eu) — search for `playground=balance_beam` (replace with your tag value) to locate playgrounds that have it mapped.
-
-### Step 5 — Commit and open a PR
-
-```bash
-git checkout -b feat/add-balance-beam-device
-git add app/src/lib/objPlaygroundEquipment.js
-git commit -m "feat: add balance_beam playground device"
-git push -u origin feat/add-balance-beam-device
-```
-
-Then open a pull request on GitHub. See the [Contributing](#contributing) section for the full PR walkthrough.
-
----
-
-## How-to: Edit UI strings / add a language
-
-> **Note:** Multi-language support has not yet been re-integrated in the Svelte rewrite. UI strings are currently hardcoded in German in the Svelte components. The `locales/*.json` files are preserved for when i18n is re-implemented — contributions to those files are welcome and will be useful once the integration is complete.
-
-The translation files live in `locales/*.json` — one file per language, structured as nested JSON.
-
-### Edit an existing translation string
-
-**Step 1 — Find the key you want to change**
-
-Open `locales/de.json` (German, the primary language) in any text editor. The file is structured as nested JSON. For example, the text on the location button is under `"location"`:
-
-```json
-"location": {
-    "yourLocation": "Dein Standort"
-}
-```
-
-**Step 2 — Edit the value**
-
-Change the string value (the part after the `:`), keeping the key (the part before the `:`) unchanged. Make sure the JSON stays valid — every value must be in double quotes, and every line except the last in an object must end with a comma.
-
-**Step 3 — Apply the change to all languages**
-
-Update the same key in the other language files (`locales/en.json`, `locales/fr.json`, etc.) too. You can use the English value as a placeholder if you don't speak the language — native speakers can improve it later.
-
----
-
-### Add a completely new language
-
-1. **Copy the English file** as a starting point:
-   ```bash
-   cp locales/en.json locales/ro.json   # replace 'ro' with your language code
-   ```
-   Use the [BCP 47 language code](https://en.wikipedia.org/wiki/IETF_language_tag) (e.g. `ro` for Romanian, `hr` for Croatian).
-
-2. **Translate all the string values.** Do not change the keys — only the values (the text in quotes after the `:`). Leave any value you're unsure about in English for now.
-
-3. **Handle plural forms** (only needed for some languages). Languages like Polish and Ukrainian have multiple plural forms. Add the appropriate plural suffixes (`_one`, `_few`, `_many`, `_other`) to equipment count strings — see `locales/pl.json` for an example.
-
-4. Commit and open a PR — see [Contributing](#contributing).
-
----
-
-## Troubleshooting
-
-### Port 8080 is already in use
-
-**Symptom:** `make up` fails with an error like `address already in use` or `port is already allocated`.
-
-**Fix:** Either stop whatever is using port 8080, or change the port in your `.env`:
-```env
-APP_PORT=8081
-```
-Then run `make up` again.
-
----
-
-### `make import` exits immediately or fails with a database error
-
-**Symptom:** The import finishes in seconds (normally takes minutes), or you see a `connection refused` or `role does not exist` error.
-
-**Fix:** The database container must be running before you import. Make sure you ran `make up` first and that all containers are healthy:
-```bash
-docker compose ps   # all containers should show "running" or "healthy"
-make import
-```
-If the database shows as unhealthy, try `make down && make up` to restart it cleanly.
-
----
-
-### Map loads but shows no playgrounds
-
-**Symptom:** The map tiles appear (you can see streets and buildings) but no playground polygons are drawn, or the detail panel is empty.
-
-**Possible causes and fixes:**
-
-1. **Import not run:** Did you run `make import` after starting the stack? Playground data is not loaded automatically.
-2. **Wrong relation ID:** Check `OSM_RELATION_ID` in your `.env`. An incorrect ID means the app filters out all playgrounds. Verify your ID at [nominatim.openstreetmap.org](https://nominatim.openstreetmap.org).
-3. **Docker stack not running:** The app requires the PostgREST backend. Make sure `make up` is running and healthy before starting `make dev`.
-4. **Browser cache:** Try a hard reload: `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac).
-
----
-
-### Geolocation button does nothing on mobile
-
-**Symptom:** Tapping the location button on a phone browser has no effect — no movement, no error.
-
-**Cause:** Browsers block the geolocation API on plain HTTP connections (non-HTTPS). This includes local IP addresses like `http://192.168.1.42:8080`. This is a browser security policy and cannot be overridden in the app.
-
-**Fix options:**
-- Test geolocation on the **production HTTPS URL** (where it works normally in all browsers).
-- On Android with **Chrome**: go to `chrome://flags`, search for "Insecure origins treated as secure", add your local URL, and relaunch Chrome.
-- **DuckDuckGo** and **Brave** do not offer this workaround — use Chrome for local geolocation testing.
-
----
-
-### Dev server starts but changes don't appear
-
-**Symptom:** You edited a JS or CSS file, saved it, but the browser still shows the old version.
-
-**Fix:** Vite hot-reload should pick up changes automatically. If it doesn't:
-1. Check the terminal running `make dev` — if there's a build error, the browser won't update until it's fixed.
-2. Try a hard reload in the browser: `Ctrl+Shift+R` / `Cmd+Shift+R`.
-3. If you changed `index.html` or a file in `public/`, you may need to stop and restart `make dev`.
-
-Note: if you're testing via `make docker-build` (the Docker stack), you need to run `make docker-build` again after every change — there is no hot-reload in that mode.
-
----
-
-### `make lan-url` prints "Could not detect LAN IP"
-
-**Symptom:** Running `make lan-url` outputs a warning instead of your IP address.
-
-**Fix:** Run this command directly and use the output as your LAN IP:
-```bash
-ip route get 1 | awk '{print $7; exit}'
-```
-Then open `http://<that-ip>:8080` on your phone.
+Run `make help` to list all available targets.
 
 ---
 
 ## Contributing
 
-All contributions are welcome — code, translations, bug reports, or documentation improvements. Here's how to get a change into the project:
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow (branch → commit → PR), or the [docs](https://mfuhrmann.github.io/spielplatzkarte/) for how-to guides (e.g. [adding a playground device](https://mfuhrmann.github.io/spielplatzkarte/contributing/add-device/)).
 
-**Repository layout** (directories not covered elsewhere in this README):
-
-| Directory | Contents |
-|---|---|
-| `app/` | Svelte 5 frontend app (source in `app/src/`) |
-| `importer/` | osm2pgsql import scripts and PostgREST API SQL |
-| `db/` | PostgreSQL initialisation SQL |
-| `oci/` | Docker build contexts — `oci/app/` (Svelte app + nginx) and `oci/data-node/` |
-| `processing/` | OSM data pipeline scripts (Lua rules, SQL, shell) used during import |
-| `taginfo/` | [taginfo](https://taginfo.openstreetmap.org) metadata describing the OSM tags this project uses |
-| `locales/` | Translation files (`*.json`, one per language) — not yet active in the Svelte rewrite |
-| `deploy/` | Systemd unit files for automated weekly import on Linux servers |
-
-### Step 1 — Create a GitHub issue
-
-Before writing code, open an issue on GitHub describing what you want to fix or add. This lets maintainers give early feedback and avoids duplicated effort. You can skip this for tiny fixes like typos.
-
-### Step 2 — Create a branch
-
-```bash
-git checkout main
-git pull                          # make sure you're up to date
-git checkout -b fix/my-fix-name   # create a new branch
-```
-
-**Branch naming convention:**
-- `feat/<description>` — new feature (e.g. `feat/add-balance-beam-device`)
-- `fix/<description>` — bug fix (e.g. `fix/popup-scroll`)
-- `docs/<description>` — documentation only (e.g. `docs/add-glossary`)
-- `chore/<description>` — maintenance, dependency updates
-
-### Step 3 — Make your change and test it
-
-Edit the files you need to change. For frontend changes, run `make dev` and check the feature in your browser. For Docker stack changes, run `make docker-build` and test at `http://localhost:8080`.
-
-### Step 4 — Commit with a conventional commit message
-
-```bash
-git add app/src/lib/objPlaygroundEquipment.js   # add only the files you changed
-git commit -m "feat: add balance_beam playground device"
-```
-
-**Commit message format:** `<type>: <short description>`
-
-Types: `feat` (new feature), `fix` (bug fix), `docs` (documentation), `style` (formatting), `refactor` (code restructure, no behaviour change), `chore` (maintenance), `ci` (CI/CD changes).
-
-Examples:
-- `feat: add filtering by device height`
-- `fix: location button not showing nearby playgrounds on mobile`
-- `docs: add balance_beam to device how-to guide`
-
-### Step 5 — Push and open a pull request
-
-```bash
-git push -u origin fix/my-fix-name
-```
-
-GitHub will print a link to open a pull request. Click it, write a short description of what you changed and why, and submit. A maintainer will review it.
-
-> **Never push directly to `main`.** All changes go through a branch and a pull request.
+New to OSM concepts like relation IDs or PBF files? See the [glossary](https://mfuhrmann.github.io/spielplatzkarte/reference/glossary/).
 
 ---
 
 ## Federation
 
-Multiple regional instances can be aggregated into a single global map using the **Hub mode** built into this codebase. The Hub is not a separate repository — it is the same Svelte app deployed with `APP_MODE=hub` in the environment.
-
-```
-APP_MODE=standalone   →  regional map (one city / Kreis / Bundesland)
-APP_MODE=hub          →  aggregation map that fetches from all registered instances
-```
-
-To run the Hub, use the same `compose.yml` and set `APP_MODE=hub`. The Hub reads a `registry.json` file listing the regional instances to aggregate.
-
-Each regional instance exposes two federation endpoints (available since v0.2.1):
-
-- `GET /api/rpc/get_playgrounds` — full GeoJSON FeatureCollection of all playgrounds in the region
-- `GET /api/rpc/get_meta` — instance metadata: OSM relation name, playground count, bounding box
-
-CORS is enabled on `/api/` so the Hub can query instances cross-origin from the browser.
+Multiple regional instances can be aggregated into a Hub by deploying with `APP_MODE=hub`. Each regional instance exposes `/api/rpc/get_playgrounds` and `/api/rpc/get_meta` for cross-origin federation. See [docs/reference/federation](https://mfuhrmann.github.io/spielplatzkarte/reference/federation/).
 
 ---
 
@@ -570,33 +112,6 @@ CORS is enabled on `/api/` so the Hub can query instances cross-origin from the 
 | [Wikidata](https://wikidata.org) | Operator entity linking |
 
 All data comes from OpenStreetMap or the free services listed above. No proprietary data, no user accounts, no tracking.
-
----
-
-## Internationalisation
-
-> **Note:** i18next has not yet been re-integrated in the Svelte rewrite. The UI is currently German-only. The translation files below are preserved for when multi-language support is re-implemented.
-
-Translation files live in `locales/*.json` — one file per language. The intended behaviour (once re-integrated) is automatic language detection from the visitor's browser settings, with English as the fallback.
-
-### Supported languages
-
-| Code | Language |
-|---|---|
-| `de` | German |
-| `en` | English |
-| `fr` | French |
-| `es` | Spanish |
-| `it` | Italian |
-| `pl` | Polish |
-| `nl` | Dutch |
-| `cs` | Czech |
-| `pt` | Portuguese |
-| `sv` | Swedish |
-| `uk` | Ukrainian |
-| `ja` | Japanese |
-
-> **Note:** Translations were not done by native speakers and may contain errors. Corrections and improvements are very welcome — see the [how-to guide](#how-to-edit-ui-strings--add-a-language) above.
 
 ---
 

--- a/docs/contributing/add-device.md
+++ b/docs/contributing/add-device.md
@@ -1,0 +1,63 @@
+# Add a Playground Device
+
+Every playground device that OSM records — slides, swings, climbing frames, balance beams — is defined in one place: `app/src/lib/objPlaygroundEquipment.js`. Adding support for a new device type is a small, self-contained change.
+
+## Step 1 — Find the OSM tag
+
+OSM uses the tag `playground=<value>` to describe individual devices. The full list of documented values is at [wiki.openstreetmap.org/wiki/Key:playground](https://wiki.openstreetmap.org/wiki/Key:playground).
+
+For example, a balance beam is `playground=balance_beam`.
+
+## Step 2 — Add an entry to `objDevices`
+
+Open `app/src/lib/objPlaygroundEquipment.js` and add a new key to the `objDevices` object. Copy an existing entry as a template:
+
+```js
+balance_beam: {
+    name_de: "Balancierbalken",
+    image: "File:Playground balance beam.jpg",
+    category: "stationary",
+    filterable: false,
+},
+```
+
+**Field reference:**
+
+| Field | Required | Description |
+|---|---|---|
+| `name_de` | Yes | German display name shown in the detail panel |
+| `image` | No | Wikimedia Commons filename for an example photo (see Step 3). Omit if no good image exists. |
+| `category` | No | Groups the device in the filter panel. Values: `stationary`, `structure_parts`, `active`. Omit to leave ungrouped. |
+| `filterable` | No | Set to `true` to make this device type appear as a filter option in the sidebar. |
+| `filter_attr` | No | Array of OSM sub-attributes to show as filter controls, e.g. `["length", "height"]`. Only meaningful when `filterable: true`. |
+
+## Step 3 — Find a Wikimedia Commons image
+
+1. Go to [commons.wikimedia.org](https://commons.wikimedia.org) and search for the device name in English.
+2. Find a clear, representative photo.
+3. On the image page, copy the filename — it starts with `File:` (e.g. `File:Playground balance beam.jpg`).
+4. Paste that filename as the `image` value in your entry.
+
+If you can't find a suitable image, omit the `image` field. No broken icon will appear.
+
+## Step 4 — Verify locally
+
+```bash
+make dev
+```
+
+Open the app at `http://localhost:5173`, navigate to a playground that has the device, and expand its entry in the equipment list. You should see the German name, the example image, and any attributes.
+
+!!! tip "Finding a playground with a specific device"
+    Use [Overpass Turbo](https://overpass-turbo.eu) — search for `playground=balance_beam` (replace with your tag value) to locate playgrounds that have it mapped.
+
+## Step 5 — Commit and open a PR
+
+```bash
+git checkout -b feat/add-balance-beam-device
+git add app/src/lib/objPlaygroundEquipment.js
+git commit -m "feat: add balance_beam playground device"
+git push -u origin feat/add-balance-beam-device
+```
+
+Then open a pull request on GitHub. See [CONTRIBUTING.md](https://github.com/mfuhrmann/spielplatzkarte/blob/main/CONTRIBUTING.md) for the full PR walkthrough.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,64 @@
+# Quick Start
+
+The easiest way to deploy Spielplatzkarte is with the interactive installer. It downloads everything it needs, walks you through configuration, and optionally runs the first import.
+
+## Requirements
+
+- Docker with the Compose plugin
+- `bash`
+- `openssl`
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spielplatzkarte/main/install.sh -o install.sh
+bash install.sh
+```
+
+## What the installer does
+
+1. Asks for a deployment directory (default: `./spielplatzkarte`)
+2. Asks for your deployment mode (`data-node`, `ui`, or `data-node-ui`)
+3. Asks for your OSM relation ID and Geofabrik PBF URL (for data-node and data-node-ui modes)
+4. Prompts for optional settings (port, UI links, zoom levels)
+5. Generates a secure database password automatically
+6. Downloads `compose.yml` and `db/init.sql` into the deployment directory
+7. Offers to pull images, start the stack, and run the first import
+
+!!! tip "Finding your OSM relation ID"
+    Search for your city, Kreis, or district on [Nominatim](https://nominatim.openstreetmap.org). The relation ID appears in the URL — e.g. `openstreetmap.org/relation/62700` → ID is `62700`.
+
+!!! tip "Finding a PBF extract"
+    Browse [download.geofabrik.de](https://download.geofabrik.de) for an extract covering your region. The PBF only needs to *contain* your region — a Bundesland extract works fine for a single Kreis.
+
+## Deployment modes
+
+| Mode | What starts | Use when |
+|---|---|---|
+| `data-node` | DB + PostgREST only | Shared backend for multiple UI instances |
+| `ui` | App only | Frontend connecting to a remote data node |
+| `data-node-ui` | Full stack | Single self-contained regional deployment |
+
+## Managing the stack
+
+After setup, manage the stack from your deployment directory:
+
+```bash
+cd spielplatzkarte
+
+# Start the stack
+docker compose --profile data-node-ui up -d
+
+# Re-import OSM data (run to refresh from Geofabrik)
+docker compose --profile data-node run --rm importer
+
+# Stop the stack
+docker compose --profile data-node-ui down
+```
+
+Replace `data-node-ui` with whichever mode you chose at install time (`DEPLOY_MODE` in your `.env`).
+
+## Next steps
+
+- [Configuration reference](../ops/configuration.md) — all available environment variables
+- [Troubleshooting](../ops/troubleshooting.md) — common problems and fixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+# Spielplatzkarte
+
+A free, interactive web map for exploring playgrounds based on [OpenStreetMap](https://openstreetmap.org) data — configurable for any region.
+
+> **Origin:** This project is a further development of the original [Berliner Spielplatzkarte](https://github.com/SupaplexOSM/spielplatzkarte) by Alex Seidel.
+
+---
+
+## Architecture
+
+```
+                  ┌─────────────────────────────────────────────────────┐
+                  │                   Production                        │
+                  │                                                     │
+  Browser ──────► nginx ──────► PostgREST ──────► PostgreSQL/PostGIS   │
+  (your phone      (serves        (turns SQL          (holds all the    │
+   or laptop)      the app,       functions into      OSM playground    │
+                   proxies API    HTTP endpoints)     data)             │
+                   requests)                                            │
+                  └─────────────────────────────────────────────────────┘
+```
+
+Your browser loads the app from nginx. Playground data requests go to `/api/`, which nginx forwards to PostgREST. PostgREST runs a SQL function in PostgreSQL and returns JSON — no custom server code needed. The database is pre-loaded with OpenStreetMap data by the osm2pgsql importer.
+
+---
+
+## Where to go next
+
+| I want to… | Go to… |
+|---|---|
+| Deploy for my region | [Quick Start](getting-started/quick-start.md) |
+| Deploy from source | [Manual Deploy](ops/manual-deploy.md) |
+| Configure environment variables | [Configuration](ops/configuration.md) |
+| Fix a problem | [Troubleshooting](ops/troubleshooting.md) |
+| Add a new playground device type | [Add a Device](contributing/add-device.md) |
+| Understand the tech stack | [Tech Stack](reference/tech-stack.md) |
+| Learn OSM terminology | [Glossary](reference/glossary.md) |

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -1,0 +1,38 @@
+# Configuration Reference
+
+All variables are set in `.env` (copy from `.env.example`). The installer generates this file interactively — you can edit it afterwards to change any setting.
+
+## Variables
+
+| Variable | Default | Mode | Description |
+|---|---|---|---|
+| `DEPLOY_MODE` | — | — | Deployment mode: `data-node`, `ui`, or `data-node-ui`. Written by the installer. |
+| `APP_MODE` | `standalone` | both | App mode: `standalone` (regional map) or `hub` (aggregation map) |
+| `OSM_RELATION_ID` | `62700` | data-node, data-node-ui | OSM relation ID of the region to display |
+| `PBF_URL` | Hessen extract | data-node, data-node-ui | Geofabrik `.osm.pbf` download URL |
+| `API_BASE_URL` | `/api` | ui, data-node-ui | Base URL of the PostgREST API. Set to the remote URL for `ui` mode (e.g. `https://data.example.com/api`). |
+| `REGION_PLAYGROUND_WIKI_URL` | Generic OSM wiki | ui, data-node-ui | Wiki page linked in the "Contribute" modal |
+| `REGION_CHAT_URL` | *(hidden)* | ui, data-node-ui | Community chat link; leave empty to hide the button |
+| `MAP_ZOOM` | `12` | ui, data-node-ui | Initial map zoom level |
+| `MAP_MIN_ZOOM` | `10` | ui, data-node-ui | Minimum zoom level |
+| `PARENT_ORIGIN` | *(own origin)* | data-node-ui | Allowed origin for `postMessage` events — set to the Hub's full origin when embedding in a Hub |
+| `APP_PORT` | `8080` | ui, data-node-ui | Host port the app is exposed on |
+| `POSTGRES_PASSWORD` | `change-me` | data-node, data-node-ui | Database password — **change in production** |
+| `POI_RADIUS_M` | `5000` | ui, data-node-ui | Radius in metres for nearby POI search |
+| `OSM2PGSQL_THREADS` | `4` | data-node, data-node-ui | CPU threads for the import |
+| `GEOSERVER_URL` | *(disabled)* | data-node, data-node-ui | Base URL of a GeoServer instance for the shadow WMS layer; leave empty to disable |
+| `GEOSERVER_WORKSPACE` | `spielplatzkarte` | data-node, data-node-ui | GeoServer workspace name — only used when `GEOSERVER_URL` is set |
+| `HUB_POLL_INTERVAL` | `300` | hub | Seconds between Hub re-fetches of playground data from all registered instances |
+
+## Applying changes
+
+After editing `.env`, restart the relevant containers. Replace `<mode>` with your `DEPLOY_MODE` value (`data-node`, `ui`, or `data-node-ui`):
+
+```bash
+# Restart app only (config changes)
+docker compose --profile <mode> up -d app
+
+# Full restart
+docker compose --profile <mode> down
+docker compose --profile <mode> up -d
+```

--- a/docs/ops/manual-deploy.md
+++ b/docs/ops/manual-deploy.md
@@ -1,0 +1,73 @@
+# Manual Deploy (from source)
+
+Use this path if you want to build the images yourself or run from a local clone. For most deployments the [Quick Start](../getting-started/quick-start.md) installer is simpler.
+
+## Requirements
+
+- [Node.js](https://nodejs.org/) v18 or newer
+- Docker with the Compose plugin
+- `git`
+
+## Step 1 — Find your region's OSM relation ID
+
+Search for your city, Kreis, or district on [Nominatim](https://nominatim.openstreetmap.org) or [openstreetmap.org](https://openstreetmap.org). The relation ID appears in the URL — e.g. `openstreetmap.org/relation/62700` → ID is `62700`.
+
+## Step 2 — Find a Geofabrik PBF extract
+
+Browse [download.geofabrik.de](https://download.geofabrik.de) for an extract covering your region. German Bundesländer and many sub-regions are available. The PBF only needs to *contain* your region — a Bundesland extract works fine for a single Kreis.
+
+## Step 3 — Configure
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```env
+DEPLOY_MODE=data-node-ui
+OSM_RELATION_ID=62700
+PBF_URL=https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf
+```
+
+See [Configuration](configuration.md) for all available variables, including `DEPLOY_MODE` options (`data-node`, `ui`, `data-node-ui`).
+
+## Step 4 — Start the stack and import data
+
+```bash
+# Start the database, API, and web server
+docker compose --profile data-node-ui up -d
+
+# Import OSM data (downloads PBF, runs osm2pgsql, sets up API functions)
+# Takes a few minutes depending on extract size and hardware
+docker compose --profile data-node run --rm importer
+```
+
+Replace `data-node-ui` with your chosen `DEPLOY_MODE`. The app will be available at `http://localhost:8080` (or the port set in `APP_PORT`).
+
+## Step 5 — Updating data
+
+Re-run the importer at any time to refresh from Geofabrik (extracts are updated daily):
+
+```bash
+docker compose --profile data-node run --rm importer
+```
+
+## Applying database changes without a full re-import
+
+SQL changes to `importer/api.sql` (PostgREST functions, indexes) can be applied directly to the running database:
+
+```bash
+make db-apply
+```
+
+## Testing on a phone / LAN access
+
+```bash
+make lan-url
+```
+
+Prints your machine's LAN IP and ready-to-use URLs. The Vite dev server and Docker stack both bind to all interfaces, so the printed URLs work immediately on any device on the same WiFi.
+
+!!! warning "Geolocation on mobile"
+    Browsers block the geolocation API on plain HTTP. If you need to test the location button on a phone, use Chrome and enable "Insecure origins treated as secure" at `chrome://flags`, or test against the production HTTPS URL.

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -1,0 +1,83 @@
+# Troubleshooting
+
+## Port 8080 is already in use
+
+**Symptom:** `make up` fails with `address already in use` or `port is already allocated`.
+
+**Fix:** Stop whatever is using port 8080, or change the port in `.env`:
+
+```env
+APP_PORT=8081
+```
+
+Then run `make up` again.
+
+---
+
+## Import exits immediately or fails with a database error
+
+**Symptom:** The import finishes in seconds (normally takes minutes), or you see a `connection refused` or `role does not exist` error.
+
+**Fix:** The database must be running before you import. Start the stack first and confirm all containers are healthy:
+
+```bash
+docker compose ps   # all containers should show "running" or "healthy"
+# then run the importer — replace <mode> with your DEPLOY_MODE (data-node or data-node-ui)
+docker compose --profile <mode> run --rm importer
+```
+
+If you are using the local development setup, `make import` is equivalent. If the database shows as unhealthy, try stopping and restarting the stack.
+
+---
+
+## Map loads but shows no playgrounds
+
+**Symptom:** Map tiles appear (streets and buildings visible) but no playground polygons are drawn, or the detail panel is empty.
+
+**Possible causes:**
+
+1. **Import not run** — Run the importer after starting the stack (`docker compose --profile <mode> run --rm importer`, or `make import` for local dev). Playground data is not loaded automatically.
+2. **Wrong relation ID** — Check `OSM_RELATION_ID` in `.env`. An incorrect ID filters out all playgrounds. Verify at [nominatim.openstreetmap.org](https://nominatim.openstreetmap.org).
+3. **Docker stack not running** — The app requires a live PostgREST backend. Confirm the stack is running and healthy before starting `make dev`.
+4. **Browser cache** — Try a hard reload: `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac).
+
+---
+
+## Geolocation button does nothing on mobile
+
+**Symptom:** Tapping the location button on a phone browser has no effect — no movement, no error.
+
+**Cause:** Browsers block the geolocation API on plain HTTP connections (including local IPs like `http://192.168.1.42:8080`). This is a browser security policy and cannot be overridden in the app.
+
+**Fix options:**
+
+- Test geolocation on the **production HTTPS URL**.
+- On Android with **Chrome**: go to `chrome://flags`, search for "Insecure origins treated as secure", add your local URL, and relaunch Chrome.
+- DuckDuckGo and Brave do not offer this workaround — use Chrome for local geolocation testing.
+
+---
+
+## Dev server starts but changes don't appear
+
+**Symptom:** You edited a JS or CSS file, but the browser still shows the old version.
+
+**Fix:** Vite hot-reload should pick up changes automatically. If it doesn't:
+
+1. Check the terminal running `make dev` — a build error will prevent the browser from updating.
+2. Try a hard reload: `Ctrl+Shift+R` / `Cmd+Shift+R`.
+3. If you changed `index.html` or a file in `public/`, stop and restart `make dev`.
+
+!!! note
+    When testing via `make docker-build` (the Docker stack), you must run `make docker-build` again after every change — there is no hot-reload in that mode.
+
+---
+
+## `make lan-url` prints "Could not detect LAN IP"
+
+**Fix:** Run this command directly and use the output as your LAN IP:
+
+```bash
+ip route get 1 | awk '{print $7; exit}'
+```
+
+Then open `http://<that-ip>:8080` on your phone.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,0 +1,53 @@
+# Architecture
+
+## Production stack
+
+```
+                  ┌─────────────────────────────────────────────────────┐
+                  │                   Production                        │
+                  │                                                     │
+  Browser ──────► nginx ──────► PostgREST ──────► PostgreSQL/PostGIS   │
+  (your phone      (serves        (turns SQL          (holds all the    │
+   or laptop)      the app,       functions into      OSM playground    │
+                   proxies API    HTTP endpoints)     data)             │
+                   requests)                                            │
+                  └─────────────────────────────────────────────────────┘
+```
+
+Your browser loads the app from nginx. When it needs playground data, it calls `/api/`, which nginx forwards to PostgREST. PostgREST runs a SQL function in PostgreSQL and returns the results as JSON — no custom server code needed. The database was pre-loaded with OpenStreetMap data by the osm2pgsql importer (a one-time step you re-run whenever you want fresh data).
+
+## Local development
+
+```
+  Browser ──────► Vite dev server ──────► (hot-reload JS/CSS)
+                                          ↓
+                                   apiBaseUrl empty?
+                                   ┌─────┴──────┐
+                                  yes            no
+                                   ↓              ↓
+                               Overpass      PostgREST
+                               (live OSM     (Docker stack
+                                queries)      via make up)
+```
+
+During local development, the Vite dev server serves the JavaScript with instant hot-reload. By default (`apiBaseUrl` empty in `public/config.js`), the frontend fetches playground data directly from Overpass — no local database required. To test against the full PostgREST backend, start `make up` and set `apiBaseUrl` in `public/config.js`.
+
+## Deployment modes
+
+The compose file supports three profiles, selected at install time via `DEPLOY_MODE`:
+
+| Mode | Services started | Use case |
+|---|---|---|
+| `data-node` | db, PostgREST, importer | Shared backend for multiple UI instances |
+| `ui` | app (nginx) | Frontend connecting to a remote data node |
+| `data-node-ui` | All of the above | Self-contained single-region deployment |
+
+## Key source directories
+
+| Path | Role |
+|---|---|
+| `app/src/` | Svelte 5 frontend components and modules |
+| `importer/` | osm2pgsql Lua rules and PostgREST API SQL (`api.sql`) |
+| `db/` | PostgreSQL schema initialisation |
+| `oci/` | Docker build contexts |
+| `processing/` | OSM data pipeline scripts used during import |

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -1,0 +1,21 @@
+# Federation
+
+Multiple regional instances can be aggregated into a single global map using the **Hub mode** built into this codebase. The Hub is not a separate repository — it is the same app deployed with `APP_MODE=hub`.
+
+```
+APP_MODE=standalone   →  regional map (one city / Kreis / Bundesland)
+APP_MODE=hub          →  aggregation map that fetches from all registered instances
+```
+
+To run the Hub, use the same `compose.yml` and set `APP_MODE=hub`. The Hub reads a `registry.json` file listing the regional instances to aggregate.
+
+## Federation endpoints
+
+Each regional instance exposes two endpoints (available since v0.2.1):
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/rpc/get_playgrounds` | Full GeoJSON FeatureCollection of all playgrounds in the region |
+| `GET /api/rpc/get_meta` | Instance metadata: OSM relation name, playground count, bounding box |
+
+CORS is enabled on `/api/` so the Hub can query instances cross-origin from the browser.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,31 @@
+# Glossary
+
+OSM-specific terms you'll encounter when working with this project.
+
+## OSM relation ID
+
+Every city, district, or region in OpenStreetMap has a numeric ID called a **relation ID**. Spielplatzkarte uses this ID to know which geographic area to show on the map.
+
+To find the relation ID for your region: search on [Nominatim](https://nominatim.openstreetmap.org) or [openstreetmap.org](https://openstreetmap.org) — it appears in the URL, e.g. `openstreetmap.org/relation/62700` → ID is `62700`.
+
+## PBF file
+
+A **PBF file** (Protocolbuffer Binary Format) is a compressed snapshot of OpenStreetMap data for a geographic region. Geofabrik publishes regularly-updated PBF extracts at [download.geofabrik.de](https://download.geofabrik.de).
+
+The importer reads a PBF file to populate the database. The file only needs to *contain* your region — a Bundesland extract works for a single Kreis within it.
+
+## osm2pgsql
+
+**osm2pgsql** is the tool that reads a PBF file and imports the OSM data into PostgreSQL. You run it via `make import` to load data for the first time, and again whenever you want to refresh from a newer Geofabrik extract.
+
+More: [osm2pgsql.org](https://osm2pgsql.org)
+
+## PostgREST
+
+**PostgREST** is a server that automatically turns a PostgreSQL database into a REST API. Instead of writing server-side code, you write SQL functions and PostgREST exposes them as HTTP endpoints. Spielplatzkarte's entire API layer is PostgREST — there is no custom backend application server.
+
+More: [postgrest.org](https://postgrest.org)
+
+## Overpass Turbo
+
+**Overpass Turbo** ([overpass-turbo.eu](https://overpass-turbo.eu)) is a web tool for running ad-hoc queries against live OpenStreetMap data. It is useful when adding support for a new device type — you can search for `playground=<tag>` to find real playgrounds that have the device mapped and use them for testing.

--- a/docs/reference/tech-stack.md
+++ b/docs/reference/tech-stack.md
@@ -1,0 +1,13 @@
+# Tech Stack
+
+| Component | Technology |
+|---|---|
+| Map | [OpenLayers](https://openlayers.org/) |
+| UI / icons | [Bootstrap 5](https://getbootstrap.com/) + [Tailwind CSS 4](https://tailwindcss.com/) + [lucide-svelte](https://lucide.dev/) |
+| Language | [Svelte 5](https://svelte.dev/) |
+| Build tool | [Vite 6](https://vitejs.dev/) |
+| Database | [PostgreSQL 16](https://www.postgresql.org/) + [PostGIS 3.4](https://postgis.net/) |
+| OSM import | [osm2pgsql](https://osm2pgsql.org/) |
+| API layer | [PostgREST v12](https://postgrest.org/) |
+| Web server | [nginx](https://nginx.org/) |
+| Container runtime | Docker / Docker Compose |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+mike==2.2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,54 @@
+site_name: Spielplatzkarte
+site_url: https://mfuhrmann.github.io/spielplatzkarte/
+repo_url: https://github.com/mfuhrmann/spielplatzkarte
+repo_name: mfuhrmann/spielplatzkarte
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Quick Start: getting-started/quick-start.md
+  - Operations:
+      - Manual Deploy: ops/manual-deploy.md
+      - Configuration: ops/configuration.md
+      - Troubleshooting: ops/troubleshooting.md
+  - Contributing:
+      - Add a Playground Device: contributing/add-device.md
+  - Reference:
+      - Architecture: reference/architecture.md
+      - Tech Stack: reference/tech-stack.md
+      - Federation: reference/federation.md
+      - Glossary: reference/glossary.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary

- Adds a full MkDocs + Material theme docs site under `docs/` deployed to GitHub Pages on every push to `main`
- Slims README from 607 to 122 lines — keeps header, architecture diagram, tech stack, quick install, abbreviated config, local dev, contributing links, federation, external services, license
- Extracts deep content into structured docs pages: manual deploy, full config reference, troubleshooting, add-device how-to, architecture, tech stack, federation, OSM-specific glossary
- Adds `CONTRIBUTING.md` at repo root (surfaced by GitHub on new issue/PR flows)
- Adds `docs-install` / `docs-serve` / `docs-build` / `docs-clean` Makefile targets

## After merging

Enable GitHub Pages in repository settings:
- **Settings → Pages → Source:** Deploy from branch
- **Branch:** `gh-pages` / `/ (root)`

The workflow will create the `gh-pages` branch on first run. The docs site will then be live at `https://mfuhrmann.github.io/spielplatzkarte/`.

## Test plan

- [ ] `make docs-install && make docs-build` — builds without errors
- [ ] `make docs-serve` — live preview at `http://localhost:8000`, all nav links resolve
- [ ] After merge: GitHub Actions `Deploy docs` workflow runs successfully
- [ ] After enabling Pages: `https://mfuhrmann.github.io/spielplatzkarte/` is accessible
- [ ] README renders correctly on GitHub — 122 lines, no ToC, all doc links present

🤖 Generated with [Claude Code](https://claude.com/claude-code)