### PR TITLE
feat: show standalone leisure=pitch areas on the map

### DIFF
--- a/app/src/components/FilterPanel.svelte
+++ b/app/src/components/FilterPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { filterStore, hasActiveFilters } from '../stores/filters.js';
-  import { Filter, Droplets, Baby, Accessibility, Armchair, UtensilsCrossed, Home, RectangleHorizontal, Goal, CircleDot, Lock } from 'lucide-svelte';
+  import { Filter, Droplets, Baby, Accessibility, Armchair, UtensilsCrossed, Home, RectangleHorizontal, Goal, CircleDot, Lock, Layers } from 'lucide-svelte';
 
   let open = false;
   let wrap;
@@ -75,6 +75,19 @@
             <span>{f.label}</span>
           </label>
         {/each}
+      </div>
+
+      <div class="layer-section">
+        <span class="layer-title"><Layers class="h-3 w-3" /> Ebenen</span>
+        <label class="filter-item" class:checked={$filterStore.standalonePitches}>
+          <input
+            type="checkbox"
+            checked={$filterStore.standalonePitches}
+            onchange={() => toggle('standalonePitches')}
+          />
+          <Goal class="h-4 w-4" />
+          <span>Sportflächen (außerhalb Spielplätze)</span>
+        </label>
       </div>
     </div>
   {/if}
@@ -210,5 +223,22 @@
     height: 18px;
     accent-color: #1b5e20;
     cursor: pointer;
+  }
+
+  .layer-section {
+    border-top: 1px solid #e8eaed;
+    padding-top: 4px;
+  }
+
+  .layer-title {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #80868b;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 6px 16px 2px;
   }
 </style>

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -235,6 +235,11 @@
     playgroundSourceStore.set(null);
   });
 
