### PR TITLE
feat(i18n): migrate German strings in JS lib files and POIPanel

### DIFF
--- a/app/src/components/BottomSheet.svelte
+++ b/app/src/components/BottomSheet.svelte
@@ -1,6 +1,7 @@
 <script>
   import { cn } from '../lib/utils.js';
   import { X, GripHorizontal } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
 
   export let open = false;
   export let title = '';
@@ -124,7 +125,7 @@
       onkeydown={e => e.key === 'Enter' && close()}
       role="button"
       tabindex="-1"
-      aria-label="Schließen"
+      aria-label={$_('info.closeBtn')}
     ></div>
   {/if}
 
@@ -159,7 +160,7 @@
           class="p-1 rounded-md transition-colors"
           style="color: #6b7280;"
           onclick={close}
-          aria-label="Schließen"
+          aria-label={$_('info.closeBtn')}
         >
           <X class="h-5 w-5" />
         </button>

--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -1,5 +1,6 @@
 <script>
   import { regionPlaygroundWikiUrl, regionChatUrl } from '../lib/config.js';
+  import { _ } from 'svelte-i18n';
 
   export let open = false;
   function close() { open = false; }
@@ -21,39 +22,37 @@
   <div class="modal-backdrop" onclick={onBackdropClick}>
     <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="dc-title">
       <div class="modal-header">
-        <h5 class="modal-title" id="dc-title">Daten ergänzen</h5>
-        <button type="button" class="close-btn" onclick={close} aria-label="Schließen">✕</button>
+        <h5 class="modal-title" id="dc-title">{$_('nav.addData')}</h5>
+        <button type="button" class="close-btn" onclick={close} aria-label={$_('modal.closeBtn')}>✕</button>
       </div>
       <div class="modal-body">
         <p class="small">
