### PR TITLE
feat(i18n): location prepositions, missing components, and ICU plural fix

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -49,8 +49,7 @@
 {#if features.length === 0 && Object.keys(fallbackCounts).length === 0}
   <ul><li><small class="text-muted">{$_('equipment.noDevices')}</small></li></ul>
   <p class="text-muted mt-2 mb-0" style="font-size:smaller">
-    Hilf mit und trage Spielgeräte auf
-    <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a> ein.
+    {@html $_('equipment.mapcompleteHint', { values: { link: '<a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>' } })}
   </p>
 {:else}
   <!-- Summary counts -->

--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -181,8 +181,7 @@
       {/each}
     </ul>
     <p class="text-muted mt-2 mb-0" style="font-size:smaller">
-      Hilf mit und trage Spielgeräte auf
-      <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a> ein.
+      {@html $_('equipment.mapcompleteHint', { values: { link: '<a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>' } })}
     </p>
   {/if}
 {/if}

--- a/app/src/components/EquipmentTooltip.svelte
+++ b/app/src/components/EquipmentTooltip.svelte
@@ -1,5 +1,6 @@
 <script>
   import { objDevices, objFitnessStation } from '../lib/objPlaygroundEquipment.js';
+  import { _ } from 'svelte-i18n';
 
   /** @type {{ x: number, y: number } | null} */
   export let position = null;
@@ -10,19 +11,21 @@
   $: label = (() => {
     if (!props) return '';
     if (props.name) return props.name;
-    if (props.playground && objDevices[props.playground]) return objDevices[props.playground].name_de;
+    if (props.playground && props.playground !== 'yes') {
+      return $_('equipment.devices.' + props.playground, { default: objDevices[props.playground]?.name_de ?? props.playground });
+    }
     if (props.leisure === 'fitness_station') {
-      return objFitnessStation[props.fitness_station] ?? 'Fitnessgerät';
+      const ft = props.fitness_station;
+      return ft ? $_('equipment.fitness.' + ft, { default: objFitnessStation[ft] ?? $_('equipment.fitnessDefault') }) : $_('equipment.fitnessDefault');
     }
     if (props.leisure === 'pitch') {
-      const sports = { soccer: 'Bolzplatz', basketball: 'Basketballfeld', table_tennis: 'Tischtennisplatte',
-        volleyball: 'Volleyballfeld', tennis: 'Tennisfeld', multi: 'Mehrzweckspielfeld' };
-      return sports[props.sport] ?? (props.sport ? `Sportfeld (${props.sport})` : 'Sportfeld');
+      const sport = props.sport;
+      return sport ? $_('equipment.pitches.' + sport, { default: `${$_('equipment.pitchDefault')} (${sport})` }) : $_('equipment.pitchDefault');
     }
-    if (props.amenity === 'bench') return 'Sitzbank';
-    if (props.amenity === 'shelter') return 'Unterstand';
-    if (props.leisure === 'picnic_table') return 'Picknicktisch';
-    return props.playground || 'Gerät';
+    if (props.amenity === 'bench') return $_('equipment.devices.bench', { default: 'Bench' });
+    if (props.amenity === 'shelter') return $_('equipment.devices.shelter', { default: 'Shelter' });
+    if (props.leisure === 'picnic_table') return $_('equipment.devices.picnic_table', { default: 'Picnic table' });
+    return props.playground || $_('equipment.fitnessDefault');
   })();
 
   $: panoramaxUuid = (() => {

--- a/app/src/components/HoverPreview.svelte
+++ b/app/src/components/HoverPreview.svelte
@@ -19,7 +19,7 @@
   $: area = attr?.area > 0 ? `${Math.round(attr.area / 10) * 10 || attr.area} m²` : null;
 
   $: surface = attr?.surface
-    ? ($_('details.surfaceValues.' + attr.surface, { default: attr.surface }) ?? attr.surface)
+    ? attr.surface.split(';').map(s => $_('details.surfaceValues.' + s.trim(), { default: s.trim() })).join(' / ')
     : null;
 
   $: ohOpen = (() => {

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -259,8 +259,8 @@
       <div class="info-panel__header">
         <div class="flex-1 min-w-0">
           <h2 class="panel-title">{getPlaygroundTitle(attr, $_)}</h2>
-          {#if getPlaygroundLocation(attr)}
-            <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
+          {#if getPlaygroundLocation(attr, $_)}
+            <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr, $_)}</p>
           {/if}
           {#if completeness}
             <Badge variant={completeness.variant} class="mt-2">{$_(completeness.key)}</Badge>
@@ -284,8 +284,8 @@
       <div class="flex items-start justify-between gap-2 mb-4">
         <div class="flex-1 min-w-0">
           <h2 class="panel-title">{getPlaygroundTitle(attr, $_)}</h2>
-          {#if getPlaygroundLocation(attr)}
-            <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr)}</p>
+          {#if getPlaygroundLocation(attr, $_)}
+            <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr, $_)}</p>
           {/if}
           {#if completeness}
             <Badge variant={completeness.variant} class="mt-2">{$_(completeness.key)}</Badge>

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -178,7 +178,7 @@
   })();
 
   $: surfaceLabel = attr?.surface
-    ? ($_('details.surfaceValues.' + attr.surface, { default: attr.surface }) ?? attr.surface)
+    ? attr.surface.split(';').map(s => $_('details.surfaceValues.' + s.trim(), { default: s.trim() })).join(' / ')
     : null;
 
   $: descriptionParts = (() => {

--- a/app/src/components/ReviewsPanel.svelte
+++ b/app/src/components/ReviewsPanel.svelte
@@ -1,5 +1,6 @@
 <script>
   import { fetchReviews, submitReview, starsHtml, relativeDate } from '../lib/reviews.js';
+  import { _ } from 'svelte-i18n';
 
   /** @type {number} Playground centre latitude (WGS84) */
   export let lat = 0;
@@ -59,10 +60,10 @@
 </script>
 
 {#if loading}
-  <small class="text-muted"><i>Wird geladen …</i></small>
+  <small class="text-muted"><i>{$_('reviews.loading')}</i></small>
 
 {:else if error}
-  <small class="text-muted">Bewertungen konnten nicht geladen werden.</small>
+  <small class="text-muted">{$_('reviews.loadError')}</small>
 
 {:else}
   <!-- Average + review list -->
@@ -71,7 +72,7 @@
       {@html starsHtml(avgRating)}
       <strong style="font-size:14px">{(avgRating / 20).toFixed(1)}</strong>
       <span class="text-muted" style="font-size:12px">
-        ({reviews.length} Bewertung{reviews.length !== 1 ? 'en' : ''})
+        ({$_('reviews.count', { values: { count: reviews.length } })})
       </span>
     </p>
 
@@ -79,20 +80,20 @@
       {@const p = r.payload}
       <div class="review-item">
         {@html starsHtml(p.rating, '#f59e0b')}
-        <span class="text-muted ms-1" style="font-size:11px">{relativeDate(p.iat)}</span>
+        <span class="text-muted ms-1" style="font-size:11px">{relativeDate(p.iat, $_)}</span>
         {#if p.opinion}
           <p class="mb-0 mt-1" style="font-size:13px">{p.opinion}</p>
         {/if}
       </div>
     {/each}
   {:else}
-    <p class="text-muted mb-2" style="font-size:12px">Noch keine Bewertungen – sei die Erste!</p>
+    <p class="text-muted mb-2" style="font-size:12px">{$_('reviews.empty')}</p>
   {/if}
 
   <!-- Submission form -->
   <div class="mt-2 pt-2 border-top">
     <!-- Star picker -->
-    <div class="d-flex gap-1 mb-2" role="group" aria-label="Bewertung auswählen">
+    <div class="d-flex gap-1 mb-2" role="group" aria-label={$_('reviews.selectRating')}>
       {#each [20, 40, 60, 80, 100] as v, i}
         <button
           type="button"
@@ -101,7 +102,7 @@
           onclick={() => selectedRating = v}
           onmouseenter={() => hoverRating = v}
           onmouseleave={() => hoverRating = null}
-          aria-label="{i + 1} Stern{i > 0 ? 'e' : ''}"
+          aria-label={$_('reviews.starLabel', { values: { n: i + 1 } })}
         >★</button>
       {/each}
     </div>
@@ -109,7 +110,7 @@
     <textarea
       class="form-control form-control-sm mb-2"
       rows="2"
-      placeholder="Deine Meinung (optional)"
+      placeholder={$_('reviews.opinionPlaceholder')}
       style="font-size:13px; resize:none;"
       bind:value={opinion}
       disabled={submitting}
@@ -124,21 +125,17 @@
       {#if submitting}
         <span class="spinner-border spinner-border-sm me-1" role="status"></span>
       {/if}
-      Bewertung abgeben
+      {$_('reviews.submit')}
     </button>
 
     {#if submitStatus === 'success'}
-      <p class="text-success mt-1 mb-0" style="font-size:11px">Danke für deine Bewertung!</p>
+      <p class="text-success mt-1 mb-0" style="font-size:11px">{$_('reviews.submitted')}</p>
     {:else if submitStatus === 'error'}
-      <p class="text-danger mt-1 mb-0" style="font-size:11px">
-        Fehler beim Übermitteln – bitte versuche es erneut.
-      </p>
+      <p class="text-danger mt-1 mb-0" style="font-size:11px">{$_('reviews.errorRetry')}</p>
     {/if}
 
     <p class="text-muted mt-1 mb-0" style="font-size:10px">
-      Bewertungen sind anonym und werden über
-      <a href="https://mangrove.reviews" target="_blank" rel="noopener" class="link-secondary">Mangrove.reviews</a>
-      gespeichert.
+      {@html $_('reviews.privacyNote', { values: { mangroveLink: '<a href="https://mangrove.reviews" target="_blank" rel="noopener" class="link-secondary">Mangrove.reviews</a>' } })}
     </p>
   </div>
 {/if}

--- a/app/src/components/SearchBar.svelte
+++ b/app/src/components/SearchBar.svelte
@@ -3,6 +3,7 @@
   import { mapStore } from '../stores/map.js';
   import { Search, Loader2, X } from 'lucide-svelte';
   import { cn } from '../lib/utils.js';
+  import { _ } from 'svelte-i18n';
 
   /** Bounding box [minLon, minLat, maxLon, maxLat] to restrict Nominatim search. */
   export let regionExtent = null;
@@ -102,16 +103,16 @@
       bind:this={inputEl}
       type="text"
       class="search-input"
-      placeholder="Ort suchen..."
+      placeholder={$_('search.placeholder')}
       bind:value={query}
       onkeydown={onKeydown}
       oninput={onInput}
       onfocus={onFocus}
       onblur={onBlur}
-      aria-label="Ortssuche"
+      aria-label={$_('search.ariaLabel')}
     />
     {#if query}
-      <button class="clear-btn" onclick={clearSearch} aria-label="Suche leeren">
+      <button class="clear-btn" onclick={clearSearch} aria-label={$_('search.clearLabel')}>
         <X class="h-4 w-4 text-gray-400" />
       </button>
     {/if}

--- a/app/src/lib/equipmentAttributes.js
+++ b/app/src/lib/equipmentAttributes.js
@@ -103,7 +103,7 @@ export function getEquipmentAttributesFromProps(props, t) {
 
     const surface = g('surface');
     if (surface) {
-        const label = tl(t, `details.surfaceValues.${surface}`, escapeHtml(surface));
+        const label = surface.split(';').map(s => tl(t, `details.surfaceValues.${s.trim()}`, escapeHtml(s.trim()))).join(' / ');
         content.push(`${t('equipAttr.surface')}: ${label}`);
     }
 

--- a/app/src/lib/playgroundHelpers.js
+++ b/app/src/lib/playgroundHelpers.js
@@ -15,10 +15,13 @@ export function getPlaygroundTitle(attr, t) {
 }
 
 /** Build a human-readable location hint from nearest_highway or in_site tags. */
-export function getPlaygroundLocation(attr) {
+export function getPlaygroundLocation(attr, t) {
     if (attr.in_site) return attr.in_site;
     const highway = attr.nearest_highway;
     if (!highway) return '';
+
+    const values = { values: { name: highway } };
+    if (!t) return `in der Nähe von ${highway}`;
 
     const am = ['weg', 'platz', 'damm', 'ring', 'ufer', 'steg', 'steig', 'pfad',
                  'gestell', 'park', 'garten', 'bogen'];
@@ -27,10 +30,10 @@ export function getPlaygroundLocation(attr) {
     const h = highway.toLowerCase();
 
     if (am.some(s => h.endsWith(s) || h.startsWith(s)) && !highway.startsWith('Am '))
-        return `am ${highway}`;
+        return t('location.am', values);
     if (an_der.some(s => h.endsWith(s) || h.startsWith(s)) && !highway.startsWith('An der '))
-        return `an der ${highway}`;
-    return `in der Nähe von ${highway}`;
+        return t('location.anDer', values);
+    return t('location.near', values);
 }
 
 /** Haversine distance in metres between two WGS84 points. */

--- a/app/src/lib/reviews.js
+++ b/app/src/lib/reviews.js
@@ -103,15 +103,26 @@ export function starsHtml(rating100, color = '#f59e0b') {
         + `<span style="color:#d1d5db">${'☆'.repeat(5 - n)}</span>`;
 }
 
-export function relativeDate(iat) {
+export function relativeDate(iat, t) {
     const diff = Math.floor(Date.now() / 1000 - iat);
-    if (diff < 86400) return 'heute';
+    if (!t) {
+        if (diff < 86400) return 'heute';
+        const days = Math.floor(diff / 86400);
+        if (days < 7)    return `vor ${days} Tag${days === 1 ? '' : 'en'}`;
+        const weeks = Math.floor(days / 7);
+        if (weeks < 5)   return `vor ${weeks} Woche${weeks === 1 ? '' : 'n'}`;
+        const months = Math.floor(days / 30);
+        if (months < 12) return `vor ${months} Monat${months === 1 ? '' : 'en'}`;
+        const years = Math.floor(days / 365);
+        return `vor ${years} Jahr${years === 1 ? '' : 'en'}`;
+    }
+    if (diff < 86400) return t('reviews.today');
     const days = Math.floor(diff / 86400);
-    if (days < 7)    return `vor ${days} Tag${days === 1 ? '' : 'en'}`;
+    if (days < 7)    return t('reviews.daysAgo', { values: { count: days } });
     const weeks = Math.floor(days / 7);
-    if (weeks < 5)   return `vor ${weeks} Woche${weeks === 1 ? '' : 'n'}`;
+    if (weeks < 5)   return t('reviews.weeksAgo', { values: { count: weeks } });
     const months = Math.floor(days / 30);
-    if (months < 12) return `vor ${months} Monat${months === 1 ? '' : 'en'}`;
+    if (months < 12) return t('reviews.monthsAgo', { values: { count: months } });
     const years = Math.floor(days / 365);
-    return `vor ${years} Jahr${years === 1 ? '' : 'en'}`;
+    return t('reviews.yearsAgo', { values: { count: years } });
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Moje poloha",
-    "yourLocation": "vaší polohy"
+    "yourLocation": "vaší polohy",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "V blízkosti {{label}}",

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -4,7 +4,9 @@
     "placeholder": "Hledat …",
     "found": "\"{{query}}\" v {{location}}",
     "foundGeneric": "\"{{query}}\" nalezeno",
-    "notFound": "Žádné výsledky nenalezeny!"
+    "notFound": "Žádné výsledky nenalezeny!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Přidat data",
@@ -60,7 +62,8 @@
     "picnic_other": "{{count}} piknikových stolů",
     "fitnessDefault": "Fitness zařízení",
     "addHint": "Vybavení zatím není individuálně zmapováno – pomozte! 👇",
-    "addLink": "Přidat vybavení"
+    "addLink": "Přidat vybavení",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Pro toto hřiště zatím nejsou žádné fotografie.<br>Byli jste tam?",

--- a/locales/de.json
+++ b/locales/de.json
@@ -96,11 +96,11 @@
     "thisLocation": "diesem Ort"
   },
   "equipment": {
-    "deviceCount": "{count, plural, one {# Spielgerät}, other {# Spielgeräte}}",
-    "fitnessCount": "{count, plural, one {# Fitnessgerät}, other {# Fitnessgeräte}}",
-    "benches": "{count, plural, one {# Sitzbank}, other {# Sitzbänke}}",
-    "shelters": "{count, plural, one {# Unterstand}, other {# Unterstände}}",
-    "picnic": "{count, plural, one {# Picknicktisch}, other {# Picknicktische}}",
+    "deviceCount": "{count, plural, one {# Spielgerät} other {# Spielgeräte}}",
+    "fitnessCount": "{count, plural, one {# Fitnessgerät} other {# Fitnessgeräte}}",
+    "benches": "{count, plural, one {# Sitzbank} other {# Sitzbänke}}",
+    "shelters": "{count, plural, one {# Unterstand} other {# Unterstände}}",
+    "picnic": "{count, plural, one {# Picknicktisch} other {# Picknicktische}}",
     "noDevices": "Keine Spielgeräte erfasst.",
     "fitnessDefault": "Fitnessgerät",
     "pitchDefault": "Sportfeld",
@@ -353,7 +353,7 @@
     "registryError": "Registry nicht erreichbar",
     "loading": "Instanzen werden geladen …",
     "instanceError": "Nicht erreichbar",
-    "playgroundCount": "{count, plural, one {# Spielplatz}, other {# Spielplätze}}"
+    "playgroundCount": "{count, plural, one {# Spielplatz} other {# Spielplätze}}"
   },
   "details": {
     "sizeLabel": "Größe",
@@ -432,10 +432,10 @@
   "reviews": {
     "loading": "Wird geladen …",
     "loadError": "Bewertungen konnten nicht geladen werden.",
-    "count": "{count, plural, one {# Bewertung}, other {# Bewertungen}}",
+    "count": "{count, plural, one {# Bewertung} other {# Bewertungen}}",
     "empty": "Noch keine Bewertungen – sei die Erste!",
     "selectRating": "Bewertung auswählen",
-    "starLabel": "{n, plural, one {# Stern}, other {# Sterne}}",
+    "starLabel": "{n, plural, one {# Stern} other {# Sterne}}",
     "opinionPlaceholder": "Deine Meinung (optional)",
     "submit": "Bewertung abgeben",
     "submitting": "Wird übermittelt …",
@@ -444,10 +444,10 @@
     "error": "Fehler beim Übermitteln.",
     "privacyNote": "Bewertungen sind anonym und werden über {mangroveLink} gespeichert.",
     "today": "heute",
-    "daysAgo": "vor {count, plural, one {# Tag}, other {# Tagen}}",
-    "weeksAgo": "vor {count, plural, one {# Woche}, other {# Wochen}}",
-    "monthsAgo": "vor {count, plural, one {# Monat}, other {# Monaten}}",
-    "yearsAgo": "vor {count, plural, one {# Jahr}, other {# Jahren}}"
+    "daysAgo": "vor {count, plural, one {# Tag} other {# Tagen}}",
+    "weeksAgo": "vor {count, plural, one {# Woche} other {# Wochen}}",
+    "monthsAgo": "vor {count, plural, one {# Monat} other {# Monaten}}",
+    "yearsAgo": "vor {count, plural, one {# Jahr} other {# Jahren}}"
   },
   "equipAttr": {
     "theme": "Motiv",

--- a/locales/de.json
+++ b/locales/de.json
@@ -79,7 +79,10 @@
   },
   "location": {
     "btn": "Standort verfolgen",
-    "yourLocation": "deinem Standort"
+    "yourLocation": "deinem Standort",
+    "am": "am {name}",
+    "anDer": "an der {name}",
+    "near": "in der Nähe von {name}"
   },
   "nearby": {
     "title": "In der Nähe von {label}",

--- a/locales/de.json
+++ b/locales/de.json
@@ -44,6 +44,8 @@
   },
   "search": {
     "placeholder": "Suchen …",
+    "ariaLabel": "Ortssuche",
+    "clearLabel": "Suche leeren",
     "found": "\"{query}\" in {location}",
     "foundGeneric": "\"{query}\" gefunden",
     "notFound": "Kein Suchergebnis gefunden!"
@@ -104,6 +106,7 @@
     "pitchDefault": "Sportfeld",
     "addHint": "Spielgeräte noch nicht einzeln kartiert – hilf mit! 👇",
     "addLink": "Spielgerät hinzufügen",
+    "mapcompleteHint": "Hilf mit und trage Spielgeräte auf {link} ein.",
     "pitches": {
       "soccer":      "Bolzplatz",
       "basketball":  "Basketballfeld",
@@ -428,15 +431,23 @@
   },
   "reviews": {
     "loading": "Wird geladen …",
+    "loadError": "Bewertungen konnten nicht geladen werden.",
     "count": "{count, plural, one {# Bewertung}, other {# Bewertungen}}",
     "empty": "Noch keine Bewertungen – sei die Erste!",
+    "selectRating": "Bewertung auswählen",
+    "starLabel": "{n, plural, one {# Stern}, other {# Sterne}}",
     "opinionPlaceholder": "Deine Meinung (optional)",
     "submit": "Bewertung abgeben",
     "submitting": "Wird übermittelt …",
     "submitted": "Danke für deine Bewertung!",
     "errorRetry": "Fehler beim Übermitteln – bitte versuche es erneut.",
     "error": "Fehler beim Übermitteln.",
-    "privacyNote": "Bewertungen sind anonym und werden über {mangroveLink} gespeichert."
+    "privacyNote": "Bewertungen sind anonym und werden über {mangroveLink} gespeichert.",
+    "today": "heute",
+    "daysAgo": "vor {count, plural, one {# Tag}, other {# Tagen}}",
+    "weeksAgo": "vor {count, plural, one {# Woche}, other {# Wochen}}",
+    "monthsAgo": "vor {count, plural, one {# Monat}, other {# Monaten}}",
+    "yearsAgo": "vor {count, plural, one {# Jahr}, other {# Jahren}}"
   },
   "equipAttr": {
     "theme": "Motiv",

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,11 +96,11 @@
     "thisLocation": "this location"
   },
   "equipment": {
-    "deviceCount": "{count, plural, one {# piece of equipment}, other {# pieces of equipment}}",
-    "fitnessCount": "{count, plural, one {# fitness station}, other {# fitness stations}}",
-    "benches": "{count, plural, one {# bench}, other {# benches}}",
-    "shelters": "{count, plural, one {# shelter}, other {# shelters}}",
-    "picnic": "{count, plural, one {# picnic table}, other {# picnic tables}}",
+    "deviceCount": "{count, plural, one {# piece of equipment} other {# pieces of equipment}}",
+    "fitnessCount": "{count, plural, one {# fitness station} other {# fitness stations}}",
+    "benches": "{count, plural, one {# bench} other {# benches}}",
+    "shelters": "{count, plural, one {# shelter} other {# shelters}}",
+    "picnic": "{count, plural, one {# picnic table} other {# picnic tables}}",
     "noDevices": "No equipment mapped.",
     "fitnessDefault": "Fitness station",
     "pitchDefault": "Sports pitch",
@@ -353,7 +353,7 @@
     "registryError": "Registry unreachable",
     "loading": "Loading instances …",
     "instanceError": "Unreachable",
-    "playgroundCount": "{count, plural, one {# playground}, other {# playgrounds}}"
+    "playgroundCount": "{count, plural, one {# playground} other {# playgrounds}}"
   },
   "details": {
     "sizeLabel": "Size",
@@ -432,10 +432,10 @@
   "reviews": {
     "loading": "Loading …",
     "loadError": "Reviews could not be loaded.",
-    "count": "{count, plural, one {# review}, other {# reviews}}",
+    "count": "{count, plural, one {# review} other {# reviews}}",
     "empty": "No reviews yet – be the first!",
     "selectRating": "Select rating",
-    "starLabel": "{n, plural, one {# star}, other {# stars}}",
+    "starLabel": "{n, plural, one {# star} other {# stars}}",
     "opinionPlaceholder": "Your opinion (optional)",
     "submit": "Submit review",
     "submitting": "Submitting …",
@@ -444,10 +444,10 @@
     "error": "Error submitting.",
     "privacyNote": "Reviews are anonymous and stored via {mangroveLink}.",
     "today": "today",
-    "daysAgo": "{count, plural, one {# day ago}, other {# days ago}}",
-    "weeksAgo": "{count, plural, one {# week ago}, other {# weeks ago}}",
-    "monthsAgo": "{count, plural, one {# month ago}, other {# months ago}}",
-    "yearsAgo": "{count, plural, one {# year ago}, other {# years ago}}"
+    "daysAgo": "{count, plural, one {# day ago} other {# days ago}}",
+    "weeksAgo": "{count, plural, one {# week ago} other {# weeks ago}}",
+    "monthsAgo": "{count, plural, one {# month ago} other {# months ago}}",
+    "yearsAgo": "{count, plural, one {# year ago} other {# years ago}}"
   },
   "equipAttr": {
     "theme": "Theme",

--- a/locales/en.json
+++ b/locales/en.json
@@ -79,7 +79,10 @@
   },
   "location": {
     "btn": "My location",
-    "yourLocation": "your location"
+    "yourLocation": "your location",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Near {label}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -44,6 +44,8 @@
   },
   "search": {
     "placeholder": "Search …",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search",
     "found": "\"{query}\" in {location}",
     "foundGeneric": "\"{query}\" found",
     "notFound": "No results found!"
@@ -104,6 +106,7 @@
     "pitchDefault": "Sports pitch",
     "addHint": "Equipment not yet mapped individually – help out! 👇",
     "addLink": "Add equipment",
+    "mapcompleteHint": "Help map equipment on {link}.",
     "pitches": {
       "soccer":      "Football pitch",
       "basketball":  "Basketball court",
@@ -428,15 +431,23 @@
   },
   "reviews": {
     "loading": "Loading …",
+    "loadError": "Reviews could not be loaded.",
     "count": "{count, plural, one {# review}, other {# reviews}}",
     "empty": "No reviews yet – be the first!",
+    "selectRating": "Select rating",
+    "starLabel": "{n, plural, one {# star}, other {# stars}}",
     "opinionPlaceholder": "Your opinion (optional)",
     "submit": "Submit review",
     "submitting": "Submitting …",
     "submitted": "Thank you for your review!",
     "errorRetry": "Error submitting – please try again.",
     "error": "Error submitting.",
-    "privacyNote": "Reviews are anonymous and stored via {mangroveLink}."
+    "privacyNote": "Reviews are anonymous and stored via {mangroveLink}.",
+    "today": "today",
+    "daysAgo": "{count, plural, one {# day ago}, other {# days ago}}",
+    "weeksAgo": "{count, plural, one {# week ago}, other {# weeks ago}}",
+    "monthsAgo": "{count, plural, one {# month ago}, other {# months ago}}",
+    "yearsAgo": "{count, plural, one {# year ago}, other {# years ago}}"
   },
   "equipAttr": {
     "theme": "Theme",

--- a/locales/es.json
+++ b/locales/es.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Mi ubicación",
-    "yourLocation": "tu ubicación"
+    "yourLocation": "tu ubicación",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Cerca de {{label}}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -4,7 +4,9 @@
     "placeholder": "Buscar …",
     "found": "\"{{query}}\" en {{location}}",
     "foundGeneric": "\"{{query}}\" encontrado",
-    "notFound": "¡No se encontraron resultados!"
+    "notFound": "¡No se encontraron resultados!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Contribuir",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} mesas de pícnic",
     "fitnessDefault": "Aparato de fitness",
     "addHint": "Equipos aún no mapeados individualmente – ¡ayuda! 👇",
-    "addLink": "Añadir equipo"
+    "addLink": "Añadir equipo",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Aún no hay fotos de este parque.<br>¿Has estado allí?",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Ma position",
-    "yourLocation": "votre position"
+    "yourLocation": "votre position",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "À proximité de {{label}}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4,7 +4,9 @@
     "placeholder": "Rechercher …",
     "found": "« {{query}} » à {{location}}",
     "foundGeneric": "« {{query}} » trouvé",
-    "notFound": "Aucun résultat trouvé !"
+    "notFound": "Aucun résultat trouvé !",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Contribuer",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} tables de pique-nique",
     "fitnessDefault": "Appareil de fitness",
     "addHint": "Équipements pas encore cartographiés individuellement – aidez-nous ! 👇",
-    "addLink": "Ajouter un équipement"
+    "addLink": "Ajouter un équipement",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Pas encore de photos pour cette aire de jeux.<br>Vous y êtes allé ?",

--- a/locales/it.json
+++ b/locales/it.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "La mia posizione",
-    "yourLocation": "la tua posizione"
+    "yourLocation": "la tua posizione",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Vicino a {{label}}",

--- a/locales/it.json
+++ b/locales/it.json
@@ -4,7 +4,9 @@
     "placeholder": "Cerca …",
     "found": "\"{{query}}\" a {{location}}",
     "foundGeneric": "\"{{query}}\" trovato",
-    "notFound": "Nessun risultato trovato!"
+    "notFound": "Nessun risultato trovato!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Contribuisci",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} tavoli da picnic",
     "fitnessDefault": "Attrezzo fitness",
     "addHint": "Attrezzature non ancora mappate individualmente – aiuta! 👇",
-    "addLink": "Aggiungi attrezzo"
+    "addLink": "Aggiungi attrezzo",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Ancora nessuna foto per questo parco.<br>Ci sei stato?",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "現在地",
-    "yourLocation": "現在地"
+    "yourLocation": "現在地",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "{{label}}の近く",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -4,7 +4,9 @@
     "placeholder": "検索 …",
     "found": "{{location}}で「{{query}}」",
     "foundGeneric": "「{{query}}」が見つかりました",
-    "notFound": "結果が見つかりませんでした！"
+    "notFound": "結果が見つかりませんでした！",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "データを追加",
@@ -50,7 +52,8 @@
     "picnic_other": "ピクニックテーブル {{count}} 台",
     "fitnessDefault": "フィットネス器具",
     "addHint": "遊具はまだ個別にマッピングされていません – ご協力ください！ 👇",
-    "addLink": "遊具を追加"
+    "addLink": "遊具を追加",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "この遊び場の写真はまだありません。<br>訪れたことがありますか？",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Mijn locatie",
-    "yourLocation": "jouw locatie"
+    "yourLocation": "jouw locatie",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "In de buurt van {{label}}",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -4,7 +4,9 @@
     "placeholder": "Zoeken …",
     "found": "\"{{query}}\" in {{location}}",
     "foundGeneric": "\"{{query}}\" gevonden",
-    "notFound": "Geen resultaten gevonden!"
+    "notFound": "Geen resultaten gevonden!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Gegevens toevoegen",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} picknicktafels",
     "fitnessDefault": "Fitnesstoestel",
     "addHint": "Toestellen nog niet individueel in kaart gebracht – help mee! 👇",
-    "addLink": "Toestel toevoegen"
+    "addLink": "Toestel toevoegen",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Nog geen foto's voor deze speeltuin.<br>Ben je er al geweest?",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Moja lokalizacja",
-    "yourLocation": "twojej lokalizacji"
+    "yourLocation": "twojej lokalizacji",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "W pobliżu {{label}}",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -4,7 +4,9 @@
     "placeholder": "Szukaj …",
     "found": "\"{{query}}\" w {{location}}",
     "foundGeneric": "\"{{query}}\" znaleziono",
-    "notFound": "Nie znaleziono wyników!"
+    "notFound": "Nie znaleziono wyników!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Dodaj dane",
@@ -65,7 +67,8 @@
     "picnic_other": "{{count}} stołów piknikowych",
     "fitnessDefault": "Urządzenie fitness",
     "addHint": "Wyposażenie jeszcze nie zmapowane indywidualnie – pomóż! 👇",
-    "addLink": "Dodaj wyposażenie"
+    "addLink": "Dodaj wyposażenie",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Brak zdjęć dla tego placu zabaw.<br>Byłeś tam?",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Minha localização",
-    "yourLocation": "sua localização"
+    "yourLocation": "sua localização",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Perto de {{label}}",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -4,7 +4,9 @@
     "placeholder": "Pesquisar …",
     "found": "\"{{query}}\" em {{location}}",
     "foundGeneric": "\"{{query}}\" encontrado",
-    "notFound": "Nenhum resultado encontrado!"
+    "notFound": "Nenhum resultado encontrado!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Adicionar dados",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} mesas de piquenique",
     "fitnessDefault": "Equipamento de fitness",
     "addHint": "Equipamentos ainda não mapeados individualmente – ajude! 👇",
-    "addLink": "Adicionar equipamento"
+    "addLink": "Adicionar equipamento",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Ainda sem fotos para este parque.<br>Já lá esteve?",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Min plats",
-    "yourLocation": "din plats"
+    "yourLocation": "din plats",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Nära {{label}}",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -4,7 +4,9 @@
     "placeholder": "Sök …",
     "found": "\"{{query}}\" i {{location}}",
     "foundGeneric": "\"{{query}}\" hittades",
-    "notFound": "Inga resultat hittades!"
+    "notFound": "Inga resultat hittades!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Lägg till data",
@@ -55,7 +57,8 @@
     "picnic_other": "{{count}} picknicbord",
     "fitnessDefault": "Fitnessredskap",
     "addHint": "Utrustning inte kartlagd individuellt ännu – hjälp till! 👇",
-    "addLink": "Lägg till utrustning"
+    "addLink": "Lägg till utrustning",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Inga foton för den här lekplatsen ännu.<br>Har du besökt den?",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -32,7 +32,10 @@
   },
   "location": {
     "btn": "Моє місцезнаходження",
-    "yourLocation": "вашого місцезнаходження"
+    "yourLocation": "вашого місцезнаходження",
+    "am": "near {name}",
+    "anDer": "near {name}",
+    "near": "near {name}"
   },
   "nearby": {
     "title": "Поблизу {{label}}",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -4,7 +4,9 @@
     "placeholder": "Пошук …",
     "found": "\"{{query}}\" у {{location}}",
     "foundGeneric": "\"{{query}}\" знайдено",
-    "notFound": "Результатів не знайдено!"
+    "notFound": "Результатів не знайдено!",
+    "ariaLabel": "Location search",
+    "clearLabel": "Clear search"
   },
   "nav": {
     "addData": "Додати дані",
@@ -65,7 +67,8 @@
     "picnic_other": "{{count}} пікнічного столу",
     "fitnessDefault": "Тренажер",
     "addHint": "Обладнання ще не нанесено індивідуально – допоможіть! 👇",
-    "addLink": "Додати обладнання"
+    "addLink": "Додати обладнання",
+    "mapcompleteHint": "Help map equipment on {link}."
   },
   "photos": {
     "none": "Ще немає фотографій для цього майданчика.<br>Ви вже там були?",

--- a/oci/app/Dockerfile
+++ b/oci/app/Dockerfile
@@ -12,6 +12,7 @@ RUN npm ci
 
 # Build the Svelte app
 COPY app/ ./
+COPY locales/ /locales/
 RUN npm run build
 
 # ── Stage 2: Serve ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #165

## Summary
- **#165** `getPlaygroundLocation(attr, t)` — prepositions (`am`/`an der`/`in der Nähe von`) are now locale keys; non-DE locales get `"near {name}"`
- **Dockerfile** — copy `locales/` into Docker build context so the Vite build can resolve `../../../locales/*.json`
- **SearchBar** — wire up existing `search.placeholder`; add `ariaLabel`/`clearLabel` keys
- **ReviewsPanel** — full i18n using existing `reviews.*` keys; add `loadError`, `selectRating`, `starLabel`, relative-date keys
- **EquipmentTooltip** — replace all hardcoded German device/pitch/amenity labels with `$_()` lookups
- **EquipmentList** — fix second missed MapComplete hint (polygon-level `playground:*` fallback path)
- **ICU plural syntax** — remove commas between plural cases (`, other {` → ` other {`); `intl-messageformat` throws `MISSING_OTHER_CLAUSE` with the comma syntax
- **Surface values** — split `surface` on `;` before locale lookup so `grass;gravel` → `Grass / Gravel` (HoverPreview, PlaygroundPanel, equipmentAttributes)
- `reviews.js relativeDate` — accept optional `t` parameter for locale-aware relative dates

## Test plan
- [ ] Browser set to English: no German strings visible in the app UI
- [ ] Equipment summary shows "3 pieces of equipment", "2 benches" (not raw ICU)
- [ ] Device tooltip shows e.g. "Zip wire" not "Seilbahn"
- [ ] Surface `grass;gravel` shows as "Grass / Gravel"
- [ ] Playground with polygon-level `playground:*` tags shows English MapComplete hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)