+  // Toggle standalone pitch layer visibility from filter store.
+  $: if (pitchLayer) {
+    pitchLayer.setVisible($filterStore.standalonePitches);
+  }
+
   // Re-style the playground layer whenever filters change.
   $: if (playgroundLayer) {
     const filters = $filterStore;

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -10,7 +10,7 @@
   import { defaults as defaultInteractions } from 'ol/interaction/defaults';
 
   import { mapZoom, mapMinZoom, osmRelationId, apiBaseUrl } from '../lib/config.js';
-  import { fetchPlaygrounds, fetchStandalonePitches } from '../lib/api.js';
+  import { fetchPlaygrounds, fetchStandaloneEquipment } from '../lib/api.js';
   import { fetchRegionInfo } from '../lib/region.js';
   import { playgroundStyleFn, selectionStyle, equipmentLayerStyleFn, treeStyle } from '../lib/vectorStyles.js';
   import { selection } from '../stores/selection.js';
@@ -202,7 +202,7 @@
         const zoom = olMap.getView().getZoom();
         if (zoom < PITCH_MIN_ZOOM) { pitchSource.clear(); return; }
         const extent = olMap.getView().calculateExtent(olMap.getSize());
-        const geojson = await fetchStandalonePitches(extent);
+        const geojson = await fetchStandaloneEquipment(extent);
         const features = new GeoJSON().readFeatures(geojson, {
           dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857',
         });

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -10,7 +10,7 @@
   import { defaults as defaultInteractions } from 'ol/interaction/defaults';
 
   import { mapZoom, mapMinZoom, osmRelationId, apiBaseUrl } from '../lib/config.js';
-  import { fetchPlaygrounds } from '../lib/api.js';
+  import { fetchPlaygrounds, fetchStandalonePitches } from '../lib/api.js';
   import { fetchRegionInfo } from '../lib/region.js';
   import { playgroundStyleFn, selectionStyle, equipmentLayerStyleFn, treeStyle } from '../lib/vectorStyles.js';
   import { selection } from '../stores/selection.js';
@@ -41,7 +41,9 @@
   let playgroundLayer = null; // exposed for filter reactivity
   let equipmentLayer = null;  // overlay: equipment points/polygons
   let treeLayer = null;       // overlay: tree dots
+  let pitchLayer = null;      // standalone pitches not within any playground
   let overlayUnsubscribe = null;
+  const PITCH_MIN_ZOOM = 12;  // only fetch standalone pitches at this zoom or above
 
   onMount(async () => {
     // Use provided source (hub) or create our own (standalone)
@@ -141,25 +143,29 @@
       const equipHit = equipmentLayer
         ? olMap.forEachFeatureAtPixel(evt.pixel, f => f, { layerFilter: l => l === equipmentLayer })
         : null;
+      const pitchHit = pitchLayer
+        ? olMap.forEachFeatureAtPixel(evt.pixel, f => f, { layerFilter: l => l === pitchLayer })
+        : null;
       const playHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
         layerFilter: l => l === playgroundLayer,
       });
 
-      mapContainer.style.cursor = (equipHit || playHit) ? 'pointer' : '';
+      mapContainer.style.cursor = (equipHit || pitchHit || playHit) ? 'pointer' : '';
 
-      // Equipment hover takes priority
-      if (equipHit !== lastEquipHoverFeature) {
-        lastEquipHoverFeature = equipHit;
-        if (equipHit) {
-          if (onequipmenthover) onequipmenthover(equipHit, evt.pixel);
+      // Equipment / standalone-pitch hover takes priority
+      const equipOrPitchHit = equipHit ?? pitchHit ?? null;
+      if (equipOrPitchHit !== lastEquipHoverFeature) {
+        lastEquipHoverFeature = equipOrPitchHit;
+        if (equipOrPitchHit) {
+          if (onequipmenthover) onequipmenthover(equipOrPitchHit, evt.pixel);
           if (lastHoverFeature) { lastHoverFeature = null; if (onclearhover) onclearhover(); }
         } else {
           if (onclearequipmenthover) onclearequipmenthover();
         }
       }
 
-      // Playground hover (only when not hovering equipment)
-      if (!equipHit) {
+      // Playground hover (only when not hovering equipment or pitch)
+      if (!equipOrPitchHit) {
         if (playHit && playHit !== lastHoverFeature) {
           lastHoverFeature = playHit;
           debouncedHover(playHit, evt.pixel);
@@ -182,10 +188,29 @@
       }
     });
 
-    // Standalone: fetch playgrounds and fit to region
+    // Standalone: fetch playgrounds, fit to region, and set up pitch layer
     if (ownSource) {
       playgroundSourceStore.set(ownSource);
       loadStandaloneData(ownSource, view);
+
+      // Standalone pitch layer — refreshed on moveend
+      const pitchSource = new VectorSource();
+      pitchLayer = new VectorLayer({ source: pitchSource, zIndex: 9, style: equipmentLayerStyleFn });
+      olMap.addLayer(pitchLayer);
+
+      const reloadPitches = debounce(async () => {
+        const zoom = olMap.getView().getZoom();
+        if (zoom < PITCH_MIN_ZOOM) { pitchSource.clear(); return; }
+        const extent = olMap.getView().calculateExtent(olMap.getSize());
+        const geojson = await fetchStandalonePitches(extent);
+        const features = new GeoJSON().readFeatures(geojson, {
+          dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857',
+        });
+        pitchSource.clear();
+        pitchSource.addFeatures(features);
+      }, 300);
+
+      olMap.on('moveend', reloadPitches);
     }
 
     // Restore selection from URL hash on load

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -40,6 +40,17 @@ export async function fetchNearbyPOIs(lat, lon, radiusM = 500, osmId = null, bas
     return [];
 }
 
+// Standalone pitches (not within any playground) within a bounding box.
+// Returns an empty FeatureCollection silently when no backend is configured.
+export async function fetchStandalonePitches(extentEPSG3857, baseUrl = defaultApiBaseUrl) {
+    if (!baseUrl) return { type: 'FeatureCollection', features: [] };
+    const [minLon, minLat, maxLon, maxLat] = transformExtent(extentEPSG3857, 'EPSG:3857', 'EPSG:4326');
+    const params = new URLSearchParams({ min_lon: minLon, min_lat: minLat, max_lon: maxLon, max_lat: maxLat });
+    const res = await fetch(`${baseUrl}/rpc/get_standalone_pitches?${params}`);
+    if (res.ok) return res.json();
+    return { type: 'FeatureCollection', features: [] };
+}
+
 // Nearest playgrounds to a given WGS84 point, ordered by distance.
 // Returns [] when apiBaseUrl is empty (Overpass / local dev mode).
 export async function fetchNearestPlaygrounds(lat, lon, baseUrl = defaultApiBaseUrl) {

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -40,13 +40,14 @@ export async function fetchNearbyPOIs(lat, lon, radiusM = 500, osmId = null, bas
     return [];
 }
 
-// Standalone pitches (not within any playground) within a bounding box.
+// Pitches, benches, shelters, picnic tables and fitness stations not within
+// any playground polygon, within a bounding box.
 // Returns an empty FeatureCollection silently when no backend is configured.
-export async function fetchStandalonePitches(extentEPSG3857, baseUrl = defaultApiBaseUrl) {
+export async function fetchStandaloneEquipment(extentEPSG3857, baseUrl = defaultApiBaseUrl) {
     if (!baseUrl) return { type: 'FeatureCollection', features: [] };
     const [minLon, minLat, maxLon, maxLat] = transformExtent(extentEPSG3857, 'EPSG:3857', 'EPSG:4326');
     const params = new URLSearchParams({ min_lon: minLon, min_lat: minLat, max_lon: maxLon, max_lat: maxLat });
-    const res = await fetch(`${baseUrl}/rpc/get_standalone_pitches?${params}`);
+    const res = await fetch(`${baseUrl}/rpc/get_standalone_equipment?${params}`);
     if (res.ok) return res.json();
     return { type: 'FeatureCollection', features: [] };
 }

--- a/app/src/stores/filters.js
+++ b/app/src/stores/filters.js
@@ -2,17 +2,18 @@ import { writable } from 'svelte/store';
 
 // Each key maps to a boolean — true means the filter is active.
 export const filterStore = writable({
-    private:     false,
-    water:       false,
-    baby:        false,
-    toddler:     false,
-    wheelchair:  false,
-    bench:       false,
-    picnic:      false,
-    shelter:     false,
-    tableTennis: false,
-    soccer:      false,
-    basketball:  false,
+    private:          false,
+    water:            false,
+    baby:             false,
+    toddler:          false,
+    wheelchair:       false,
+    bench:            false,
+    picnic:           false,
+    shelter:          false,
+    tableTennis:      false,
+    soccer:           false,
+    basketball:       false,
+    standalonePitches: false,  // layer toggle — show pitches outside playground areas
 });
 
 /**

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -316,32 +316,20 @@ AS $$
       3857
     ) AS geom
   ),
-  -- Nodes (pitches, benches, shelters, picnic tables, fitness stations)
-  -- not contained within any playground polygon
-  standalone_nodes AS (
-    SELECT
-      p.osm_id,
-      'N'::text AS osm_type,
-      p.name,
-      p.amenity,
-      p.leisure,
-      p.sport,
-      p.tags,
-      ST_Transform(p.way, 4326) AS geom
-    FROM planet_osm_point p, bbox b
+  -- Standalone pitch polygons in the bbox (not intersecting any playground)
+  pitch_areas AS (
+    SELECT p.way
+    FROM planet_osm_polygon p, bbox b
     WHERE p.way && b.geom
-      AND (
-        p.amenity IN ('bench', 'shelter')
-        OR p.leisure IN ('picnic_table', 'pitch', 'fitness_station')
-      )
+      AND p.leisure = 'pitch'
       AND NOT EXISTS (
         SELECT 1 FROM planet_osm_polygon pg
         WHERE pg.leisure = 'playground'
-          AND ST_Within(p.way, pg.way)
+          AND ST_Intersects(p.way, pg.way)
       )
   ),
-  -- Polygon ways not intersecting any playground polygon
-  standalone_ways AS (
+  -- The pitch polygons themselves
+  pitch_ways AS (
     SELECT
       p.osm_id,
       'W'::text AS osm_type,
@@ -353,20 +341,56 @@ AS $$
       ST_Transform(p.way, 4326) AS geom
     FROM planet_osm_polygon p, bbox b
     WHERE p.way && b.geom
-      AND (
-        p.amenity IN ('bench', 'shelter')
-        OR p.leisure IN ('picnic_table', 'pitch', 'fitness_station')
-      )
+      AND p.leisure = 'pitch'
       AND NOT EXISTS (
         SELECT 1 FROM planet_osm_polygon pg
         WHERE pg.leisure = 'playground'
           AND ST_Intersects(p.way, pg.way)
       )
   ),
+  -- Standalone pitch nodes (not within any playground)
+  pitch_nodes AS (
+    SELECT
+      p.osm_id,
+      'N'::text AS osm_type,
+      p.name,
+      p.amenity,
+      p.leisure,
+      p.sport,
+      p.tags,
+      ST_Transform(p.way, 4326) AS geom
+    FROM planet_osm_point p, bbox b
+    WHERE p.way && b.geom
+      AND p.leisure = 'pitch'
+      AND NOT EXISTS (
+        SELECT 1 FROM planet_osm_polygon pg
+        WHERE pg.leisure = 'playground'
+          AND ST_Within(p.way, pg.way)
+      )
+  ),
+  -- Equipment nodes (benches, shelters, etc.) within a standalone pitch polygon
+  equip_nodes AS (
+    SELECT
+      p.osm_id,
+      'N'::text AS osm_type,
+      p.name,
+      p.amenity,
+      p.leisure,
+      p.sport,
+      p.tags,
+      ST_Transform(p.way, 4326) AS geom
+    FROM planet_osm_point p
+    JOIN pitch_areas pa ON ST_Within(p.way, pa.way)
+    WHERE
+      p.amenity IN ('bench', 'shelter')
+      OR p.leisure IN ('picnic_table', 'fitness_station')
+  ),
   all_features AS (
-    SELECT * FROM standalone_nodes
+    SELECT * FROM pitch_ways
     UNION ALL
-    SELECT * FROM standalone_ways
+    SELECT * FROM pitch_nodes
+    UNION ALL
+    SELECT * FROM equip_nodes
   )
   SELECT json_build_object(
     'type', 'FeatureCollection',

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -291,16 +291,16 @@ $$;
 GRANT EXECUTE ON FUNCTION api.get_equipment(float8, float8, float8, float8) TO web_anon;
 
 -- =========================================================================
--- 3. get_standalone_pitches(min_lon, min_lat, max_lon, max_lat)
---    Returns leisure=pitch features (nodes and polygon ways) that do NOT
---    lie within any leisure=playground polygon.  These are pitches that
---    exist independently of a playground and would otherwise be invisible
---    in the app.  The GeoJSON shape matches get_equipment so the same
---    frontend style and tooltip can be reused.
+-- 3. get_standalone_equipment(min_lon, min_lat, max_lon, max_lat)
+--    Returns pitches, benches, shelters, picnic tables and fitness stations
+--    (nodes and polygon ways) that do NOT lie within any
+--    leisure=playground polygon.  The GeoJSON shape matches get_equipment
+--    so the same frontend styles and tooltip can be reused.
 -- =========================================================================
 DROP FUNCTION IF EXISTS api.get_standalone_pitches(float8, float8, float8, float8);
+DROP FUNCTION IF EXISTS api.get_standalone_equipment(float8, float8, float8, float8);
 
-CREATE OR REPLACE FUNCTION api.get_standalone_pitches(
+CREATE OR REPLACE FUNCTION api.get_standalone_equipment(
   min_lon float8,
   min_lat float8,
   max_lon float8,
@@ -316,48 +316,57 @@ AS $$
       3857
     ) AS geom
   ),
-  -- Pitch nodes not contained within any playground polygon
-  pitch_nodes AS (
+  -- Nodes (pitches, benches, shelters, picnic tables, fitness stations)
+  -- not contained within any playground polygon
+  standalone_nodes AS (
     SELECT
       p.osm_id,
       'N'::text AS osm_type,
       p.name,
+      p.amenity,
       p.leisure,
       p.sport,
       p.tags,
       ST_Transform(p.way, 4326) AS geom
     FROM planet_osm_point p, bbox b
     WHERE p.way && b.geom
-      AND p.leisure = 'pitch'
+      AND (
+        p.amenity IN ('bench', 'shelter')
+        OR p.leisure IN ('picnic_table', 'pitch', 'fitness_station')
+      )
       AND NOT EXISTS (
         SELECT 1 FROM planet_osm_polygon pg
         WHERE pg.leisure = 'playground'
           AND ST_Within(p.way, pg.way)
       )
   ),
-  -- Pitch polygon ways not intersecting any playground polygon
-  pitch_ways AS (
+  -- Polygon ways not intersecting any playground polygon
+  standalone_ways AS (
     SELECT
       p.osm_id,
       'W'::text AS osm_type,
       p.name,
+      p.amenity,
       p.leisure,
       p.sport,
       p.tags,
       ST_Transform(p.way, 4326) AS geom
     FROM planet_osm_polygon p, bbox b
     WHERE p.way && b.geom
-      AND p.leisure = 'pitch'
+      AND (
+        p.amenity IN ('bench', 'shelter')
+        OR p.leisure IN ('picnic_table', 'pitch', 'fitness_station')
+      )
       AND NOT EXISTS (
         SELECT 1 FROM planet_osm_polygon pg
         WHERE pg.leisure = 'playground'
           AND ST_Intersects(p.way, pg.way)
       )
   ),
-  all_pitches AS (
-    SELECT * FROM pitch_nodes
+  all_features AS (
+    SELECT * FROM standalone_nodes
     UNION ALL
-    SELECT * FROM pitch_ways
+    SELECT * FROM standalone_ways
   )
   SELECT json_build_object(
     'type', 'FeatureCollection',
@@ -371,6 +380,7 @@ AS $$
               'osm_id',   abs(osm_id),
               'osm_type', osm_type,
               'name',     name,
+              'amenity',  amenity,
               'leisure',  leisure,
               'sport',    sport
             ) || COALESCE(hstore_to_jsonb(tags), '{}'::jsonb)
@@ -380,10 +390,10 @@ AS $$
       '[]'::json
     )
   )
-  FROM all_pitches;
+  FROM all_features;
 $$;
 
-GRANT EXECUTE ON FUNCTION api.get_standalone_pitches(float8, float8, float8, float8) TO web_anon;
+GRANT EXECUTE ON FUNCTION api.get_standalone_equipment(float8, float8, float8, float8) TO web_anon;
 
 -- =========================================================================
 -- 4. get_pois(lat, lon, radius_m)

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -291,7 +291,102 @@ $$;
 GRANT EXECUTE ON FUNCTION api.get_equipment(float8, float8, float8, float8) TO web_anon;
 
 -- =========================================================================
--- 3. get_pois(lat, lon, radius_m)
+-- 3. get_standalone_pitches(min_lon, min_lat, max_lon, max_lat)
+--    Returns leisure=pitch features (nodes and polygon ways) that do NOT
+--    lie within any leisure=playground polygon.  These are pitches that
+--    exist independently of a playground and would otherwise be invisible
+--    in the app.  The GeoJSON shape matches get_equipment so the same
+--    frontend style and tooltip can be reused.
+-- =========================================================================
+DROP FUNCTION IF EXISTS api.get_standalone_pitches(float8, float8, float8, float8);
+
+CREATE OR REPLACE FUNCTION api.get_standalone_pitches(
+  min_lon float8,
+  min_lat float8,
+  max_lon float8,
+  max_lat float8
+)
+RETURNS json
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, api
+AS $$
+  WITH bbox AS (
+    SELECT ST_Transform(
+      ST_MakeEnvelope(min_lon, min_lat, max_lon, max_lat, 4326),
+      3857
+    ) AS geom
+  ),
+  -- Pitch nodes not contained within any playground polygon
+  pitch_nodes AS (
+    SELECT
+      p.osm_id,
+      'N'::text AS osm_type,
+      p.name,
+      p.leisure,
+      p.sport,
+      p.tags,
+      ST_Transform(p.way, 4326) AS geom
+    FROM planet_osm_point p, bbox b
+    WHERE p.way && b.geom
+      AND p.leisure = 'pitch'
+      AND NOT EXISTS (
+        SELECT 1 FROM planet_osm_polygon pg
+        WHERE pg.leisure = 'playground'
+          AND ST_Within(p.way, pg.way)
+      )
+  ),
+  -- Pitch polygon ways not intersecting any playground polygon
+  pitch_ways AS (
+    SELECT
+      p.osm_id,
+      'W'::text AS osm_type,
+      p.name,
+      p.leisure,
+      p.sport,
+      p.tags,
+      ST_Transform(p.way, 4326) AS geom
+    FROM planet_osm_polygon p, bbox b
+    WHERE p.way && b.geom
+      AND p.leisure = 'pitch'
+      AND NOT EXISTS (
+        SELECT 1 FROM planet_osm_polygon pg
+        WHERE pg.leisure = 'playground'
+          AND ST_Intersects(p.way, pg.way)
+      )
+  ),
+  all_pitches AS (
+    SELECT * FROM pitch_nodes
+    UNION ALL
+    SELECT * FROM pitch_ways
+  )
+  SELECT json_build_object(
+    'type', 'FeatureCollection',
+    'features', COALESCE(
+      json_agg(
+        json_build_object(
+          'type', 'Feature',
+          'geometry', ST_AsGeoJSON(geom)::json,
+          'properties', (
+            jsonb_build_object(
+              'osm_id',   abs(osm_id),
+              'osm_type', osm_type,
+              'name',     name,
+              'leisure',  leisure,
+              'sport',    sport
+            ) || COALESCE(hstore_to_jsonb(tags), '{}'::jsonb)
+          )
+        )
+      ),
+      '[]'::json
+    )
+  )
+  FROM all_pitches;
+$$;
+
+GRANT EXECUTE ON FUNCTION api.get_standalone_pitches(float8, float8, float8, float8) TO web_anon;
+
+-- =========================================================================
+-- 4. get_pois(lat, lon, radius_m)
 --    Returns nearby POIs within radius_m metres of the given point.
 --    Return shape matches the existing frontend: array of
 --      { lat, lon, osm_id, tags: { … } }


### PR DESCRIPTION
## Summary

- Adds new DB function `get_standalone_equipment()` returning pitches, benches, shelters, picnic tables and fitness stations **not within any playground polygon**
- Equipment (benches etc.) is restricted to nodes physically **within** a standalone pitch polygon — not the full viewport — to avoid showing street furniture
- Standalone pitches are **hidden by default**; a new "Ebenen" section in the filter panel lets users enable them via "Sportflächen (außerhalb Spielplätze)"
- Hover shows the existing `EquipmentTooltip`, matching the in-playground experience
- Layer only loads at zoom ≥ 12 to avoid unnecessary queries

Closes #151

## Test plan

- [ ] Run `make db-apply` then `make docker-build`
- [ ] Standalone pitches hidden by default — map looks unchanged
- [ ] Open filter panel → "Ebenen" section → enable "Sportflächen" → pitches appear at zoom ≥ 12
- [ ] Benches/equipment visible only when physically inside a pitch polygon, not on streets
- [ ] Hovering a standalone pitch shows the equipment tooltip
- [ ] Selecting a playground still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)