### PR TITLE
fix(panel): slim sections, share button, hide controls on full sheet, fix search debounce (#125–129)

### DIFF
--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import OpeningHours from 'opening_hours';
   import { transform } from 'ol/proj';
-  import { X, ChevronDown, ChevronRight, Pencil, MapPin, Clock, Trees, Ruler, Users, Phone, Mail, ExternalLink, Image, Package, Navigation, Star } from 'lucide-svelte';
+  import { X, Share2, Check, ChevronDown, ChevronRight, Pencil, MapPin, Clock, Trees, Ruler, Users, Phone, Mail, ExternalLink, Image, Package, Navigation, Star } from 'lucide-svelte';
 
   import { selection } from '../stores/selection.js';
   import { fetchPlaygroundEquipment, fetchNearbyPOIs } from '../lib/api.js';
@@ -187,6 +187,27 @@
   })();
 
   $: openingHoursInfo = attr?.opening_hours ? openingHoursState(attr.opening_hours) : null;
+
+  // ── Share button ──────────────────────────────────────────────────────────
+  let shareConfirmed = false;
+  let shareTimeout;
+
+  async function sharePlayground() {
+    if (!attr) return;
+    const url = `${window.location.origin}${window.location.pathname}#${attr.osm_type}${attr.osm_id}`;
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: getPlaygroundTitle(attr), url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      shareConfirmed = true;
+      clearTimeout(shareTimeout);
+      shareTimeout = setTimeout(() => { shareConfirmed = false; }, 2000);
+    } catch (err) {
+      if (err.name !== 'AbortError') console.warn('Share failed:', err);
+    }
+  }
 </script>
 
 {#if feature && attr}
@@ -206,9 +227,18 @@
             <Badge variant={completeness.variant} class="mt-2">{completeness.label}</Badge>
           {/if}
         </div>
-        <Button variant="ghost" size="icon" class="shrink-0" onclick={() => selection.clear()} aria-label="Schließen">
-          <X class="h-5 w-5" />
-        </Button>
+        <div class="flex items-center gap-1 shrink-0">
+          <Button variant="ghost" size="icon" onclick={sharePlayground} aria-label="Link kopieren">
+            {#if shareConfirmed}
+              <Check class="h-5 w-5 text-green-600" />
+            {:else}
+              <Share2 class="h-5 w-5" />
+            {/if}
+          </Button>
+          <Button variant="ghost" size="icon" onclick={() => selection.clear()} aria-label="Schließen">
+            <X class="h-5 w-5" />
+          </Button>
+        </div>
       </div>
     {:else}
       <!-- Embedded header (simpler, for bottom sheet) -->
@@ -279,7 +309,7 @@
 
       <!-- Contact Info -->
       {#if attr['contact:email'] || attr.email || attr['contact:phone'] || attr.phone || attr.operator}
-        <div class="space-y-2 mb-4 p-3 rounded-lg border border-border">
+        <div class="space-y-2 mb-4">
           {#if attr.operator}
             <div class="flex items-center gap-2 text-sm" data-testid="operator-value">
               <span class="text-muted-foreground">Betreiber:</span>
@@ -320,11 +350,11 @@
       </a>
 
       <!-- Accordion Sections -->
-      <div class="space-y-2">
+      <div class="border-t border-border">
         <!-- Photos -->
-        <div class="border border-border rounded-lg overflow-hidden">
-          <button 
-            class="w-full flex items-center gap-2 px-3 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
+        <div class="border-b border-border">
+          <button
+            class="w-full flex items-center gap-2 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
             onclick={() => toggleSection('photos')}
           >
             {#if openSections.has('photos')}
@@ -336,16 +366,16 @@
             Bilder
           </button>
           {#if openSections.has('photos')}
-            <div class="px-3 pb-3 border-t border-border">
+            <div class="pb-3">
               <PanoramaxViewer uuids={panoramaxUuids} {mcUrl} />
             </div>
           {/if}
         </div>
 
         <!-- Equipment -->
-        <div class="border border-border rounded-lg overflow-hidden">
-          <button 
-            class="w-full flex items-center gap-2 px-3 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
+        <div class="border-b border-border">
+          <button
+            class="w-full flex items-center gap-2 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
             onclick={() => toggleSection('equipment')}
           >
             {#if openSections.has('equipment')}
@@ -357,7 +387,7 @@
             Ausstattung
           </button>
           {#if openSections.has('equipment')}
-            <div class="px-3 pb-3 border-t border-border">
+            <div class="pb-3">
               {#if equipmentLoading}
                 <p class="text-sm text-muted-foreground italic py-2">Wird geladen...</p>
               {:else}
@@ -368,9 +398,9 @@
         </div>
 
         <!-- POIs -->
-        <div class="border border-border rounded-lg overflow-hidden">
-          <button 
-            class="w-full flex items-center gap-2 px-3 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
+        <div class="border-b border-border">
+          <button
+            class="w-full flex items-center gap-2 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
             onclick={() => toggleSection('pois')}
           >
             {#if openSections.has('pois')}
@@ -382,7 +412,7 @@
             Umfeld
           </button>
           {#if openSections.has('pois')}
-            <div class="px-3 pb-3 border-t border-border">
+            <div class="pb-3">
               {#if poisLoading}
                 <p class="text-sm text-muted-foreground italic py-2">Wird geladen...</p>
               {:else}
@@ -393,9 +423,9 @@
         </div>
 
         <!-- Reviews -->
-        <div class="border border-border rounded-lg overflow-hidden">
-          <button 
-            class="w-full flex items-center gap-2 px-3 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
+        <div class="border-b border-border">
+          <button
+            class="w-full flex items-center gap-2 py-2.5 text-sm font-medium hover:bg-muted/50 transition-colors"
             onclick={() => toggleSection('reviews')}
           >
             {#if openSections.has('reviews')}
@@ -407,23 +437,11 @@
             Bewertungen
           </button>
           {#if openSections.has('reviews')}
-            <div class="px-3 pb-3 border-t border-border">
+            <div class="pb-3">
               <ReviewsPanel lat={centerLat} lon={centerLon} />
             </div>
           {/if}
         </div>
-      </div>
-
-      <!-- OSM Link -->
-      <div class="mt-4 pt-4 border-t border-border">
-        <a 
-          href="https://www.openstreetmap.org/{mcOsmType}/{attr.osm_id}"
-          target="_blank" 
-          rel="noopener" 
-          class="text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          OSM ID: {attr.osm_id}
-        </a>
       </div>
     </div>
   </aside>

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -198,8 +198,19 @@
     try {
       if (navigator.share) {
         await navigator.share({ title: getPlaygroundTitle(attr), url });
-      } else {
+      } else if (navigator.clipboard) {
         await navigator.clipboard.writeText(url);
+      } else {
+        // fallback for non-secure contexts
+        const ta = document.createElement('textarea');
+        ta.value = url;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
       }
       shareConfirmed = true;
       clearTimeout(shareTimeout);
@@ -228,28 +239,37 @@
           {/if}
         </div>
         <div class="flex items-center gap-1 shrink-0">
-          <Button variant="ghost" size="icon" onclick={sharePlayground} aria-label="Link kopieren">
+          <button class="panel-icon-btn" onclick={sharePlayground} aria-label="Link kopieren">
             {#if shareConfirmed}
               <Check class="h-5 w-5 text-green-600" />
             {:else}
               <Share2 class="h-5 w-5" />
             {/if}
-          </Button>
-          <Button variant="ghost" size="icon" onclick={() => selection.clear()} aria-label="Schließen">
+          </button>
+          <button class="panel-icon-btn" onclick={() => selection.clear()} aria-label="Schließen">
             <X class="h-5 w-5" />
-          </Button>
+          </button>
         </div>
       </div>
     {:else}
-      <!-- Embedded header (simpler, for bottom sheet) -->
-      <div class="mb-4">
-        <h2 class="text-lg font-semibold text-foreground leading-tight">{getPlaygroundTitle(attr)}</h2>
-        {#if getPlaygroundLocation(attr)}
-          <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
-        {/if}
-        {#if completeness}
-          <Badge variant={completeness.variant} class="mt-2">{completeness.label}</Badge>
-        {/if}
+      <!-- Embedded header (bottom sheet) -->
+      <div class="flex items-start justify-between gap-2 mb-4">
+        <div class="flex-1 min-w-0">
+          <h2 class="text-lg font-semibold text-foreground leading-tight">{getPlaygroundTitle(attr)}</h2>
+          {#if getPlaygroundLocation(attr)}
+            <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
+          {/if}
+          {#if completeness}
+            <Badge variant={completeness.variant} class="mt-2">{completeness.label}</Badge>
+          {/if}
+        </div>
+        <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label="Link kopieren">
+          {#if shareConfirmed}
+            <Check class="h-5 w-5 text-green-600" />
+          {:else}
+            <Share2 class="h-5 w-5" />
+          {/if}
+        </button>
       </div>
     {/if}
 
@@ -502,5 +522,24 @@
     .info-panel {
       display: none !important;
     }
+  }
+
+  .panel-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: none;
+    background: transparent;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    color: #6b7280;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .panel-icon-btn:hover {
+    background: #f3f4f6;
+    color: #1f2937;
   }
 </style>

--- a/app/src/components/SearchBar.svelte
+++ b/app/src/components/SearchBar.svelte
@@ -61,11 +61,10 @@
   }
 
   function onInput() {
-    // Debounced search as user types
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
       if (query.length >= 2) search();
-    }, 300);
+    }, 450);
   }
 
   let searchTimeout;
@@ -109,7 +108,6 @@
       oninput={onInput}
       onfocus={onFocus}
       onblur={onBlur}
-      disabled={searching}
       aria-label="Ortssuche"
     />
     {#if query}

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -129,50 +129,52 @@
     onclearhover={clearHover}
   />
 
-  <!-- Search bar: top-left, Google Maps style -->
-  <div class="search-area">
-    <SearchBar {regionExtent} onlocation={handleLocation} />
-    <FilterChips />
-    {#if nearbyLocation}
-      <NearbyPlaygrounds lat={nearbyLocation.lat} lon={nearbyLocation.lon} ondismiss={dismissNearby} />
-    {/if}
-  </div>
+  {#if !(isMobile && bottomSheetSnap === 'full')}
+    <!-- Search bar: top-left, Google Maps style -->
+    <div class="search-area">
+      <SearchBar {regionExtent} onlocation={handleLocation} />
+      <FilterChips />
+      {#if nearbyLocation}
+        <NearbyPlaygrounds lat={nearbyLocation.lat} lon={nearbyLocation.lon} ondismiss={dismissNearby} />
+      {/if}
+    </div>
 
-  <!-- Top-right controls: filter, edit -->
-  <div class="controls-top-right">
-    <FilterPanel />
-    <button
-      class="control-btn"
-      onclick={() => dataModalOpen = true}
-      title="Daten ergänzen"
-      aria-label="Daten ergänzen"
-    >
-      <Pencil class="h-5 w-5" />
-    </button>
-  </div>
-
-  <!-- Bottom-right controls: locate, zoom (Google Maps style) -->
-  <div class="controls-bottom-right">
-    <LocateButton onlocation={handleLocation} />
-    <div class="zoom-controls">
+    <!-- Top-right controls: filter, edit -->
+    <div class="controls-top-right">
+      <FilterPanel />
       <button
-        class="zoom-btn zoom-in"
-        onclick={zoomIn}
-        title="Vergrößern"
-        aria-label="Vergrößern"
+        class="control-btn"
+        onclick={() => dataModalOpen = true}
+        title="Daten ergänzen"
+        aria-label="Daten ergänzen"
       >
-        <Plus class="h-4 w-4" />
-      </button>
-      <button
-        class="zoom-btn zoom-out"
-        onclick={zoomOut}
-        title="Verkleinern"
-        aria-label="Verkleinern"
-      >
-        <Minus class="h-4 w-4" />
+        <Pencil class="h-5 w-5" />
       </button>
     </div>
-  </div>
+
+    <!-- Bottom-right controls: locate, zoom (Google Maps style) -->
+    <div class="controls-bottom-right">
+      <LocateButton onlocation={handleLocation} />
+      <div class="zoom-controls">
+        <button
+          class="zoom-btn zoom-in"
+          onclick={zoomIn}
+          title="Vergrößern"
+          aria-label="Vergrößern"
+        >
+          <Plus class="h-4 w-4" />
+        </button>
+        <button
+          class="zoom-btn zoom-out"
+          onclick={zoomOut}
+          title="Verkleinern"
+          aria-label="Verkleinern"
+        >
+          <Minus class="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  {/if}
 
   <!-- Desktop: Side panel slides in from left -->
   {#if !isMobile && $hasSelection}


### PR DESCRIPTION
## Summary

- **#125** Accordion sections now use simple `border-top` dividers instead of rounded card frames; contact block border removed — panel feels like a continuous scrollable document
- **#126** Map controls (search bar, filter, zoom, locate) are hidden when the mobile bottom sheet is swiped to `full` height; swiping down restores them
- **#127** OSM ID line removed from the bottom of the detail panel
- **#128** Share button added to the detail panel header — uses Web Share API on mobile, falls back to clipboard copy; icon swaps to a checkmark for 2 s after success
- **#129** Search debounce raised from 300 ms to 450 ms; `disabled` attribute removed from the search input so it no longer loses focus mid-typing on mobile

## Test plan

- [ ] Open a playground on desktop — sections show plain divider lines with no card shadow/border
- [ ] Contact info block (if present) shows no surrounding box
- [ ] Header shows share icon; click it — URL with `#W<id>` hash is copied to clipboard; icon turns to checkmark for 2 s
- [ ] On mobile, open a playground and swipe bottom sheet to full height — search bar, zoom buttons, filter and edit buttons all disappear; swipe down — they reappear
- [ ] OSM ID is no longer shown at the bottom of the detail panel
- [ ] Type quickly in the search box on mobile — input retains focus throughout; suggestions only appear after a short pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)