### PR TITLE
fix: cancel debounced hover on pointer leave to prevent ghost preview

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -177,6 +177,7 @@
     });
 
     mapContainer.addEventListener('pointerleave', () => {
+      debouncedHover.cancel();
       if (lastEquipHoverFeature) {
         lastEquipHoverFeature = null;
         if (onclearequipmenthover) onclearequipmenthover();

--- a/app/src/lib/utils.js
+++ b/app/src/lib/utils.js
@@ -39,10 +39,12 @@ export function escapeHtml(str) {
  */
 export function debounce(fn, ms = 300) {
     let timeoutId;
-    return function (...args) {
+    const debounced = function (...args) {
         clearTimeout(timeoutId);
         timeoutId = setTimeout(() => fn.apply(this, args), ms);
     };
+    debounced.cancel = () => clearTimeout(timeoutId);
+    return debounced;
 }
 
 /**


### PR DESCRIPTION
## Problem

Regression of #105. The `HoverPreview` was reappearing after the cursor left the map canvas.

## Root cause

`debouncedHover` fires 100 ms after the last `pointermove`. If the pointer left the canvas within that window, `pointerleave` had already called `onclearhover()` — but the pending debounce callback then called `onhover()` again, making the preview reappear.

## Fix

Added a `cancel()` method to the `debounce()` utility and call it at the top of the `pointerleave` handler, so any pending hover callback is discarded when the cursor leaves the map.

## Test plan

- [ ] `make docker-build`
- [ ] Hover a playground on desktop → preview appears
- [ ] Move cursor off the map canvas quickly → preview disappears and stays gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)