### PR TITLE
fix: union region polygon rows in get_playgrounds/get_meta

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -112,10 +112,12 @@ LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, api
 AS $$
   WITH region AS (
-    -- osm2pgsql stores relation IDs as negative numbers
-    SELECT way FROM planet_osm_polygon
+    -- osm2pgsql stores relation IDs as negative numbers. Union all matching
+    -- rows: assembly can emit multiple polygon rows per relation when member
+    -- ways are clipped (e.g. by a narrow PBF extract), and picking one at
+    -- random yields inconsistent results.
+    SELECT ST_Union(way) AS way FROM planet_osm_polygon
     WHERE osm_id = -relation_id
-    LIMIT 1
   ),
   playgrounds AS (
     SELECT
@@ -442,7 +444,11 @@ LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, api
 AS $$
   WITH region AS (
-    SELECT name, way FROM planet_osm_polygon WHERE osm_id = -relation_id LIMIT 1
+    -- See get_playgrounds for why ST_Union is needed. Name is identical
+    -- across fragments of the same relation, so max() picks any non-null.
+    SELECT max(name) AS name, ST_Union(way) AS way
+    FROM planet_osm_polygon
+    WHERE osm_id = -relation_id
   ),
   bbox AS (
     SELECT ST_Transform(way, 4326) AS geom FROM region


### PR DESCRIPTION
## Summary

- Replace `LIMIT 1` with `ST_Union(way)` in the `region` CTE of both `api.get_playgrounds` and `api.get_meta` so queries are deterministic when `planet_osm_polygon` holds multiple rows for the same relation.
- `max(name)` in `get_meta` preserves the relation name (identical across all fragments).

osm2pgsql can emit multiple polygon rows with the same negative `osm_id` when multipolygon assembly for a boundary relation fails — typically because the PBF extract clips member ways. `LIMIT 1` without `ORDER BY` then picks one fragment at random. On the hub at spieli.eu the Baden-Württemberg data-node was returning **0**, **3**, or **~13849** playgrounds across consecutive requests (Büsingen exclave fragment / degenerate fragment / real BW polygon, respectively).

Unioning preserves exclave data (Büsingen's playgrounds correctly count as BW) and is correct for any number of matching rows.

Closes #141

## Test plan

- [ ] `make db-apply` on the BW data-node (no re-import needed — `api.sql` + PostgREST schema reload is enough)
- [ ] `curl https://<bw-node>/api/rpc/get_meta | jq` repeated 5× — `playground_count` and `bbox` stable across calls
- [ ] `get_meta.playground_count` matches `get_playgrounds.features | length` on the same node
- [ ] Hub at spieli.eu: BW instance panel settles on the full count (~13852, including Büsingen)
- [ ] Standalone instances (Berlin, Fulda) still return their normal counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)