### PR TITLE
fix(map): clear equipment overlay when playground is deselected (#137)

### DIFF
--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import OpeningHours from 'opening_hours';
   import { transform } from 'ol/proj';
   import { X, Share2, Check, ChevronDown, ChevronRight, Pencil, Clock, ExternalLink, Image, Package, Navigation, Star } from 'lucide-svelte';
@@ -108,6 +108,10 @@
   onMount(() => {
     window.addEventListener('keydown', handleKeydown);
     return () => window.removeEventListener('keydown', handleKeydown);
+  });
+
+  onDestroy(() => {
+    overlayFeaturesStore.set({ equipment: [], trees: [] });
   });
 
   // ── Completeness badge ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Equipment and tree overlay layers now clear when a playground is deselected
- Root cause: `PlaygroundPanel` is unmounted when `$hasSelection` becomes false, so the reactive `else` branch never fired to reset the store
- Fix: `onDestroy` hook resets `overlayFeaturesStore` to empty arrays, triggering `Map.svelte` to remove the layers

## Test plan

- [ ] Select a playground — equipment overlay appears
- [ ] Click empty map area to deselect — overlay disappears
- [ ] Re-select the same playground — overlay reappears correctly

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)