### PR TITLE
fix(mobile): bottom sheet fills full screen, controls float above sheet (#133)

### DIFF
--- a/app/src/components/BottomSheet.svelte
+++ b/app/src/components/BottomSheet.svelte
@@ -16,7 +16,7 @@
   const snapHeights = {
     peek: 140,
     half: typeof window !== 'undefined' ? window.innerHeight * 0.5 : 400,
-    full: typeof window !== 'undefined' ? window.innerHeight - 60 : 700,
+    full: typeof window !== 'undefined' ? window.innerHeight : 700,
   };
 
   $: if (open && !isDragging) {
@@ -132,7 +132,8 @@
   <div
     bind:this={sheetEl}
     class={cn(
-      'fixed inset-x-0 bottom-0 z-50 rounded-t-2xl shadow-xl lg:hidden bottom-sheet',
+      'fixed inset-x-0 bottom-0 z-50 shadow-xl lg:hidden bottom-sheet flex flex-col',
+      snapPoint !== 'full' ? 'rounded-t-2xl' : '',
       isDragging ? '' : 'transition-[height] duration-300 ease-out'
     )}
     style="height: {currentHeight}px; background: #ffffff; color-scheme: light; --color-background: #ffffff; --color-foreground: #1f2937; --color-card: #ffffff; --color-card-foreground: #1f2937; --color-muted: #f3f4f6; --color-muted-foreground: #6b7280; --color-border: #e5e7eb;"
@@ -166,7 +167,7 @@
     {/if}
 
     <!-- Content -->
-    <div class="flex-1 overflow-y-auto overscroll-contain px-4 py-3" style="height: calc(100% - {title ? '80px' : '40px'})">
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 py-3">
       <slot />
     </div>
   </div>

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -70,6 +70,14 @@
   let bottomSheetOpen = false;
   let bottomSheetSnap = 'half';
 
+  // Keep bottom-right controls above the sheet at each snap height
+  $: controlsBottomStyle = (() => {
+    if (!isMobile || !bottomSheetOpen) return '';
+    if (bottomSheetSnap === 'peek') return 'bottom: calc(140px + 1rem)';
+    if (bottomSheetSnap === 'half') return 'bottom: calc(50vh + 1rem)';
+    return '';
+  })();
+
   // Sync bottom sheet with selection on mobile
   $: if (isMobile && $hasSelection) {
     bottomSheetOpen = true;
@@ -153,7 +161,7 @@
     </div>
 
     <!-- Bottom-right controls: locate, zoom (Google Maps style) -->
-    <div class="controls-bottom-right">
+    <div class="controls-bottom-right" style={controlsBottomStyle}>
       <LocateButton onlocation={handleLocation} />
       <div class="zoom-controls">
         <button
@@ -243,6 +251,7 @@
     flex-direction: column;
     gap: 0.75rem;
     align-items: center;
+    transition: bottom 0.3s ease-out;
   }
 
   /* Control button (for edit button, locate button) */


### PR DESCRIPTION
## Summary

- Full snap height changed from `window.innerHeight - 60` to `window.innerHeight` — sheet now fills the entire viewport
- Border-radius removed at full snap so it truly fills edge-to-edge
- Inner content div no longer has a rigid `height: calc(100% - Xpx)` — replaced with `flex-1 min-h-0` so flexbox handles the height and inner scroll no longer conflicts with the swipe gesture
- Bottom-right controls (zoom, locate) now float reactively above the sheet at each snap height (`peek` → `calc(140px + 1rem)`, `half` → `calc(50vh + 1rem)`, `full` → hidden), with a `0.3s ease-out` transition matching the sheet animation

## Test plan

- [ ] Swipe sheet to full — fills entire screen, no gap at top, rounded corners gone
- [ ] Scroll content in full-screen sheet — no conflict with swipe gesture
- [ ] Zoom/locate buttons visible above sheet in peek and half states
- [ ] Zoom/locate buttons animate upward smoothly as sheet snaps from peek → half
- [ ] Zoom/locate buttons disappear in full state (existing behaviour)
- [ ] Swiping sheet down from full restores buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)