-          Die Daten dieser Karte stammen aus
-          <a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>.
-          Du kannst sie direkt bearbeiten – kein Account nötig bei MapComplete.
+          {@html $_('modal.addData.introText', { values: { name: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>' } })}
         </p>
 
-        <h6 class="section-heading">Spielgeräte &amp; Details ergänzen</h6>
+        <h6 class="section-heading">{$_('modal.addData.equipTitle')}</h6>
         <p class="small">
-          Mit <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>
-          kannst du Spielgeräte, Fotos und weitere Details einfach per Klick eintragen.
+          <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>
+          — {$_('modal.addData.mapcompleteText')}
         </p>
 
-        <h6 class="section-heading">OSM-Wiki</h6>
+        <h6 class="section-heading">{$_('modal.addData.wikiTitle')}</h6>
         <p class="small">
           <a href={regionPlaygroundWikiUrl} target="_blank" rel="noopener">
-            Erfassungsregeln für Spielplätze in dieser Region
+            {$_('modal.addData.wikiLinkText')}
           </a>
         </p>
 
         {#if regionChatUrl}
-          <h6 class="section-heading">Community</h6>
+          <h6 class="section-heading">{$_('modal.addData.community.label')}</h6>
           <p class="small">
-            Fragen und Austausch im
-            <a href={regionChatUrl} target="_blank" rel="noopener">regionalen Chat</a>.
+            {$_('modal.addData.community.simpleText')}
+            <a href={regionChatUrl} target="_blank" rel="noopener">{$_('modal.addData.community.simpleChatLabel')}</a>.
           </p>
         {/if}
       </div>
       <div class="modal-footer">
-        <button type="button" class="ok-btn" onclick={close}>OK</button>
+        <button type="button" class="ok-btn" onclick={close}>{$_('modal.ok')}</button>
       </div>
     </div>
   </div>

--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -80,7 +80,7 @@
         {@const name = $_('equipment.devices.' + key, { default: objDevices[key]?.name_de ?? key })}
         {@const cat = objDevices[key]?.category ?? 'fallback'}
         {@const color = objColors[cat] ?? objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
         {@const id = uid(f)}
         <li>
           {#if detail.html || detail.panoramaxUuid}
@@ -111,7 +111,7 @@
           ? $_('equipment.fitness.' + fsType, { default: objFitnessStation[fsType] ?? $_('equipment.fitnessDefault') })
           : $_('equipment.fitnessDefault')}
         {@const color = objColors['activity'] ?? objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
         {@const id = uid(f)}
         <li>
           {#if detail.html || detail.panoramaxUuid}
@@ -142,7 +142,7 @@
           ? $_('equipment.pitches.' + sport, { default: `${$_('equipment.pitchDefault')} (${sport})` })
           : $_('equipment.pitchDefault')}
         {@const color = objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties)}
+        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
         {@const id = uid(f)}
         <li>
           {#if detail.html || detail.panoramaxUuid}

--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -2,28 +2,12 @@
   import { objDevices, objFitnessStation } from '../lib/objPlaygroundEquipment.js';
   import { objColors } from '../lib/vectorStyles.js';
   import { getEquipmentAttributesFromProps } from '../lib/equipmentAttributes.js';
+  import { _ } from 'svelte-i18n';
 
   /** @type {Array} GeoJSON features from fetchPlaygroundEquipment */
   export let features = [];
   /** @type {Object} Playground polygon properties (for playground:<key> fallback) */
   export let playgroundAttr = {};
-
-  const pitchLabels = {
-    soccer:          ['Bolzplatz',          'Bolzplätze'],
-    basketball:      ['Basketballfeld',     'Basketballfelder'],
-    table_tennis:    ['Tischtennisplatte',  'Tischtennisplatten'],
-    volleyball:      ['Volleyballfeld',     'Volleyballfelder'],
-    tennis:          ['Tennisfeld',         'Tennisfelder'],
-    handball:        ['Handballfeld',       'Handballfelder'],
-    badminton:       ['Badmintonfeld',      'Badmintonfelder'],
-    boules:          ['Boulesbahn',         'Boulesanlagen'],
-    petanque:        ['Pétanquebahn',       'Pétanqueanlagen'],
-    multi:           ['Mehrzweckspielfeld', 'Mehrzweckspielfelder'],
-    skateboard:      ['Skatepark',          'Skateparks'],
-    bmx:             ['BMX-Bahn',           'BMX-Bahnen'],
-    climbing:        ['Kletteranlage',      'Kletteranlagen'],
-    fitness:         ['Fitnessbereich',     'Fitnessbereiche'],
-  };
 
   $: deviceFeatures  = features.filter(f => f.properties.playground && f.properties.playground !== 'yes');
   $: fitnessFeatures = features.filter(f => f.properties.leisure === 'fitness_station');
@@ -63,7 +47,7 @@
 </script>
 
 {#if features.length === 0 && Object.keys(fallbackCounts).length === 0}
-  <ul><li><small class="text-muted">Keine Spielgeräte erfasst.</small></li></ul>
+  <ul><li><small class="text-muted">{$_('equipment.noDevices')}</small></li></ul>
   <p class="text-muted mt-2 mb-0" style="font-size:smaller">
     Hilf mit und trage Spielgeräte auf
     <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a> ein.
@@ -72,19 +56,19 @@
   <!-- Summary counts -->
   <ul class="summary-list">
     {#if deviceFeatures.length}
-      <li>{deviceFeatures.length} Spielgerät{deviceFeatures.length !== 1 ? 'e' : ''}</li>
+      <li>{$_('equipment.deviceCount', { values: { count: deviceFeatures.length } })}</li>
     {/if}
     {#if fitnessFeatures.length}
-      <li>{fitnessFeatures.length} Fitnessgerät{fitnessFeatures.length !== 1 ? 'e' : ''}</li>
+      <li>{$_('equipment.fitnessCount', { values: { count: fitnessFeatures.length } })}</li>
     {/if}
     {#if benchCount}
-      <li>{benchCount} {benchCount !== 1 ? 'Sitzbänke' : 'Sitzbank'}</li>
+      <li>{$_('equipment.benches', { values: { count: benchCount } })}</li>
     {/if}
     {#if shelterCount}
-      <li>{shelterCount} Unterstand{shelterCount !== 1 ? 'e' : ''}</li>
+      <li>{$_('equipment.shelters', { values: { count: shelterCount } })}</li>
     {/if}
     {#if picnicCount}
-      <li>{picnicCount} Picknicktisch{picnicCount !== 1 ? 'e' : ''}</li>
+      <li>{$_('equipment.picnic', { values: { count: picnicCount } })}</li>
     {/if}
   </ul>
 
@@ -93,7 +77,7 @@
     <ul class="mb-0 device-list">
       {#each deviceFeatures as f (f.properties.osm_id)}
         {@const key = f.properties.playground}
-        {@const name = objDevices[key]?.name_de ?? key}
+        {@const name = $_('equipment.devices.' + key, { default: objDevices[key]?.name_de ?? key })}
         {@const cat = objDevices[key]?.category ?? 'fallback'}
         {@const color = objColors[cat] ?? objColors['fallback']}
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
@@ -107,9 +91,9 @@
             {#if openItems.has(id)}
               <div class="device-detail">
                 {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
                 {/if}
                 {@html detail.html}
@@ -123,7 +107,9 @@
 
       {#each fitnessFeatures as f (f.properties.osm_id)}
         {@const fsType = f.properties.fitness_station}
-        {@const name = (fsType && objFitnessStation[fsType]) ? objFitnessStation[fsType] : 'Fitnessgerät'}
+        {@const name = fsType
+          ? $_('equipment.fitness.' + fsType, { default: objFitnessStation[fsType] ?? $_('equipment.fitnessDefault') })
+          : $_('equipment.fitnessDefault')}
         {@const color = objColors['activity'] ?? objColors['fallback']}
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
         {@const id = uid(f)}
@@ -136,9 +122,9 @@
             {#if openItems.has(id)}
               <div class="device-detail">
                 {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
                 {/if}
                 {@html detail.html}
@@ -152,7 +138,9 @@
 
       {#each pitchFeatures as f (f.properties.osm_id)}
         {@const sport = f.properties.sport ?? ''}
-        {@const label = (pitchLabels[sport]?.[0]) ?? (sport ? `Sportfeld (${sport})` : 'Sportfeld')}
+        {@const label = sport
+          ? $_('equipment.pitches.' + sport, { default: `${$_('equipment.pitchDefault')} (${sport})` })
+          : $_('equipment.pitchDefault')}
         {@const color = objColors['fallback']}
         {@const detail = getEquipmentAttributesFromProps(f.properties)}
         {@const id = uid(f)}
@@ -165,9 +153,9 @@
             {#if openItems.has(id)}
               <div class="device-detail">
                 {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title="Foto vergrößern">
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt="Straßenfoto" class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> Foto dieses Geräts</span>
+                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
                 {/if}
                 {@html detail.html}
@@ -184,7 +172,7 @@
   {:else if Object.keys(fallbackCounts).length}
     <ul class="mb-0">
       {#each Object.entries(fallbackCounts) as [key, count]}
-        {@const name = objDevices[key]?.name_de ?? key}
+        {@const name = $_('equipment.devices.' + key, { default: objDevices[key]?.name_de ?? key })}
         {@const cat  = objDevices[key]?.category ?? 'fallback'}
         {@const color = objColors[cat] ?? objColors['fallback']}
         <li>
@@ -205,15 +193,15 @@
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="photo-modal-backdrop" onclick={() => modalUuid = null}>
     <div class="photo-modal" onclick={e => e.stopPropagation()}
-         role="dialog" aria-modal="true" aria-label="Gerätefoto" tabindex="-1">
+         role="dialog" aria-modal="true" aria-label={$_('popup.devicePhoto')} tabindex="-1">
       <div class="photo-modal-header">
-        <span class="photo-modal-title">Foto dieses Geräts</span>
-        <button type="button" class="btn-close" onclick={() => modalUuid = null} aria-label="Schließen"></button>
+        <span class="photo-modal-title">{$_('popup.devicePhoto')}</span>
+        <button type="button" class="btn-close" onclick={() => modalUuid = null} aria-label={$_('info.closeBtn')}></button>
       </div>
       <iframe
         src={viewerUrl(modalUuid)}
         style="width:100%; flex:1; border:none;"
-        title="Gerätefoto"
+        title={$_('popup.devicePhoto')}
         allowfullscreen
       ></iframe>
     </div>

--- a/app/src/components/FilterChips.svelte
+++ b/app/src/components/FilterChips.svelte
@@ -1,24 +1,16 @@
 <script>
   import { filterStore, hasActiveFilters } from '../stores/filters.js';
+  import { _ } from 'svelte-i18n';
   import { X } from 'lucide-svelte';
 
-  const FILTER_LABELS = {
-    private:     'Nur öffentlich',
-    water:       'Wasserspielplatz',
-    baby:        'Baby-geeignet',
-    toddler:     'Kleinkind-geeignet',
-    wheelchair:  'Rollstuhlgerecht',
-    bench:       'Mit Sitzbank',
-    picnic:      'Mit Picknicktisch',
-    shelter:     'Mit Unterstand',
-    tableTennis: 'Tischtennisplatte',
-    soccer:      'Mit Bolzplatz',
-    basketball:  'Basketballfeld',
-  };
+  const FILTER_KEYS = new Set([
+    'private', 'water', 'baby', 'toddler', 'wheelchair',
+    'bench', 'picnic', 'shelter', 'tableTennis', 'soccer', 'basketball',
+  ]);
 
   $: activeFilters = Object.entries($filterStore)
-    .filter(([_, active]) => active)
-    .map(([key]) => ({ key, label: FILTER_LABELS[key] }));
+    .filter(([key, active]) => active && FILTER_KEYS.has(key))
+    .map(([key]) => ({ key, label: $_('filter.labels.' + key) }));
 
   $: hasFilters = hasActiveFilters($filterStore);
 
@@ -39,7 +31,7 @@
         <button
           class="chip-remove"
           onclick={() => removeFilter(filter.key)}
-          aria-label="{filter.label} entfernen"
+          aria-label={$_('filter.removeChip', { values: { label: filter.label } })}
         >
           <X class="h-3 w-3" />
         </button>
@@ -48,7 +40,7 @@
 
     {#if activeFilters.length > 1}
       <button class="clear-all" onclick={clearAll}>
-        Alle löschen
+        {$_('filter.clearChips')}
       </button>
     {/if}
   </div>

--- a/app/src/components/FilterPanel.svelte
+++ b/app/src/components/FilterPanel.svelte
@@ -1,5 +1,6 @@
 <script>
   import { filterStore, hasActiveFilters } from '../stores/filters.js';
+  import { _ } from 'svelte-i18n';
   import { Filter, Droplets, Baby, Accessibility, Armchair, UtensilsCrossed, Home, RectangleHorizontal, Goal, CircleDot, Lock, Layers } from 'lucide-svelte';
 
   let open = false;
@@ -9,19 +10,25 @@
     if (open && wrap && !wrap.contains(e.target)) open = false;
   }
 
-  const FILTERS = [
-    { key: 'private',     label: 'Nur öffentlich',       icon: Lock },
-    { key: 'water',       label: 'Wasserspielplatz',     icon: Droplets },
-    { key: 'baby',        label: 'Baby-geeignet',        icon: Baby },
-    { key: 'toddler',     label: 'Kleinkind-geeignet',   icon: Baby },
-    { key: 'wheelchair',  label: 'Rollstuhlgerecht',     icon: Accessibility },
-    { key: 'bench',       label: 'Mit Sitzbank',         icon: Armchair },
-    { key: 'picnic',      label: 'Mit Picknicktisch',    icon: UtensilsCrossed },
-    { key: 'shelter',     label: 'Mit Unterstand',       icon: Home },
-    { key: 'tableTennis', label: 'Tischtennisplatte',    icon: RectangleHorizontal },
-    { key: 'soccer',      label: 'Mit Bolzplatz',        icon: Goal },
-    { key: 'basketball',  label: 'Basketballfeld',       icon: CircleDot },
-  ];
+  const FILTER_ICONS = {
+    private:     Lock,
+    water:       Droplets,
+    baby:        Baby,
+    toddler:     Baby,
+    wheelchair:  Accessibility,
+    bench:       Armchair,
+    picnic:      UtensilsCrossed,
+    shelter:     Home,
+    tableTennis: RectangleHorizontal,
+    soccer:      Goal,
+    basketball:  CircleDot,
+  };
+
+  $: FILTERS = Object.entries(FILTER_ICONS).map(([key, icon]) => ({
+    key,
+    label: $_('filter.labels.' + key),
+    icon,
+  }));
 
   $: active = hasActiveFilters($filterStore);
   $: activeCount = Object.values($filterStore).filter(Boolean).length;
@@ -42,8 +49,8 @@
     class="control-btn"
     class:active
     onclick={() => open = !open}
-    title="Filter"
-    aria-label="Filter"
+    title={$_('filter.title')}
+    aria-label={$_('filter.title')}
     aria-expanded={open}
   >
     <Filter class="h-5 w-5" />
@@ -55,10 +62,10 @@
   {#if open}
     <div class="filter-dropdown">
       <div class="dropdown-header">
-        <span class="dropdown-title">Filter</span>
+        <span class="dropdown-title">{$_('filter.title')}</span>
         {#if active}
           <button class="clear-btn" onclick={clearAll}>
-            Alle zurücksetzen
+            {$_('filter.clearAll')}
           </button>
         {/if}
       </div>
@@ -78,7 +85,7 @@
       </div>
 
       <div class="layer-section">
-        <span class="layer-title"><Layers class="h-3 w-3" /> Ebenen</span>
+        <span class="layer-title"><Layers class="h-3 w-3" /> {$_('filter.layers')}</span>
         <label class="filter-item" class:checked={$filterStore.standalonePitches}>
           <input
             type="checkbox"
@@ -86,7 +93,7 @@
             onchange={() => toggle('standalonePitches')}
           />
           <Goal class="h-4 w-4" />
-          <span>Sportflächen (außerhalb Spielplätze)</span>
+          <span>{$_('filter.standalonePitches')}</span>
         </label>
       </div>
     </div>

--- a/app/src/components/HoverPreview.svelte
+++ b/app/src/components/HoverPreview.svelte
@@ -11,7 +11,7 @@
   export let feature = null;
 
   $: attr = feature?.getProperties() ?? null;
-  $: title = attr ? getPlaygroundTitle(attr) : '';
+  $: title = attr ? getPlaygroundTitle(attr, $_) : '';
   $: isWater = attr?.is_water;
   $: hasTrees = attr?.tree_count > 0;
   $: forBaby = attr?.for_baby;

--- a/app/src/components/HoverPreview.svelte
+++ b/app/src/components/HoverPreview.svelte
@@ -3,6 +3,7 @@
   import { cn } from '../lib/utils.js';
   import { getPlaygroundTitle } from '../lib/playgroundHelpers.js';
   import { MapPin, Droplets, Baby, TreeDeciduous, Accessibility, Clock } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
 
   /** @type {{ x: number, y: number } | null} */
   export let position = null;
@@ -17,13 +18,9 @@
   $: isWheelchair = attr?.wheelchair === 'yes' || attr?.wheelchair === 'limited';
   $: area = attr?.area > 0 ? `${Math.round(attr.area / 10) * 10 || attr.area} m²` : null;
 
-  const surfaceLabels = {
-    sand: 'Sand', grass: 'Rasen', wood_chips: 'Holzschnitzel', bark_mulch: 'Rindenmulch',
-    rubber: 'Gummi', asphalt: 'Asphalt', concrete: 'Beton', gravel: 'Kies',
-    fine_gravel: 'Feinkies', dirt: 'Erde', compacted: 'verdichtet', tartan: 'Tartan',
-    artificial_turf: 'Kunstgras', paving_stones: 'Pflastersteine',
-  };
-  $: surface = attr?.surface ? (surfaceLabels[attr.surface] ?? attr.surface) : null;
+  $: surface = attr?.surface
+    ? ($_('details.surfaceValues.' + attr.surface, { default: attr.surface }) ?? attr.surface)
+    : null;
 
   $: ohOpen = (() => {
     if (!attr?.opening_hours || attr.opening_hours === '24/7') return null;
@@ -52,22 +49,22 @@
         <div class="flex flex-wrap gap-1.5 mb-2">
           {#if isWater}
             <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-water/15 text-water">
-              <Droplets class="h-3 w-3" />Wasser
+              <Droplets class="h-3 w-3" />{$_('hover.tagWater')}
             </span>
           {/if}
           {#if forBaby}
             <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-primary/15 text-primary">
-              <Baby class="h-3 w-3" />Baby
+              <Baby class="h-3 w-3" />{$_('hover.tagBaby')}
             </span>
           {/if}
           {#if hasTrees}
             <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full bg-nature/15 text-nature">
-              <TreeDeciduous class="h-3 w-3" />Bäume
+              <TreeDeciduous class="h-3 w-3" />{$_('hover.tagTrees')}
             </span>
           {/if}
           {#if isWheelchair}
             <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full" style="background:rgba(99,102,241,.1);color:#6366f1;">
-              <Accessibility class="h-3 w-3" />Barrierefrei
+              <Accessibility class="h-3 w-3" />{$_('hover.tagAccessible')}
             </span>
           {/if}
         </div>
@@ -76,13 +73,13 @@
         <div class="flex flex-col gap-1 text-xs" style="color: #6b7280;">
           <div class="flex items-center gap-1.5">
             <MapPin class="h-3 w-3 shrink-0" />
-            <span>{area ?? 'Spielplatz'}{surface ? ` · ${surface}` : ''}</span>
+            <span>{area ?? $_('hover.playground')}{surface ? ` · ${surface}` : ''}</span>
           </div>
           {#if ohOpen !== null}
             <div class="flex items-center gap-1.5">
               <Clock class="h-3 w-3 shrink-0" />
               <span style="color: {ohOpen ? '#16a34a' : '#dc2626'}">
-                {ohOpen ? 'Geöffnet' : 'Geschlossen'}
+                {ohOpen ? $_('poi.open') : $_('poi.closed')}
               </span>
             </div>
           {/if}
@@ -104,13 +101,13 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  
+
   /* Force light theme for hover preview card */
   .hover-card {
     background: #ffffff;
     border-color: #e5e7eb;
     color-scheme: light;
-    
+
     /* Override CSS variables for light theme */
     --color-background: #ffffff;
     --color-foreground: #1f2937;

--- a/app/src/components/LocateButton.svelte
+++ b/app/src/components/LocateButton.svelte
@@ -2,6 +2,7 @@
   import { fromLonLat } from 'ol/proj';
   import { mapStore } from '../stores/map.js';
   import { Navigation2, Loader2 } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
 
   /** Called with (lat, lon) after a GPS fix is obtained. */
   export let onlocation = null;
@@ -11,7 +12,7 @@
 
   function locate() {
     if (!navigator.geolocation) {
-      error = 'Geolocation nicht verfügbar.';
+      error = $_('locate.notSupported');
       return;
     }
     locating = true;
@@ -26,7 +27,7 @@
       },
       err => {
         locating = false;
-        error = err.code === 1 ? 'Standortzugriff verweigert.' : 'Standort nicht verfügbar.';
+        error = err.code === 1 ? $_('locate.denied') : $_('locate.unavailable');
       },
       { timeout: 10000, maximumAge: 60000 }
     );
@@ -38,8 +39,8 @@
   class:error={!!error}
   onclick={locate}
   disabled={locating}
-  title={error || 'Meinen Standort anzeigen'}
-  aria-label="Meinen Standort anzeigen"
+  title={error || $_('locate.title')}
+  aria-label={$_('locate.title')}
 >
   {#if locating}
     <Loader2 class="h-5 w-5 animate-spin" />

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -6,6 +6,7 @@
   import { fetchNearestPlaygrounds } from '../lib/api.js';
   import { playgroundCompleteness } from '../lib/completeness.js';
   import { apiBaseUrl } from '../lib/config.js';
+  import { _ } from 'svelte-i18n';
 
   export let lat;
   export let lon;
@@ -87,18 +88,18 @@
 </script>
 
 <div class="nearby-card">
-  <div class="nearby-header">In der Nähe</div>
+  <div class="nearby-header">{$_('nearby.header')}</div>
   {#if loading}
-    <div class="nearby-loading">Wird geladen …</div>
+    <div class="nearby-loading">{$_('nearby.loading')}</div>
   {:else if items.length === 0}
-    <div class="nearby-loading">Keine Spielplätze gefunden.</div>
+    <div class="nearby-loading">{$_('nearby.empty')}</div>
   {:else}
     <ul class="nearby-list">
       {#each items as item}
         <li>
           <button class="nearby-item" onclick={() => selectSuggestion(item)}>
             <span class="dot {completenessClass(item.tags)}"></span>
-            <span class="nearby-name">{item.name || 'Unbekannter Spielplatz'}</span>
+            <span class="nearby-name">{item.name || $_('nearby.unknownName')}</span>
             <span class="nearby-dist">{formatDistance(item.distance_m)}</span>
           </button>
         </li>

--- a/app/src/components/POIPanel.svelte
+++ b/app/src/components/POIPanel.svelte
@@ -1,6 +1,7 @@
 <script>
   import { haversineDistance, formatDistance, bearingDeg, bearingToDir } from '../lib/playgroundHelpers.js';
   import { poiRadiusM } from '../lib/config.js';
+  import { _ } from 'svelte-i18n';
 
   /** @type {Array} POI objects from fetchNearbyPOIs */
   export let pois = [];
@@ -9,39 +10,39 @@
   /** @type {number} Playground centre longitude (WGS84) */
   export let centerLon = 0;
 
-  const CATEGORIES = [
+  $: CATEGORIES = [
     {
-      icon: '🚻', label: 'Toiletten',
+      icon: '🚻', label: $_('poi.categories.toilets'),
       match: f => f.amenity === 'toilets',
-      fallback: 'Toiletten',
+      fallback: $_('poi.fallbacks.toilets'),
     },
     {
-      icon: '🚌', label: 'Bushaltestellen',
+      icon: '🚌', label: $_('poi.categories.busStops'),
       match: f => f.highway === 'bus_stop',
-      fallback: 'Bushaltestelle',
+      fallback: $_('poi.fallbacks.busStops'),
       hint: (poi) => poi.tags.towards
         ? `→ ${poi.tags.towards}`
-        : bearingToDir(bearingDeg(centerLat, centerLon, poi.lat, poi.lon)),
+        : $_('compass.' + bearingToDir(bearingDeg(centerLat, centerLon, poi.lat, poi.lon))),
     },
     {
-      icon: '🍦', label: 'Eis',
+      icon: '🍦', label: $_('poi.categories.iceCream'),
       match: f => f.amenity === 'ice_cream' || (f.cuisine && f.cuisine.includes('ice_cream')),
-      fallback: 'Eisdiele',
+      fallback: $_('poi.fallbacks.iceCream'),
     },
     {
-      icon: '🛒', label: 'Einkaufen',
+      icon: '🛒', label: $_('poi.categories.shopping'),
       match: f => f.shop === 'supermarket' || f.shop === 'convenience',
-      fallback: 'Supermarkt',
+      fallback: $_('poi.fallbacks.shopping'),
     },
     {
-      icon: '🧴', label: 'Drogerie',
+      icon: '🧴', label: $_('poi.categories.drugstore'),
       match: f => f.shop === 'chemist',
-      fallback: 'Drogerie',
+      fallback: $_('poi.fallbacks.drugstore'),
     },
     {
-      icon: '🏥', label: 'Notaufnahme',
+      icon: '🏥', label: $_('poi.categories.emergency'),
       match: f => f.emergency === 'yes' || f['healthcare:speciality'] === 'emergency',
-      fallback: 'Notaufnahme',
+      fallback: $_('poi.fallbacks.emergency'),
     },
   ];
 
@@ -68,7 +69,7 @@
 
 {#if sections.length === 0}
   <small class="text-muted">
-    Keine nahegelegenen Einrichtungen im Umkreis von {(poiRadiusM / 1000).toFixed(0)} km gefunden.
+    {$_('poi.noNearby', { values: { radius: (poiRadiusM / 1000).toFixed(0) } })}
   </small>
 {:else}
   {#each sections as cat}
@@ -87,10 +88,10 @@
           </span>
           <span class="ms-2 text-nowrap">
             <a href={geoUrl} class="text-muted text-decoration-none" style="font-size:smaller;"
-               title="In Navigations-App öffnen">{formatDistance(poi.dist)} ↗</a>
+               title={$_('poi.openNavApp')}>{formatDistance(poi.dist)} ↗</a>
             <a href={osmUrl} target="_blank" rel="noopener"
                class="text-muted text-decoration-none ms-1" style="font-size:smaller;"
-               title="Im Browser navigieren">🗺</a>
+               title={$_('poi.openInBrowser')}>🗺</a>
           </span>
         </div>
       {/each}

--- a/app/src/components/PanoramaxViewer.svelte
+++ b/app/src/components/PanoramaxViewer.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount } from 'svelte';
+  import { _ } from 'svelte-i18n';
 
   /** @type {{ uuids?: string[], mcUrl?: string }} */
   let { uuids = [], mcUrl = '' } = $props();
@@ -53,9 +54,9 @@
 {#if uuids.length === 0}
   <div class="text-center py-2">
     <span class="bi bi-camera" style="font-size:1.8rem; color:#d1d5db;"></span>
-    <p class="text-muted mt-1 mb-2" style="font-size:smaller;">Noch keine Fotos vorhanden.</p>
+    <p class="text-muted mt-1 mb-2" style="font-size:smaller;">{$_('panoramax.noPhotos')}</p>
     <a href={mcUrl} target="_blank" rel="noopener" class="mc-add-link small">
-      <span class="bi bi-camera-fill"></span> Foto hinzufügen
+      <span class="bi bi-camera-fill"></span> {$_('popup.addPhoto')}
     </a>
   </div>
 {:else}
@@ -63,12 +64,12 @@
   <div class="panoramax-preview" role="button" tabindex="0"
        onclick={() => openModal(selectedIndex)}
        onkeydown={e => e.key === 'Enter' && openModal(selectedIndex)}
-       title="Vollbild anzeigen"
+       title={$_('panoramax.fullscreen')}
   >
     <iframe
       src={viewerUrl(uuids[selectedIndex])}
       style="width:100%; height:240px; border:none; border-radius:4px; pointer-events:none;"
-      title="Straßenfoto"
+      title={$_('modal.streetPhoto')}
       allowfullscreen
     ></iframe>
     <div class="panoramax-overlay">
@@ -82,8 +83,8 @@
       {#each uuids as uuid, i}
         <button type="button" class="thumb-btn {i === selectedIndex ? 'thumb-active' : ''}"
                 onclick={() => selectedIndex = i}
-                title="Foto {i + 1} von {uuids.length}">
-          <img src={thumbUrl(uuid)} alt="Foto {i + 1}"
+                title={$_('photos.thumbnailTitle', { values: { n: i + 1, total: uuids.length } })}>
+          <img src={thumbUrl(uuid)} alt={$_('photos.thumbnail', { values: { n: i + 1 } })}
                style="width:52px; height:36px; object-fit:cover; border-radius:3px;" />
         </button>
       {/each}
@@ -92,7 +93,7 @@
 
   <p class="mt-1 mb-0">
     <a href={mcUrl} target="_blank" rel="noopener" class="mc-add-link small">
-      <span class="bi bi-camera-fill"></span> Foto hinzufügen
+      <span class="bi bi-camera-fill"></span> {$_('popup.addPhoto')}
     </a>
   </p>
 
@@ -104,28 +105,28 @@
 {#if fullscreen}
   <div use:portal class="panoramax-modal-backdrop" onclick={closeModal}>
     <div class="panoramax-modal" onclick={e => e.stopPropagation()}
-         role="dialog" aria-modal="true" aria-label="Straßenfoto" tabindex="-1">
+         role="dialog" aria-modal="true" aria-label={$_('modal.streetPhoto')} tabindex="-1">
       <div class="panoramax-modal-header">
         <div class="panoramax-nav">
           <button type="button" class="nav-btn"
-                  onclick={prev} disabled={uuids.length < 2} title="Vorheriges Foto">
+                  onclick={prev} disabled={uuids.length < 2} title={$_('modal.prevPhoto')}>
             &#8249;
           </button>
           <button type="button" class="nav-btn"
-                  onclick={next} disabled={uuids.length < 2} title="Nächstes Foto">
+                  onclick={next} disabled={uuids.length < 2} title={$_('modal.nextPhoto')}>
             &#8250;
           </button>
           <span class="photo-counter">{modalIndex + 1} / {uuids.length}</span>
-          <span class="photo-title">Straßenfoto</span>
+          <span class="photo-title">{$_('modal.streetPhoto')}</span>
         </div>
-        <button type="button" class="close-btn" onclick={closeModal} aria-label="Schließen">
+        <button type="button" class="close-btn" onclick={closeModal} aria-label={$_('modal.closeBtn')}>
           &#10005;
         </button>
       </div>
       <iframe
         src={viewerUrl(uuids[modalIndex])}
         style="width:100%; flex:1; border:none;"
-        title="Straßenfoto {modalIndex + 1}"
+        title={$_('photos.thumbnailTitle', { values: { n: modalIndex + 1, total: uuids.length } })}
         allowfullscreen
       ></iframe>
     </div>

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -225,7 +225,7 @@
     const url = `${window.location.origin}${window.location.pathname}#${attr.osm_type}${attr.osm_id}`;
     try {
       if (navigator.share) {
-        await navigator.share({ title: getPlaygroundTitle(attr), url });
+        await navigator.share({ title: getPlaygroundTitle(attr, $_), url });
       } else if (navigator.clipboard) {
         await navigator.clipboard.writeText(url);
       } else {
@@ -258,7 +258,7 @@
     {#if !embedded}
       <div class="info-panel__header">
         <div class="flex-1 min-w-0">
-          <h2 class="panel-title">{getPlaygroundTitle(attr)}</h2>
+          <h2 class="panel-title">{getPlaygroundTitle(attr, $_)}</h2>
           {#if getPlaygroundLocation(attr)}
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
           {/if}
@@ -283,7 +283,7 @@
       <!-- Embedded header (bottom sheet) -->
       <div class="flex items-start justify-between gap-2 mb-4">
         <div class="flex-1 min-w-0">
-          <h2 class="panel-title">{getPlaygroundTitle(attr)}</h2>
+          <h2 class="panel-title">{getPlaygroundTitle(attr, $_)}</h2>
           {#if getPlaygroundLocation(attr)}
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
           {/if}

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -3,6 +3,7 @@
   import OpeningHours from 'opening_hours';
   import { transform } from 'ol/proj';
   import { X, Share2, Check, ChevronDown, ChevronRight, Pencil, Clock, ExternalLink, Image, Package, Navigation, Star } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
 
   import { selection } from '../stores/selection.js';
   import { fetchPlaygroundEquipment, fetchNearbyPOIs, fetchTrees } from '../lib/api.js';
@@ -115,64 +116,70 @@
   });
 
   // ── Completeness badge ────────────────────────────────────────────────────
-  const COMPLETENESS = {
-    complete: { variant: 'success', label: 'Vollständig' },
-    partial:  { variant: 'warning', label: 'Teilweise erfasst' },
-    missing:  { variant: 'destructive', label: 'Daten fehlen' },
+  const COMPLETENESS_VARIANT = {
+    complete: 'success',
+    partial:  'warning',
+    missing:  'destructive',
   };
-  $: completeness = attr ? COMPLETENESS[playgroundCompleteness(attr)] : null;
+  const COMPLETENESS_KEY = {
+    complete: 'completeness.badgeComplete',
+    partial:  'completeness.partial',
+    missing:  'completeness.dotMissing',
+  };
+  $: completenessLevel = attr ? playgroundCompleteness(attr) : null;
+  $: completeness = completenessLevel
+    ? { variant: COMPLETENESS_VARIANT[completenessLevel], key: COMPLETENESS_KEY[completenessLevel] }
+    : null;
 
   // ── Opening hours ─────────────────────────────────────────────────────────
-  // Returns { color, label, suffix, error } so the template can render without
-  // {@html}. label includes the ● bullet; suffix is trailing plain text (e.g.
-  // "· Öffnet morgen um 09:00") rendered outside the coloured span.
-  function openingHoursState(ohStr) {
-    const fmt = d => d.toLocaleTimeString('de', { hour: '2-digit', minute: '2-digit' });
+  function openingHoursState(ohStr, t) {
+    const fmt = d => d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
     const dayLabel = (d, now) => {
-      if (d.toDateString() === now.toDateString()) return 'heute';
+      if (d.toDateString() === now.toDateString()) return t('poi.today');
       const tomorrow = new Date(now); tomorrow.setDate(now.getDate() + 1);
-      if (d.toDateString() === tomorrow.toDateString()) return 'morgen';
+      if (d.toDateString() === tomorrow.toDateString()) return t('poi.tomorrow');
       const diff = Math.round((d - now) / 86400000);
-      if (diff <= 6) return d.toLocaleDateString('de', { weekday: 'long' });
-      return d.toLocaleDateString('de', { weekday: 'short', day: '2-digit', month: '2-digit' });
+      if (diff <= 6) return d.toLocaleDateString(undefined, { weekday: 'long' });
+      return d.toLocaleDateString(undefined, { weekday: 'short', day: '2-digit', month: '2-digit' });
     };
     try {
       const oh = new OpeningHours(ohStr, { address: { country_code: 'de' } });
       const now = new Date();
       const isOpen = oh.getState(now);
       const next = oh.getNextChange(now);
-      if (ohStr.trim() === '24/7') return { open: true, text: 'Immer geöffnet' };
+      if (ohStr.trim() === '24/7') return { open: true, text: t('poi.alwaysOpen') };
       if (isOpen) {
-        const label = next ? `Geöffnet bis ${fmt(next)}` : 'Geöffnet';
+        const label = next
+          ? t('poi.openUntil', { values: { time: fmt(next) } })
+          : t('poi.open');
         return { open: true, text: label };
       }
-      if (next) return { open: false, text: `Geschlossen · Öffnet ${dayLabel(next, now)} um ${fmt(next)}` };
-      return { open: false, text: 'Geschlossen' };
+      if (next) return {
+        open: false,
+        text: `${t('poi.closed')} · ${t('poi.opensAt', { values: { day: dayLabel(next, now), time: fmt(next) } })}`,
+      };
+      return { open: false, text: t('poi.closed') };
     } catch {
       return { open: null, text: ohStr };
     }
   }
 
-  // ── Attribute helpers ─────────────────────────────────────────────────────
-  const surfaceLabels = {
-    sand:'Sand', grass:'Rasen', wood_chips:'Holzschnitzel', bark_mulch:'Rindenmulch',
-    rubber:'Gummigranulat', asphalt:'Asphalt', concrete:'Beton',
-    paving_stones:'Pflastersteine', tartan:'Tartan', artificial_turf:'Kunstgras',
-    gravel:'Kies', fine_gravel:'Feinkies', dirt:'Erde', compacted:'verdichtet',
-  };
-  const accessDict = {
-    yes:'öffentlich', private:'privat', customers:'nur für Gäste',
-    no:'nicht zugänglich', permissive:'öffentlich geduldet',
-    destination:'nur für Anlieger', residents:'nur für Anwohnende',
-  };
-  const privateDict = {
-    residents:'nur für Anwohnende', students:'nur für Schule',
-    employees:'nur für Mitarbeitende',
-  };
+  $: openingHoursInfo = attr?.opening_hours ? openingHoursState(attr.opening_hours, $_) : null;
 
-  $: accessLabel = attr
-    ? (privateDict[attr.private] ?? accessDict[attr.access] ?? 'unbekannt')
-    : '';
+  // ── Attribute helpers ─────────────────────────────────────────────────────
+  $: accessLabel = (() => {
+    if (!attr) return '';
+    const privateVal = attr.private;
+    if (privateVal === 'residents') return $_('details.access.residents');
+    if (privateVal === 'students')  return $_('details.access.students');
+    if (privateVal === 'employees') return $_('details.access.employees');
+    const access = attr.access ?? 'unknown';
+    return $_('details.access.' + access, { default: $_('details.access.unknown') });
+  })();
+
+  $: surfaceLabel = attr?.surface
+    ? ($_('details.surfaceValues.' + attr.surface, { default: attr.surface }) ?? attr.surface)
+    : null;
 
   $: descriptionParts = (() => {
     if (!attr) return [];
@@ -208,8 +215,6 @@
     }
     return uuids;
   })();
-
-  $: openingHoursInfo = attr?.opening_hours ? openingHoursState(attr.opening_hours) : null;
 
   // ── Share button ──────────────────────────────────────────────────────────
   let shareConfirmed = false;
@@ -258,18 +263,18 @@
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
           {/if}
           {#if completeness}
-            <Badge variant={completeness.variant} class="mt-2">{completeness.label}</Badge>
+            <Badge variant={completeness.variant} class="mt-2">{$_(completeness.key)}</Badge>
           {/if}
         </div>
         <div class="flex items-center gap-1 shrink-0">
-          <button class="panel-icon-btn" onclick={sharePlayground} aria-label="Link kopieren">
+          <button class="panel-icon-btn" onclick={sharePlayground} aria-label={$_('info.copyLink')}>
             {#if shareConfirmed}
               <Check class="h-5 w-5 text-green-600" />
             {:else}
               <Share2 class="h-5 w-5" />
             {/if}
           </button>
-          <button class="panel-icon-btn" onclick={() => selection.clear()} aria-label="Schließen">
+          <button class="panel-icon-btn" onclick={() => selection.clear()} aria-label={$_('info.closeBtn')}>
             <X class="h-5 w-5" />
           </button>
         </div>
@@ -283,10 +288,10 @@
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
           {/if}
           {#if completeness}
-            <Badge variant={completeness.variant} class="mt-2">{completeness.label}</Badge>
+            <Badge variant={completeness.variant} class="mt-2">{$_(completeness.key)}</Badge>
           {/if}
         </div>
-        <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label="Link kopieren">
+        <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label={$_('info.copyLink')}>
           {#if shareConfirmed}
             <Check class="h-5 w-5 text-green-600" />
           {:else}
@@ -306,37 +311,37 @@
       <div class="grid grid-cols-2 gap-x-4 gap-y-2 mb-4">
         {#if attr.area > 0}
           <div class="fact-item">
-            <span class="info-label">Größe</span>
+            <span class="info-label">{$_('details.sizeLabel')}</span>
             <span class="fact-value">{Math.round(attr.area / 10) * 10 || attr.area} m²</span>
           </div>
         {/if}
 
         <div class="fact-item">
-          <span class="info-label">Zugänglichkeit</span>
+          <span class="info-label">{$_('details.accessLabel')}</span>
           <span class="fact-value">{accessLabel}</span>
         </div>
 
-        {#if attr.surface}
+        {#if surfaceLabel}
           <div class="fact-item">
-            <span class="info-label">Oberfläche</span>
-            <span class="fact-value">{surfaceLabels[attr.surface] ?? attr.surface}</span>
+            <span class="info-label">{$_('details.surfaceLabel')}</span>
+            <span class="fact-value">{surfaceLabel}</span>
           </div>
         {/if}
 
         {#if attr.tree_count > 0}
           <div class="fact-item">
-            <span class="info-label">Bäume</span>
+            <span class="info-label">{$_('hover.tagTrees')}</span>
             <span class="fact-value">{attr.tree_count}</span>
           </div>
         {/if}
 
         {#if attr.min_age || attr.max_age}
           <div class="fact-item col-span-2">
-            <span class="info-label">Alter</span>
+            <span class="info-label">{$_('details.ageLabel')}</span>
             <span class="fact-value">
-              {#if attr.min_age && attr.max_age}{attr.min_age}–{attr.max_age} Jahre
-              {:else if attr.min_age}ab {attr.min_age} Jahren
-              {:else}bis {attr.max_age} Jahre{/if}
+              {#if attr.min_age && attr.max_age}{$_('details.ageRange', { values: { min: attr.min_age, max: attr.max_age } })}
+              {:else if attr.min_age}{$_('details.ageMin', { values: { age: attr.min_age } })}
+              {:else}{$_('details.ageMax', { values: { age: attr.max_age } })}{/if}
             </span>
           </div>
         {/if}
@@ -355,7 +360,7 @@
         <div class="space-y-2 mb-4">
           {#if attr.operator}
             <div class="fact-item" data-testid="operator-value">
-              <span class="info-label">Betreiber</span>
+              <span class="info-label">{$_('details.operatorLabel')}</span>
               {#if attr['operator:wikidata']}
                 <a href="https://www.wikidata.org/wiki/{attr['operator:wikidata']}"
                    target="_blank" rel="noopener" class="fact-value text-primary hover:underline">{attr.operator}</a>
@@ -367,7 +372,7 @@
           {#if attr['contact:phone'] || attr.phone}
             {@const phone = attr['contact:phone'] || attr.phone}
             <div class="fact-item">
-              <span class="info-label">Telefon</span>
+              <span class="info-label">{$_('details.phoneLabel')}</span>
               {#if /^\+?\d/.test(phone.trim())}
                 <a href="tel:{phone}" class="fact-value text-primary hover:underline">{phone}</a>
               {:else}<span class="fact-value">{phone}</span>{/if}
@@ -376,7 +381,7 @@
           {#if attr['contact:email'] || attr.email}
             {@const email = attr['contact:email'] || attr.email}
             <div class="fact-item">
-              <span class="info-label">E-Mail</span>
+              <span class="info-label">{$_('details.emailLabel')}</span>
               {#if email.includes('@') && !/^javascript:/i.test(email.trim())}
                 <a href="mailto:{email}" class="fact-value text-primary hover:underline">{email}</a>
               {:else}<span class="fact-value">{email}</span>{/if}
@@ -388,7 +393,7 @@
       <!-- Edit Link -->
       <a href={mcUrl} target="_blank" rel="noopener" class="panel-edit-link">
         <Pencil class="h-3 w-3" />
-        Bei MapComplete bearbeiten
+        {$_('details.editMapComplete')}
         <ExternalLink class="h-3 w-3" />
       </a>
 
@@ -406,7 +411,7 @@
               <ChevronRight class="h-4 w-4 text-muted-foreground" />
             {/if}
             <Image class="h-4 w-4 text-muted-foreground" />
-            Bilder
+            {$_('accordion.photos')}
           </button>
           {#if openSections.has('photos')}
             <div class="pb-3">
@@ -427,12 +432,12 @@
               <ChevronRight class="h-4 w-4 text-muted-foreground" />
             {/if}
             <Package class="h-4 w-4 text-muted-foreground" />
-            Ausstattung
+            {$_('accordion.equipment')}
           </button>
           {#if openSections.has('equipment')}
             <div class="pb-3">
               {#if equipmentLoading}
-                <p class="text-sm text-muted-foreground italic py-2">Wird geladen...</p>
+                <p class="text-sm text-muted-foreground italic py-2">{$_('details.loading')}</p>
               {:else}
                 <EquipmentList features={equipmentFeatures} playgroundAttr={attr} />
               {/if}
@@ -452,12 +457,12 @@
               <ChevronRight class="h-4 w-4 text-muted-foreground" />
             {/if}
             <Navigation class="h-4 w-4 text-muted-foreground" />
-            Umfeld
+            {$_('accordion.surroundings')}
           </button>
           {#if openSections.has('pois')}
             <div class="pb-3">
               {#if poisLoading}
-                <p class="text-sm text-muted-foreground italic py-2">Wird geladen...</p>
+                <p class="text-sm text-muted-foreground italic py-2">{$_('details.loading')}</p>
               {:else}
                 <POIPanel {pois} {centerLat} {centerLon} />
               {/if}
@@ -477,7 +482,7 @@
               <ChevronRight class="h-4 w-4 text-muted-foreground" />
             {/if}
             <Star class="h-4 w-4 text-muted-foreground" />
-            Bewertungen
+            {$_('accordion.reviews')}
           </button>
           {#if openSections.has('reviews')}
             <div class="pb-3">
@@ -505,7 +510,7 @@
     flex-direction: column;
     border-right: 1px solid #e5e7eb;
     color-scheme: light;
-    
+
     /* Force light theme variables */
     --color-background: #ffffff;
     --color-foreground: #1f2937;

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -2,6 +2,7 @@
   import VectorSource from 'ol/source/Vector.js';
   import { onDestroy } from 'svelte';
   import { Pencil, Plus, Minus } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
   import { transformExtent } from 'ol/proj';
 
   import Map from '../components/Map.svelte';
@@ -173,8 +174,8 @@
       <button
         class="control-btn"
         onclick={() => dataModalOpen = true}
-        title="Daten ergänzen"
-        aria-label="Daten ergänzen"
+        title={$_('nav.addData')}
+        aria-label={$_('nav.addData')}
       >
         <Pencil class="h-5 w-5" />
       </button>
@@ -187,16 +188,16 @@
         <button
           class="zoom-btn zoom-in"
           onclick={zoomIn}
-          title="Vergrößern"
-          aria-label="Vergrößern"
+          title={$_('zoom.in')}
+          aria-label={$_('zoom.in')}
         >
           <Plus class="h-4 w-4" />
         </button>
         <button
           class="zoom-btn zoom-out"
           onclick={zoomOut}
-          title="Verkleinern"
-          aria-label="Verkleinern"
+          title={$_('zoom.out')}
+          aria-label={$_('zoom.out')}
         >
           <Minus class="h-4 w-4" />
         </button>

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { _ } from 'svelte-i18n';
+
   /** @type {import('svelte/store').Readable<Array>} */
   export let backends;
   /** @type {import('svelte/store').Readable<string|null>} */
@@ -7,18 +9,18 @@
 
 <aside class="instance-panel">
   <h6 class="instance-panel__title">
-    <i class="bi bi-map me-1"></i> Spielplatzkarte Hub
+    <i class="bi bi-map me-1"></i> {$_('hub.title')}
   </h6>
 
   {#if $registryError}
     <p class="text-danger small px-2 mb-0">
       <i class="bi bi-exclamation-triangle-fill me-1"></i>
-      Registry nicht erreichbar
+      {$_('hub.registryError')}
     </p>
   {:else if $backends.length === 0}
     <p class="text-muted small px-2 mb-0">
       <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-      Instanzen werden geladen …
+      {$_('hub.loading')}
     </p>
   {:else}
     <ul class="instance-list">
@@ -34,17 +36,17 @@
           {#if b.loading}
             <div class="instance-status text-muted">
               <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-              Wird geladen …
+              {$_('details.loading')}
             </div>
           {:else if b.error}
             <div class="instance-status text-danger">
               <i class="bi bi-exclamation-triangle-fill me-1"></i>
-              Nicht erreichbar
+              {$_('hub.instanceError')}
             </div>
           {:else}
             <div class="instance-status text-muted">
               <i class="bi bi-geo-alt-fill me-1"></i>
-              {b.featureCount} Spielplätze
+              {$_('hub.playgroundCount', { values: { count: b.featureCount } })}
             </div>
           {/if}
         </li>

--- a/app/src/lib/equipmentAttributes.js
+++ b/app/src/lib/equipmentAttributes.js
@@ -1,64 +1,8 @@
 // Generates an HTML detail string for a single equipment feature.
 // Ported from js/popup.js → getEquipmentAttributes / getEquipmentAttributesFromProps.
 
-import { objDevices, objFitnessStation } from './objPlaygroundEquipment.js';
+import { objDevices } from './objPlaygroundEquipment.js';
 import { escapeHtml } from './utils.js';
-
-const objMaterial = {
-    wood:'Holz', metal:'Metall', steel:'Stahl', aluminium:'Aluminium',
-    plastic:'Kunststoff', stone:'Stein', sandstone:'Sandstein', concrete:'Beton',
-    brick:'Ziegelstein', granite:'Granit', rope:'Seil', rubber:'Gummi',
-    chain:'Kette', sand:'Sand',
-};
-
-const objPlaygroundTheme = {
-    animal:'Tier', bicycle:'Fahrrad', boat:'Boot', camel:'Kamel', car:'Auto',
-    carrot:'Karotte', castle:'Burg', construction:'Baustelle', dragon:'Drache',
-    duck:'Ente', dungeon:'Burgverlies', elephant:'Elefant', farm:'Farm',
-    fish:'Fisch', flower:'Blume', helicopter:'Hubschrauber', horse:'Pferd',
-    house:'Haus', ice_cream:'Eis', jungle:'Jungle', lama:'Lama',
-    lighthouse:'Leuchtturm', locomotive:'Lokomotive', mammoth:'Mammut',
-    mushroom:'Pilz', ocean:'Ozean', plane:'Flugzeug', rainbow:'Regenbogen',
-    rock:'Felsen', seal:'Robbe', sheep:'Schaf', ship:'Schiff', snake:'Schlange',
-    sport:'Sport', tent:'Zelt', tower:'Turm', train:'Eisenbahn', water:'Wasser',
-    whale:'Wal', windmill:'Windmühle',
-};
-
-const objStatus = {
-    ok:'OK', broken:'kaputt', missing_beam:'kaputt',
-    out_of_order:'außer Betrieb', locked:'verschlossen', blocked:'blockiert',
-};
-
-const objSport = {
-    'soccer;basketball':'Fußball, Basketball', 'basketball;soccer':'Fußball, Basketball',
-    athletics:'Leichtathletik', beachvolleyball:'Beachvolleyball', bmx:'BMX',
-    boules:'Boule', chess:'Schach', climbing:'Klettern', field_hockey:'Hockey',
-    fitness:'Fitness', gymnastics:'Gymnastik', multi:'verschiedene',
-    nine_mens_morris:'Mühle', running:'Laufsport', skateboard:'Skateboarding',
-    table_soccer:'Tischfußball', tennis:'Tennis', toboggan:'Rodeln',
-    volleyball:'Volleyball',
-};
-
-const objSurface = {
-    acrylic:'Acrylharz', artificial_turf:'Kunstrasen', asphalt:'Asphalt',
-    clay:'Asche', cobblestone:'Kopfsteinpflaster', compacted:'verdichtet',
-    concrete:'Beton', dirt:'Erde', earth:'Erde', fine_gravel:'Splitt',
-    grass:'Gras', gravel:'Schotter', ground:'Erde', metal:'Metall',
-    mud:'Schlamm', paved:'versiegelt', paving_stones:'Pflastersteine',
-    pebblestone:'Kies', plastic:'Kunststoff', rock:'Stein', rubber:'Gummi',
-    sand:'Sand', tartan:'Tartan', unpaved:'unversiegelt', wood:'Holz',
-    woodchips:'Holzhackschnitzel',
-};
-
-const objGenus = {
-    Abies:'Tanne', Acer:'Ahorn', Aesculus:'Rosskastanie', Betula:'Birke',
-    Carpinus:'Hainbuche', Castanea:'Kastanie', Catalpa:'Trompetenbaum',
-    Fagus:'Buche', Fraxinus:'Esche', Ginkgo:'Ginkgo', Juglans:'Walnuss',
-    Larix:'Lärche', Malus:'Apfel', Picea:'Fichte', Pinus:'Kiefer',
-    Platanus:'Platane', Populus:'Pappel', Prunus:'Kirsche', Quercus:'Eiche',
-    Robinia:'Robinie', Salix:'Weide', Sorbus:'Mehlbeere', Taxus:'Eibe',
-    Tilia:'Linde',
-};
 
 const pitchImages = {
     soccer:'File:Association football pitch imperial.svg',
@@ -80,71 +24,98 @@ const pitchImages = {
     climbing:'File:Outdoor bouldering wall.jpg',
 };
 
+function tl(t, key, fallback) {
+    const v = t(key, { default: fallback ?? key });
+    return v ?? fallback ?? key;
+}
+
 /**
  * Returns detail attributes for a single equipment item.
  * @param {Object} props - plain GeoJSON feature properties object
+ * @param {Function} t - svelte-i18n translate function
  * @returns {{ html: string, panoramaxUuid: string|null }}
  */
-export function getEquipmentAttributesFromProps(props) {
+export function getEquipmentAttributesFromProps(props, t) {
     const g = key => props[key];
     const content = [];
 
     const theme = g('playground:theme');
-    if (theme && theme !== 'playground')
-        content.push(`Motiv: ${objPlaygroundTheme[theme] ?? escapeHtml(theme)}`);
+    if (theme && theme !== 'playground') {
+        const label = tl(t, `equipAttr.themes.${theme}`, escapeHtml(theme));
+        content.push(`${t('equipAttr.theme')}: ${label}`);
+    }
 
-    if (g('capacity'))       content.push(`Plätze: ${escapeHtml(String(g('capacity')))}`);
-    if (g('capacity:baby'))  content.push(`Babyplätze: ${escapeHtml(String(g('capacity:baby')))}`);
+    if (g('capacity'))      content.push(`${t('equipAttr.capacity')}: ${escapeHtml(String(g('capacity')))}`);
+    if (g('capacity:baby')) content.push(`${t('equipAttr.babyCapacity')}: ${escapeHtml(String(g('capacity:baby')))}`);
 
-    for (const [tag, label] of [['height','Höhe'],['width','Breite']]) {
+    for (const [tag, labelKey] of [['height','equipAttr.height'],['width','equipAttr.width']]) {
         let v = g(tag);
         if (v) {
             v = v.replace(' ', '').toLowerCase();
             if (v.includes('cm')) { v = v.replace('cm',''); if (!isNaN(v)) v = v / 100; }
-            content.push((`${label}: ${escapeHtml(String(v))}` + (!isNaN(v) ? ' Meter' : '')).replace('.', ','));
+            const num = !isNaN(v);
+            content.push((`${t(labelKey)}: ${escapeHtml(String(v))}` + (num ? ` ${t('equipAttr.meters')}` : '')).replace('.', ','));
         }
     }
     const len = g('length');
-    if (len) content.push(`Länge: ${escapeHtml(String(len).replace('.', ','))} Meter`);
+    if (len) content.push(`${t('equipAttr.length')}: ${escapeHtml(String(len).replace('.', ','))} ${t('equipAttr.meters')}`);
 
     const pump_status = g('pump:status');
-    if (pump_status) content.push(`Status: ${objStatus[pump_status] ?? escapeHtml(pump_status)}`);
+    if (pump_status) {
+        const label = tl(t, `equipAttr.statuses.${pump_status}`, escapeHtml(pump_status));
+        content.push(`${t('equipAttr.status')}: ${label}`);
+    }
 
     const covered = g('covered');
-    if (covered === 'yes') content.push('überdacht');
-    else if (covered === 'no') content.push('nicht überdacht');
+    if (covered === 'yes') content.push(t('equipAttr.covered'));
+    else if (covered === 'no') content.push(t('equipAttr.notCovered'));
 
     const material = g('material');
-    if (material) content.push(`Material: ${objMaterial[material] ?? escapeHtml(material)}`);
+    if (material) {
+        const label = tl(t, `equipAttr.materials.${material}`, escapeHtml(material));
+        content.push(`${t('equipAttr.material')}: ${label}`);
+    }
 
-    if (g('baby') === 'yes') content.push('für Babys geeignet');
-    if (g('provided_for:toddler') === 'yes') content.push('für Kleinkinder geeignet');
+    if (g('baby') === 'yes') content.push(t('equipAttr.suitableBaby'));
+    if (g('provided_for:toddler') === 'yes') content.push(t('equipAttr.suitableToddler'));
 
     const wc = g('wheelchair');
-    if (wc === 'yes') content.push('Rollstuhlgerecht');
-    else if (wc === 'limited') content.push('Eingeschränkt rollstuhlgerecht');
-    else if (wc === 'no') content.push('Nicht rollstuhlgerecht');
+    if (wc === 'yes') content.push(t('equipAttr.wheelchairYes'));
+    else if (wc === 'limited') content.push(t('equipAttr.wheelchairLimited'));
+    else if (wc === 'no') content.push(t('equipAttr.wheelchairNo'));
 
-    if (g('blind') === 'yes') content.push('Für sehbehinderte Personen geeignet');
+    if (g('blind') === 'yes') content.push(t('equipAttr.blind'));
 
-    if (pump_status && g('check_date')) content.push(`Zuletzt überprüft: ${escapeHtml(g('check_date'))}`);
+    if (pump_status && g('check_date'))
+        content.push(`${t('equipAttr.lastChecked')}: ${escapeHtml(g('check_date'))}`);
 
     const backrest = g('backrest');
-    if (backrest === 'yes') content.push('mit Rückenlehne');
-    else if (backrest === 'no') content.push('ohne Rückenlehne');
+    if (backrest === 'yes') content.push(t('equipAttr.withBackrest'));
+    else if (backrest === 'no') content.push(t('equipAttr.noBackrest'));
 
     const sport = g('sport');
-    if (sport && !['table_tennis','soccer','basketball'].includes(sport))
-        content.push(`Sportart: ${objSport[sport] ?? escapeHtml(sport)}`);
+    if (sport && !['table_tennis','soccer','basketball'].includes(sport)) {
+        // Normalize semicolon-separated combos (e.g. "soccer;basketball" → "soccer_basketball")
+        const sportKey = sport.split(';').sort().join('_');
+        const label = tl(t, `equipAttr.sports.${sportKey}`, escapeHtml(sport));
+        content.push(`${t('equipAttr.sport')}: ${label}`);
+    }
 
     const surface = g('surface');
-    if (surface) content.push(`Oberflächenbelag: ${objSurface[surface] ?? escapeHtml(surface)}`);
+    if (surface) {
+        const label = tl(t, `details.surfaceValues.${surface}`, escapeHtml(surface));
+        content.push(`${t('equipAttr.surface')}: ${label}`);
+    }
 
     const genus = g('genus');
-    if (genus) content.push(`Baumart: ${objGenus[genus] ?? escapeHtml(genus)}`);
+    if (genus) {
+        const label = tl(t, `equipAttr.genera.${genus}`, escapeHtml(genus));
+        content.push(`${t('equipAttr.genus')}: ${label}`);
+    }
 
     const diameter_crown = g('diameter_crown');
-    if (diameter_crown) content.push(`Kronendurchmesser: ${escapeHtml(String(diameter_crown))} Meter`);
+    if (diameter_crown)
+        content.push(`${t('equipAttr.crownDiameter')}: ${escapeHtml(String(diameter_crown))} ${t('equipAttr.meters')}`);
 
     // Find Panoramax UUID on the device
     let panoramaxUuid = g('panoramax') || g('panoramax:0');
@@ -155,7 +126,7 @@ export function getEquipmentAttributesFromProps(props) {
     const osmId    = g('osm_id');
     const mcTheme  = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
     const mcUrl    = `https://mapcomplete.org/${mcTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
-    const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> Foto hinzufügen</a></p>`;
+    const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> ${escapeHtml(t('popup.addPhoto'))}</a></p>`;
 
     let html = '';
     if (content.length) {
@@ -169,11 +140,12 @@ export function getEquipmentAttributesFromProps(props) {
         const sportRaw  = g('sport');
         if (deviceKey && objDevices[deviceKey]?.image) {
             const imgFile = objDevices[deviceKey].image.replace(/^File:/, '').replace(/ /g, '_');
+            const altText = tl(t, `equipment.devices.${deviceKey}`, objDevices[deviceKey].name_de ?? deviceKey);
             html = `<div class="device-img-wrap">` +
                 `<img src="https://commons.wikimedia.org/wiki/Special:FilePath/${imgFile}?width=800"` +
                 ` data-fallback="https://wiki.openstreetmap.org/wiki/Special:FilePath/${imgFile}"` +
-                ` alt="${escapeHtml(objDevices[deviceKey].name_de)}" style="object-fit:contain;width:100%" onerror="${onerror}">` +
-                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> Symbolbild</p></div>`;
+                ` alt="${escapeHtml(altText)}" style="object-fit:contain;width:100%" onerror="${onerror}">` +
+                `<p class="mb-0 text-muted" style="font-size:0.75rem;"><span class="bi bi-image"></span> ${escapeHtml(t('popup.deviceSymbol'))}</p></div>`;
         } else if (leisure === 'pitch' && sportRaw && pitchImages[sportRaw]) {
             const imgFile = pitchImages[sportRaw].replace(/^File:/, '').replace(/ /g, '_');
             html = `<div class="device-img-wrap">` +

--- a/app/src/lib/playgroundHelpers.js
+++ b/app/src/lib/playgroundHelpers.js
@@ -1,11 +1,15 @@
 // Pure helper functions for playground display logic.
 // Ported from js/selectPlayground.js.
 
-/** Build a display title from OSM name tags. */
-export function getPlaygroundTitle(attr) {
+/**
+ * Build a display title from OSM name tags.
+ * @param {Object} attr - feature properties
+ * @param {Function} t - svelte-i18n translate function (optional)
+ */
+export function getPlaygroundTitle(attr, t) {
     const parts = [attr.name, attr.alt_name, attr.loc_name, attr.official_name, attr.old_name, attr.short_name]
         .filter(Boolean);
-    if (!parts.length) return 'Spielplatz';
+    if (!parts.length) return t ? t('nearby.defaultName') : 'Spielplatz';
     if (parts.length === 1) return parts[0];
     return `${parts[0]} (${parts.slice(1).join(', ')})`;
 }
@@ -38,10 +42,10 @@ export function haversineDistance(lat1, lon1, lat2, lon2) {
     return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-/** Format a distance in metres for display. */
+/** Format a distance in metres for display, using browser locale. */
 export function formatDistance(m) {
     if (m < 1000) return `~${Math.round(m / 10) * 10} m`;
-    return `~${(m / 1000).toLocaleString('de', { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km`;
+    return `~${(m / 1000).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} km`;
 }
 
 /** Bearing in degrees (0 = N, 90 = E) between two points. */
@@ -53,6 +57,7 @@ export function bearingDeg(lat1, lon1, lat2, lon2) {
     return (Math.atan2(y, x) * 180 / Math.PI + 360) % 360;
 }
 
+/** Returns a compass direction key suitable for $_('compass.KEY'). */
 export function bearingToDir(deg) {
-    return ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'][Math.round(deg / 45) % 8];
+    return ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'][Math.round(deg / 45) % 8];
 }

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -12,6 +12,7 @@
   import DataContributionModal from '../components/DataContributionModal.svelte';
   import { onDestroy } from 'svelte';
   import { Pencil, Plus, Minus } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
   import { apiBaseUrl } from '../lib/config.js';
   import { mapStore } from '../stores/map.js';
   import { selection, hasSelection } from '../stores/selection.js';
@@ -171,8 +172,8 @@
       <button
         class="control-btn"
         onclick={() => dataModalOpen = true}
-        title="Daten ergänzen"
-        aria-label="Daten ergänzen"
+        title={$_('nav.addData')}
+        aria-label={$_('nav.addData')}
       >
         <Pencil class="h-5 w-5" />
       </button>
@@ -185,16 +186,16 @@
         <button
           class="zoom-btn zoom-in"
           onclick={zoomIn}
-          title="Vergrößern"
-          aria-label="Vergrößern"
+          title={$_('zoom.in')}
+          aria-label={$_('zoom.in')}
         >
           <Plus class="h-4 w-4" />
         </button>
         <button
           class="zoom-btn zoom-out"
           onclick={zoomOut}
-          title="Verkleinern"
-          aria-label="Verkleinern"
+          title={$_('zoom.out')}
+          aria-label={$_('zoom.out')}
         >
           <Minus class="h-4 w-4" />
         </button>

--- a/locales/de.json
+++ b/locales/de.json
@@ -285,7 +285,13 @@
     "streetPhoto": "Straßenfoto",
     "prevPhoto": "Vorheriges Foto",
     "nextPhoto": "Nächstes Foto",
+    "ok": "OK",
     "addData": {
+      "introText": "Die Daten dieser Karte stammen aus {name}. Du kannst sie direkt bearbeiten – kein Account nötig bei MapComplete.",
+      "equipTitle": "Spielgeräte & Details ergänzen",
+      "mapcompleteText": "Spielgeräte, Fotos und weitere Details einfach per Klick eintragen.",
+      "wikiTitle": "OSM-Wiki",
+      "wikiLinkText": "Erfassungsregeln für Spielplätze in dieser Region",
       "osm": {
         "label": "OpenStreetMap",
         "text": "Die Daten stammen aus {osmLink} — einer freien, kollaborativen Weltkarte von Millionen Freiwilligen. Nur was eingetragen wurde, erscheint auch hier.",
@@ -305,7 +311,9 @@
       "community": {
         "label": "Community",
         "text": "Fragen oder mitmachen? Die lokale OSM-Community ist erreichbar über den {chatLink}.",
-        "chatLabel": "lokalen OSM-Community-Chat"
+        "chatLabel": "lokalen OSM-Community-Chat",
+        "simpleText": "Fragen und Austausch im",
+        "simpleChatLabel": "regionalen Chat"
       }
     },
     "about": {
@@ -326,6 +334,13 @@
         "repoLabel": "öffentlich verfügbar"
       }
     }
+  },
+  "hub": {
+    "title": "Spielplatzkarte Hub",
+    "registryError": "Registry nicht erreichbar",
+    "loading": "Instanzen werden geladen …",
+    "instanceError": "Nicht erreichbar",
+    "playgroundCount": "{count, plural, one {# Spielplatz}, other {# Spielplätze}}"
   },
   "details": {
     "sizeLabel": "Größe",

--- a/locales/de.json
+++ b/locales/de.json
@@ -262,6 +262,9 @@
     "openingHours": "Öffnungszeiten",
     "today": "Heute",
     "tomorrow": "Morgen",
+    "noNearby": "Keine nahegelegenen Einrichtungen im Umkreis von {radius} km gefunden.",
+    "openNavApp": "In Navigations-App öffnen",
+    "openInBrowser": "Im Browser navigieren",
     "categories": {
       "toilets": "Toiletten",
       "busStops": "Bushaltestellen",
@@ -334,6 +337,10 @@
         "repoLabel": "öffentlich verfügbar"
       }
     }
+  },
+  "compass": {
+    "N": "N", "NE": "NO", "E": "O", "SE": "SO",
+    "S": "S", "SW": "SW", "W": "W", "NW": "NW"
   },
   "hub": {
     "title": "Spielplatzkarte Hub",

--- a/locales/de.json
+++ b/locales/de.json
@@ -57,7 +57,8 @@
     "hint": "Spielplatz antippen für Details",
     "shareBtn": "Spielplatz teilen",
     "osmBtn": "Bei OpenStreetMap anzeigen",
-    "closeBtn": "Schließen"
+    "closeBtn": "Schließen",
+    "copyLink": "Link kopieren"
   },
   "completeness": {
     "complete": "Fotos, Name & Details vorhanden",
@@ -65,7 +66,8 @@
     "missing": "Noch keine Daten",
     "dotComplete": "Daten vollständig",
     "dotPartial": "Teilweise erfasst",
-    "dotMissing": "Daten fehlen"
+    "dotMissing": "Daten fehlen",
+    "badgeComplete": "Vollständig"
   },
   "accordion": {
     "photos": "Bilder",
@@ -336,6 +338,8 @@
     "ageMin": "ab {age} Jahren",
     "ageMax": "bis {age} Jahre",
     "operatorLabel": "Betreiber",
+    "phoneLabel": "Telefon",
+    "emailLabel": "E-Mail",
     "editMapComplete": "Bei MapComplete bearbeiten",
     "loading": "Wird geladen …",
     "access": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,5 +1,47 @@
 {
   "appTitle": "{regionName}er Spielplatzkarte",
+  "locate": {
+    "title": "Meinen Standort anzeigen",
+    "denied": "Standortzugriff verweigert.",
+    "unavailable": "Standort nicht verfügbar.",
+    "notSupported": "Geolocation nicht verfügbar."
+  },
+  "filter": {
+    "title": "Filter",
+    "clearAll": "Alle zurücksetzen",
+    "clearChips": "Alle löschen",
+    "removeChip": "{label} entfernen",
+    "layers": "Ebenen",
+    "standalonePitches": "Sportflächen (außerhalb Spielplätze)",
+    "labels": {
+      "private":     "Nur öffentlich",
+      "water":       "Wasserspielplatz",
+      "baby":        "Baby-geeignet",
+      "toddler":     "Kleinkind-geeignet",
+      "wheelchair":  "Rollstuhlgerecht",
+      "bench":       "Mit Sitzbank",
+      "picnic":      "Mit Picknicktisch",
+      "shelter":     "Mit Unterstand",
+      "tableTennis": "Tischtennisplatte",
+      "soccer":      "Mit Bolzplatz",
+      "basketball":  "Basketballfeld"
+    }
+  },
+  "hover": {
+    "tagWater":     "Wasser",
+    "tagBaby":      "Baby",
+    "tagTrees":     "Bäume",
+    "tagAccessible":"Barrierefrei",
+    "playground":   "Spielplatz"
+  },
+  "zoom": {
+    "in":  "Vergrößern",
+    "out": "Verkleinern"
+  },
+  "panoramax": {
+    "noPhotos":  "Noch keine Fotos vorhanden.",
+    "fullscreen":"Vollbild anzeigen"
+  },
   "search": {
     "placeholder": "Suchen …",
     "found": "\"{query}\" in {location}",
@@ -39,6 +81,10 @@
   },
   "nearby": {
     "title": "In der Nähe von {label}",
+    "header": "In der Nähe",
+    "loading": "Wird geladen …",
+    "empty": "Keine Spielplätze gefunden.",
+    "unknownName": "Unbekannter Spielplatz",
     "defaultName": "Spielplatz",
     "thisLocation": "diesem Ort"
   },
@@ -48,9 +94,27 @@
     "benches": "{count, plural, one {# Sitzbank}, other {# Sitzbänke}}",
     "shelters": "{count, plural, one {# Unterstand}, other {# Unterstände}}",
     "picnic": "{count, plural, one {# Picknicktisch}, other {# Picknicktische}}",
+    "noDevices": "Keine Spielgeräte erfasst.",
     "fitnessDefault": "Fitnessgerät",
+    "pitchDefault": "Sportfeld",
     "addHint": "Spielgeräte noch nicht einzeln kartiert – hilf mit! 👇",
     "addLink": "Spielgerät hinzufügen",
+    "pitches": {
+      "soccer":      "Bolzplatz",
+      "basketball":  "Basketballfeld",
+      "table_tennis":"Tischtennisplatte",
+      "volleyball":  "Volleyballfeld",
+      "tennis":      "Tennisfeld",
+      "handball":    "Handballfeld",
+      "badminton":   "Badmintonfeld",
+      "boules":      "Boulesbahn",
+      "petanque":    "Pétanquebahn",
+      "multi":       "Mehrzweckspielfeld",
+      "skateboard":  "Skatepark",
+      "bmx":         "BMX-Bahn",
+      "climbing":    "Kletteranlage",
+      "fitness":     "Fitnessbereich"
+    },
     "devices": {
       "slide": "Rutsche",
       "seesaw": "Wippe",
@@ -183,7 +247,8 @@
     "none": "Noch keine Fotos für diesen Spielplatz.<br>Warst du schon dort?",
     "addLink": "Foto hinzufügen",
     "enlarge": "Klicken zum Vergrößern",
-    "thumbnail": "Foto {n}"
+    "thumbnail": "Foto {n}",
+    "thumbnailTitle": "Foto {n} von {total}"
   },
   "poi": {
     "errorLoad": "Umfeld-Daten konnten nicht geladen werden.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -262,6 +262,9 @@
     "openingHours": "Opening hours",
     "today": "Today",
     "tomorrow": "Tomorrow",
+    "noNearby": "No nearby facilities found within {radius} km.",
+    "openNavApp": "Open in navigation app",
+    "openInBrowser": "Navigate in browser",
     "categories": {
       "toilets": "Toilets",
       "busStops": "Bus stops",
@@ -334,6 +337,10 @@
         "repoLabel": "publicly available"
       }
     }
+  },
+  "compass": {
+    "N": "N", "NE": "NE", "E": "E", "SE": "SE",
+    "S": "S", "SW": "SW", "W": "W", "NW": "NW"
   },
   "hub": {
     "title": "Spielplatzkarte Hub",

--- a/locales/en.json
+++ b/locales/en.json
@@ -285,7 +285,13 @@
     "streetPhoto": "Street photo",
     "prevPhoto": "Previous photo",
     "nextPhoto": "Next photo",
+    "ok": "OK",
     "addData": {
+      "introText": "The data on this map comes from {name}. You can edit it directly – no account needed for MapComplete.",
+      "equipTitle": "Equipment & details",
+      "mapcompleteText": "Add equipment, photos and further details with a click.",
+      "wikiTitle": "OSM wiki",
+      "wikiLinkText": "Mapping rules for playgrounds in this region",
       "osm": {
         "label": "OpenStreetMap",
         "text": "The data comes from {osmLink} — a free, collaborative world map built by millions of volunteers. Only what has been mapped will appear here.",
@@ -305,7 +311,9 @@
       "community": {
         "label": "Community",
         "text": "Questions or want to get involved? The local OSM community can be reached via {chatLink}.",
-        "chatLabel": "local OSM community chat"
+        "chatLabel": "local OSM community chat",
+        "simpleText": "Questions and discussion in the",
+        "simpleChatLabel": "local chat"
       }
     },
     "about": {
@@ -326,6 +334,13 @@
         "repoLabel": "publicly available"
       }
     }
+  },
+  "hub": {
+    "title": "Spielplatzkarte Hub",
+    "registryError": "Registry unreachable",
+    "loading": "Loading instances …",
+    "instanceError": "Unreachable",
+    "playgroundCount": "{count, plural, one {# playground}, other {# playgrounds}}"
   },
   "details": {
     "sizeLabel": "Size",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,47 @@
 {
   "appTitle": "{regionName} Playground Map",
+  "locate": {
+    "title": "Show my location",
+    "denied": "Location access denied.",
+    "unavailable": "Location unavailable.",
+    "notSupported": "Geolocation not available."
+  },
+  "filter": {
+    "title": "Filter",
+    "clearAll": "Reset all",
+    "clearChips": "Clear all",
+    "removeChip": "Remove {label}",
+    "layers": "Layers",
+    "standalonePitches": "Sports pitches (outside playgrounds)",
+    "labels": {
+      "private":     "Public only",
+      "water":       "Water playground",
+      "baby":        "Baby-friendly",
+      "toddler":     "Toddler-friendly",
+      "wheelchair":  "Wheelchair accessible",
+      "bench":       "With bench",
+      "picnic":      "With picnic table",
+      "shelter":     "With shelter",
+      "tableTennis": "Table tennis table",
+      "soccer":      "With football pitch",
+      "basketball":  "Basketball court"
+    }
+  },
+  "hover": {
+    "tagWater":     "Water",
+    "tagBaby":      "Baby",
+    "tagTrees":     "Trees",
+    "tagAccessible":"Accessible",
+    "playground":   "Playground"
+  },
+  "zoom": {
+    "in":  "Zoom in",
+    "out": "Zoom out"
+  },
+  "panoramax": {
+    "noPhotos":  "No photos yet.",
+    "fullscreen":"Show fullscreen"
+  },
   "search": {
     "placeholder": "Search …",
     "found": "\"{query}\" in {location}",
@@ -39,6 +81,10 @@
   },
   "nearby": {
     "title": "Near {label}",
+    "header": "Nearby",
+    "loading": "Loading …",
+    "empty": "No playgrounds found.",
+    "unknownName": "Unknown playground",
     "defaultName": "Playground",
     "thisLocation": "this location"
   },
@@ -48,9 +94,27 @@
     "benches": "{count, plural, one {# bench}, other {# benches}}",
     "shelters": "{count, plural, one {# shelter}, other {# shelters}}",
     "picnic": "{count, plural, one {# picnic table}, other {# picnic tables}}",
+    "noDevices": "No equipment mapped.",
     "fitnessDefault": "Fitness station",
+    "pitchDefault": "Sports pitch",
     "addHint": "Equipment not yet mapped individually – help out! 👇",
     "addLink": "Add equipment",
+    "pitches": {
+      "soccer":      "Football pitch",
+      "basketball":  "Basketball court",
+      "table_tennis":"Table tennis table",
+      "volleyball":  "Volleyball court",
+      "tennis":      "Tennis court",
+      "handball":    "Handball court",
+      "badminton":   "Badminton court",
+      "boules":      "Boules court",
+      "petanque":    "Pétanque court",
+      "multi":       "Multi-use pitch",
+      "skateboard":  "Skate park",
+      "bmx":         "BMX track",
+      "climbing":    "Climbing area",
+      "fitness":     "Fitness area"
+    },
     "devices": {
       "slide": "Slide",
       "seesaw": "Seesaw",
@@ -183,7 +247,8 @@
     "none": "No photos for this playground yet.<br>Have you been there?",
     "addLink": "Add photo",
     "enlarge": "Click to enlarge",
-    "thumbnail": "Photo {n}"
+    "thumbnail": "Photo {n}",
+    "thumbnailTitle": "Photo {n} of {total}"
   },
   "poi": {
     "errorLoad": "Could not load surroundings data.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -57,7 +57,8 @@
     "hint": "Tap a playground for details",
     "shareBtn": "Share playground",
     "osmBtn": "View on OpenStreetMap",
-    "closeBtn": "Close"
+    "closeBtn": "Close",
+    "copyLink": "Copy link"
   },
   "completeness": {
     "complete": "Photos, name & details available",
@@ -65,7 +66,8 @@
     "missing": "No data yet",
     "dotComplete": "Data complete",
     "dotPartial": "Partially mapped",
-    "dotMissing": "No data"
+    "dotMissing": "No data",
+    "badgeComplete": "Complete"
   },
   "accordion": {
     "photos": "Photos",
@@ -336,6 +338,8 @@
     "ageMin": "from {age} years",
     "ageMax": "up to {age} years",
     "operatorLabel": "Operator",
+    "phoneLabel": "Phone",
+    "emailLabel": "Email",
     "editMapComplete": "Edit on MapComplete",
     "loading": "Loading …",
     "access": {


### PR DESCRIPTION
Closes #164

## Summary
- **`playgroundHelpers.js`**: `getPlaygroundTitle` accepts optional `t` param (fallback uses `nearby.defaultName`); `formatDistance` uses browser locale instead of hardcoded `'de'`; `bearingToDir` now returns standard English compass keys (`N/NE/E/SE/S/SW/W/NW`) for locale lookup
- **`equipmentAttributes.js`**: `getEquipmentAttributesFromProps` accepts `t` param; all German inline strings and local dicts replaced with locale key lookups (`equipAttr.*`, `details.surfaceValues.*`, `equipment.devices.*`); sport key with semicolons normalised (e.g. `soccer;basketball` → `soccer_basketball`)
- **`EquipmentList.svelte`**: passes `$_` to `getEquipmentAttributesFromProps`
- **`HoverPreview.svelte`**, **`PlaygroundPanel.svelte`**: pass `$_` to `getPlaygroundTitle`
- **`POIPanel.svelte`**: `CATEGORIES` is now a reactive statement using `$_()`; compass direction rendered as `$_('compass.' + bearingToDir(...))`; no-nearby message and nav link titles from locale
- Added locale keys: `compass.*` (DE uses NO/O/SO; EN uses NE/E/SE), `poi.noNearby/openNavApp/openInBrowser`

## Test plan
- [ ] Build passes
- [ ] Equipment detail cards render translated attribute labels (height, material, status, etc.)
- [ ] Playground title falls back to translated "Spielplatz"/"Playground" when no name
- [ ] POI panel category headings appear in correct language
- [ ] Bus stop compass direction shows "NO" in DE, "NE" in EN
- [ ] Distance formatting uses browser locale decimal separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)