### PR TITLE
fix: clear hover preview when pointer leaves the map canvas

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -113,6 +113,14 @@
       }
     });
 
+    mapContainer.addEventListener('pointerleave', () => {
+      if (lastHoverFeature) {
+        lastHoverFeature = null;
+        mapContainer.style.cursor = '';
+        if (onclearhover) onclearhover();
+      }
+    });
+
     // Standalone: fetch playgrounds and fit to region
     if (ownSource) {
       playgroundSourceStore.set(ownSource);


### PR DESCRIPTION
## Summary
- Adds a `pointerleave` listener on `mapContainer` that clears `lastHoverFeature`, resets the cursor, and calls `onclearhover()` when the pointer exits the map canvas
- Previously the hover popup (HoverPreview) remained visible indefinitely after the cursor left the map area, because `pointermove` stops firing once the pointer is off-canvas

## Test plan
- [ ] Hover over a playground — HoverPreview popup appears
- [ ] Move cursor off the map canvas (onto sidebar, browser chrome, outside window) — popup immediately disappears
- [ ] Move cursor back over the map — popup reappears on next hover

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)