### PR TITLE
refactor(ui): extract AppShell and make Map a pure renderer (#144)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -1,0 +1,450 @@
+<script>
+  import Map from './Map.svelte';
+  import PlaygroundPanel from './PlaygroundPanel.svelte';
+  import SearchBar from './SearchBar.svelte';
+  import LocateButton from './LocateButton.svelte';
+  import FilterPanel from './FilterPanel.svelte';
+  import FilterChips from './FilterChips.svelte';
+  import BottomSheet from './BottomSheet.svelte';
+  import HoverPreview from './HoverPreview.svelte';
+  import EquipmentTooltip from './EquipmentTooltip.svelte';
+  import NearbyPlaygrounds from './NearbyPlaygrounds.svelte';
+  import DataContributionModal from './DataContributionModal.svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import { Pencil, Plus, Minus } from 'lucide-svelte';
+  import { mapStore } from '../stores/map.js';
+  import { selection, hasSelection } from '../stores/selection.js';
+  import { playgroundSourceStore } from '../stores/playgroundSource.js';
+  import { parseHash } from '../lib/deeplink.js';
+
+  /**
+   * The OL VectorSource that renders the playground layer. The shell passes it
+   * to the Map and to widgets that need to scan features (NearbyPlaygrounds
+   * fallback, URL-hash restore).
+   * @type {import('ol/source/Vector.js').default}
+   */
+  export let playgroundSource;
+
+  /**
+   * Readable store emitting the current map view in WGS84 as
+   * `[minLon, minLat, maxLon, maxLat]` (or null). Consumed by SearchBar as
+   * Nominatim `viewbox`.
+   * @type {import('svelte/store').Readable<[number,number,number,number]|null>}
+   */
+  export let searchExtent;
+
+  /**
+   * `(lat, lon) => Promise<Array<{ osm_id, name, distance_m, ... }>>` returning
+   * distance-sorted nearby playgrounds. Standalone wires this to a single
+   * PostgREST call; hub wires it to a multi-backend merge.
+   * @type {(lat: number, lon: number) => Promise<Array>}
+   */
+  export let nearestFetcher = null;
+
+  /**
+   * Links shown in the data-contribution modal.
+   * @type {{ wikiUrl: string, chatUrl: string | null }}
+   */
+  export let dataContribLinks;
+
+  /** Fallback backend URL applied to features that don't carry `_backendUrl`. */
+  export let defaultBackendUrl = '';
+
+  /**
+   * Optional Svelte snippet rendered in the bottom-left corner, above the
+   * scale-line. Hub uses this to render the instance-pill; standalone leaves
+   * it empty.
+   * @type {import('svelte').Snippet | null}
+   */
+  export let instancePanel = null;
+
+  // ── URL hash restore ──────────────────────────────────────────────────────
+  //
+  // On first load the shell inspects `location.hash` and — once the injected
+  // source has features — selects the matching osm_id. The slug is accepted
+  // but not enforced here; hub mode layers its own slug→backend resolution on
+  // top (see #148).
+  let hashRestored = false;
+  function tryRestoreFromHash() {
+    if (hashRestored) return;
+    const parsed = parseHash(window.location.hash);
+    if (!parsed) { hashRestored = true; return; }
+    const feat = playgroundSource.getFeatures().find(f => f.get('osm_id') === parsed.osmId);
+    if (feat) {
+      const backendUrl = feat.get('_backendUrl') ?? defaultBackendUrl;
+      selection.select(feat, backendUrl);
+      hashRestored = true;
+    }
+  }
+
+  onMount(() => {
+    // If features are already loaded (sync fetch or test fixture), try now.
+    tryRestoreFromHash();
+    // Otherwise wait for the source to populate.
+    const key = playgroundSource.on('change', tryRestoreFromHash);
+    return () => playgroundSource.un('change', tryRestoreFromHash);
+  });
+
+  let dataModalOpen = false;
+
+  // Nearest-playground suggestions panel
+  let nearbyLocation = null;  // { lat, lon } | null
+  let dismissUnsub = null;
+
+  function handleLocation(lat, lon) {
+    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+    if (lat === null) { nearbyLocation = null; return; }
+    nearbyLocation = { lat, lon };
+    let first = true;
+    dismissUnsub = selection.subscribe(() => {
+      if (first) { first = false; return; }
+      nearbyLocation = null;
+      if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+    });
+  }
+
+  function dismissNearby() {
+    nearbyLocation = null;
+    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+  }
+
+  onDestroy(() => { if (dismissUnsub) dismissUnsub(); });
+
+  // Responsive: track if we're on mobile
+  let isMobile = false;
+  function checkMobile() {
+    isMobile = typeof window !== 'undefined' && window.innerWidth < 1024;
+  }
+  $: if (typeof window !== 'undefined') {
+    checkMobile();
+  }
+
+  // Bottom sheet state for mobile
+  let bottomSheetOpen = false;
+  let bottomSheetSnap = 'half';
+
+  // Keep bottom-right controls above the sheet at each snap height
+  $: controlsBottomStyle = (() => {
+    if (!isMobile || !bottomSheetOpen) return '';
+    if (bottomSheetSnap === 'peek') return 'bottom: calc(140px + 1rem)';
+    if (bottomSheetSnap === 'half') return 'bottom: calc(50vh + 1rem)';
+    return '';
+  })();
+
+  // Sync bottom sheet with selection on mobile
+  $: if (isMobile && $hasSelection) {
+    bottomSheetOpen = true;
+    bottomSheetSnap = 'peek';
+    const feat = $selection.feature;
+    if (feat && $mapStore) {
+      $mapStore.getView().fit(feat.getGeometry().getExtent(), {
+        padding: [40, 40, 180, 40],
+        maxZoom: 19,
+        duration: 400,
+      });
+    }
+  }
+  $: if (isMobile && !$hasSelection) {
+    bottomSheetOpen = false;
+  }
+
+  // Hover preview state
+  let hoverFeature = null;
+  let hoverPosition = null;
+
+  function handleHover(feature, pixel) {
+    if (isMobile) return;
+    hoverFeature = feature;
+    hoverPosition = pixel ? { x: pixel[0], y: pixel[1] } : null;
+  }
+
+  function clearHover() {
+    hoverFeature = null;
+    hoverPosition = null;
+  }
+
+  let equipHoverFeature = null;
+  let equipHoverPosition = null;
+
+  function handleEquipHover(feature, pixel) {
+    if (isMobile) return;
+    equipHoverFeature = feature;
+    equipHoverPosition = pixel ? { x: pixel[0], y: pixel[1] } : null;
+  }
+
+  function clearEquipHover() {
+    equipHoverFeature = null;
+    equipHoverPosition = null;
+  }
+
+  function zoomIn() {
+    if ($mapStore) {
+      const view = $mapStore.getView();
+      view.animate({ zoom: view.getZoom() + 1, duration: 200 });
+    }
+  }
+
+  function zoomOut() {
+    if ($mapStore) {
+      const view = $mapStore.getView();
+      view.animate({ zoom: view.getZoom() - 1, duration: 200 });
+    }
+  }
+</script>
+
+<svelte:window onresize={checkMobile} />
+
+<div class="app-root">
+  <Map
+    {playgroundSource}
+    {defaultBackendUrl}
+    onhover={handleHover}
+    onclearhover={clearHover}
+    onequipmenthover={handleEquipHover}
+    onclearequipmenthover={clearEquipHover}
+  />
+
+  {#if !(isMobile && bottomSheetSnap === 'full')}
+    <div class="search-area">
+      <SearchBar regionExtent={$searchExtent} onlocation={handleLocation} />
+      <FilterChips />
+      {#if nearbyLocation}
+        <NearbyPlaygrounds
+          lat={nearbyLocation.lat}
+          lon={nearbyLocation.lon}
+          fetcher={nearestFetcher}
+          {defaultBackendUrl}
+          ondismiss={dismissNearby}
+        />
+      {/if}
+    </div>
+
+    <div class="controls-top-right">
+      <FilterPanel />
+      <button
+        class="control-btn"
+        onclick={() => dataModalOpen = true}
+        title="Daten ergänzen"
+        aria-label="Daten ergänzen"
+      >
+        <Pencil class="h-5 w-5" />
+      </button>
+    </div>
+
+    <div class="controls-bottom-right" style={controlsBottomStyle}>
+      <LocateButton onlocation={handleLocation} />
+      <div class="zoom-controls">
+        <button
+          class="zoom-btn zoom-in"
+          onclick={zoomIn}
+          title="Vergrößern"
+          aria-label="Vergrößern"
+        >
+          <Plus class="h-4 w-4" />
+        </button>
+        <button
+          class="zoom-btn zoom-out"
+          onclick={zoomOut}
+          title="Verkleinern"
+          aria-label="Verkleinern"
+        >
+          <Minus class="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+
+    {#if instancePanel}
+      <div class="instance-slot">
+        {@render instancePanel()}
+      </div>
+    {/if}
+  {/if}
+
+  {#if !isMobile && $hasSelection}
+    <div class="side-panel">
+      <PlaygroundPanel />
+    </div>
+  {/if}
+
+  {#if isMobile}
+    <BottomSheet
+      bind:open={bottomSheetOpen}
+      bind:snapPoint={bottomSheetSnap}
+      title=""
+    >
+      {#if $hasSelection}
+        <PlaygroundPanel embedded={true} />
+      {/if}
+    </BottomSheet>
+  {/if}
+
+  <HoverPreview position={$hasSelection ? null : hoverPosition} feature={$hasSelection ? null : hoverFeature} />
+  <EquipmentTooltip position={equipHoverPosition} feature={equipHoverFeature} />
+
+  <DataContributionModal
+    bind:open={dataModalOpen}
+    wikiUrl={dataContribLinks.wikiUrl}
+    chatUrl={dataContribLinks.chatUrl}
+  />
+</div>
+
+<style>
+  .app-root {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .search-area {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .controls-top-right {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+  }
+
+  .controls-bottom-right {
+    position: absolute;
+    bottom: 7rem;
+    right: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
+    transition: bottom 0.3s ease-out;
+  }
+
+  .control-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background: white;
+    border: none;
+    border-radius: 50%;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    color: #666;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .control-btn:hover {
+    background: #f5f5f5;
+    color: #333;
+  }
+
+  .zoom-controls {
+    display: flex;
+    flex-direction: column;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+  }
+
+  .zoom-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    background: white;
+    border: none;
+    cursor: pointer;
+    color: #666;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .zoom-btn:hover {
+    background: #f5f5f5;
+    color: #333;
+  }
+
+  .zoom-in {
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  /* Bottom-left slot for the hub instance-pill (and any future bottom-left widget). */
+  .instance-slot {
+    position: absolute;
+    bottom: 1rem;
+    left: 1rem;
+    z-index: 100;
+  }
+
+  .side-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 380px;
+    z-index: 200;
+    background: var(--color-card);
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+    overflow-y: auto;
+    animation: slideInLeft 0.3s ease-out;
+    color-scheme: light;
+
+    --color-background: #ffffff;
+    --color-foreground: #1f2937;
+    --color-card: #ffffff;
+    --color-card-foreground: #1f2937;
+    --color-popover: #ffffff;
+    --color-popover-foreground: #1f2937;
+    --color-muted: #f3f4f6;
+    --color-muted-foreground: #6b7280;
+    --color-border: #e5e7eb;
+    --color-input: #e5e7eb;
+  }
+
+  @keyframes slideInLeft {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  @media (max-width: 1023px) {
+    .search-area {
+      top: 0.75rem;
+      left: 0.75rem;
+      right: 0.75rem;
+    }
+
+    .controls-top-right {
+      top: auto;
+      bottom: auto;
+      right: 0.75rem;
+      top: 0.75rem;
+    }
+
+    .controls-bottom-right {
+      bottom: 10rem;
+      right: 0.75rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .app-root:has(.side-panel) .search-area {
+      left: calc(380px + 1rem);
+      transition: left 0.3s ease-out;
+    }
+  }
+</style>

--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -2,6 +2,10 @@
   import { regionPlaygroundWikiUrl, regionChatUrl } from '../lib/config.js';
 
   export let open = false;
+  /** OSM wiki page shown as "Erfassungsregeln für Spielplätze in dieser Region". */
+  export let wikiUrl = regionPlaygroundWikiUrl;
+  /** Community chat URL; hidden when null/falsy. */
+  export let chatUrl = regionChatUrl;
   function close() { open = false; }
 
   function onBackdropClick(e) {
@@ -39,16 +43,16 @@
 
         <h6 class="section-heading">OSM-Wiki</h6>
         <p class="small">
-          <a href={regionPlaygroundWikiUrl} target="_blank" rel="noopener">
+          <a href={wikiUrl} target="_blank" rel="noopener">
             Erfassungsregeln für Spielplätze in dieser Region
           </a>
         </p>
 
-        {#if regionChatUrl}
+        {#if chatUrl}
           <h6 class="section-heading">Community</h6>
           <p class="small">
             Fragen und Austausch im
-            <a href={regionChatUrl} target="_blank" rel="noopener">regionalen Chat</a>.
+            <a href={chatUrl} target="_blank" rel="noopener">regionalen Chat</a>.
           </p>
         {/if}
       </div>

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -142,7 +142,7 @@
 
     olMap.on('pointermove', (evt) => {
       // Overlay hit-test: any layer tagged with `kind: 'overlay'` participates
-      // (equipment points, trees, standalone pitches contributed by the shell).
+      // (equipment points, standalone pitches contributed by the shell).
       const overlayHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
         layerFilter: l => l.get('kind') === 'overlay',
       });

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -5,13 +5,11 @@
   import VectorSource from 'ol/source/Vector.js';
   import XYZ from 'ol/source/XYZ.js';
   import GeoJSON from 'ol/format/GeoJSON.js';
-  import { transform, transformExtent } from 'ol/proj';
+  import { transform } from 'ol/proj';
   import { ScaleLine, defaults as defaultControls } from 'ol/control.js';
   import { defaults as defaultInteractions } from 'ol/interaction/defaults';
 
-  import { mapZoom, mapMinZoom, osmRelationId, apiBaseUrl } from '../lib/config.js';
-  import { fetchPlaygrounds, fetchStandaloneEquipment } from '../lib/api.js';
-  import { fetchRegionInfo } from '../lib/region.js';
+  import { mapZoom, mapMinZoom, apiBaseUrl } from '../lib/config.js';
   import { playgroundStyleFn, selectionStyle, equipmentLayerStyleFn, treeStyle } from '../lib/vectorStyles.js';
   import { selection } from '../stores/selection.js';
   import { mapStore } from '../stores/map.js';
@@ -20,7 +18,7 @@
   import { overlayFeaturesStore } from '../stores/overlayLayer.js';
   import { debounce } from '../lib/utils.js';
 
-  // Props: optional overrides for hub mode (multiple backends feed into one shared source)
+  // Props: the source is injected; Map itself never loads data.
   /** @type {VectorSource | null} - when provided, the map uses this source instead of creating one */
   export let playgroundSource = null;
   /** Backend URL used for selection — standalone passes apiBaseUrl, hub passes per-feature URL */
@@ -37,17 +35,15 @@
 
   let mapContainer;
   let olMap = null;
-  let ownSource = null;       // only set when we own the source (standalone mode)
   let playgroundLayer = null; // exposed for filter reactivity
   let equipmentLayer = null;  // overlay: equipment points/polygons
   let treeLayer = null;       // overlay: tree dots
-  let pitchLayer = null;      // standalone pitches not within any playground
   let overlayUnsubscribe = null;
-  const PITCH_MIN_ZOOM = 12;  // only fetch standalone pitches at this zoom or above
 
   onMount(async () => {
-    // Use provided source (hub) or create our own (standalone)
-    const source = playgroundSource ?? (ownSource = new VectorSource());
+    // The shell owns the source; fall back to an empty one so the map still
+    // renders in degraded paths (e.g. tests that mount Map without a parent).
+    const source = playgroundSource ?? new VectorSource();
 
     playgroundLayer = new VectorLayer({
       source,
@@ -99,7 +95,12 @@
           { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' }
         );
         src.addFeatures(olFeatures);
-        equipmentLayer = new VectorLayer({ source: src, zIndex: 20, style: equipmentLayerStyleFn });
+        equipmentLayer = new VectorLayer({
+          source: src,
+          zIndex: 20,
+          style: equipmentLayerStyleFn,
+          properties: { kind: 'overlay' },
+        });
         olMap.addLayer(equipmentLayer);
       }
 
@@ -140,32 +141,30 @@
     }, 100);
 
     olMap.on('pointermove', (evt) => {
-      const equipHit = equipmentLayer
-        ? olMap.forEachFeatureAtPixel(evt.pixel, f => f, { layerFilter: l => l === equipmentLayer })
-        : null;
-      const pitchHit = pitchLayer
-        ? olMap.forEachFeatureAtPixel(evt.pixel, f => f, { layerFilter: l => l === pitchLayer })
-        : null;
+      // Overlay hit-test: any layer tagged with `kind: 'overlay'` participates
+      // (equipment points, trees, standalone pitches contributed by the shell).
+      const overlayHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
+        layerFilter: l => l.get('kind') === 'overlay',
+      });
       const playHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
         layerFilter: l => l === playgroundLayer,
       });
 
-      mapContainer.style.cursor = (equipHit || pitchHit || playHit) ? 'pointer' : '';
+      mapContainer.style.cursor = (overlayHit || playHit) ? 'pointer' : '';
 
-      // Equipment / standalone-pitch hover takes priority
-      const equipOrPitchHit = equipHit ?? pitchHit ?? null;
-      if (equipOrPitchHit !== lastEquipHoverFeature) {
-        lastEquipHoverFeature = equipOrPitchHit;
-        if (equipOrPitchHit) {
-          if (onequipmenthover) onequipmenthover(equipOrPitchHit, evt.pixel);
+      // Overlay hover takes priority
+      if (overlayHit !== lastEquipHoverFeature) {
+        lastEquipHoverFeature = overlayHit;
+        if (overlayHit) {
+          if (onequipmenthover) onequipmenthover(overlayHit, evt.pixel);
           if (lastHoverFeature) { lastHoverFeature = null; if (onclearhover) onclearhover(); }
         } else {
           if (onclearequipmenthover) onclearequipmenthover();
         }
       }
 
-      // Playground hover (only when not hovering equipment or pitch)
-      if (!equipOrPitchHit) {
+      // Playground hover (only when not hovering an overlay feature)
+      if (!overlayHit) {
         if (playHit && playHit !== lastHoverFeature) {
           lastHoverFeature = playHit;
           debouncedHover(playHit, evt.pixel);
@@ -189,42 +188,9 @@
       }
     });
 
-    // Standalone: fetch playgrounds, fit to region, and set up pitch layer
-    if (ownSource) {
-      playgroundSourceStore.set(ownSource);
-      loadStandaloneData(ownSource, view);
-
-      // Standalone pitch layer — refreshed on moveend
-      const pitchSource = new VectorSource();
-      pitchLayer = new VectorLayer({ source: pitchSource, zIndex: 9, style: equipmentLayerStyleFn });
-      olMap.addLayer(pitchLayer);
-
-      const reloadPitches = debounce(async () => {
-        const zoom = olMap.getView().getZoom();
-        if (zoom < PITCH_MIN_ZOOM) { pitchSource.clear(); return; }
-        const extent = olMap.getView().calculateExtent(olMap.getSize());
-        const geojson = await fetchStandaloneEquipment(extent);
-        const features = new GeoJSON().readFeatures(geojson, {
-          dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857',
-        });
-        pitchSource.clear();
-        pitchSource.addFeatures(features);
-      }, 300);
-
-      olMap.on('moveend', reloadPitches);
-    }
-
-    // Restore selection from URL hash on load
-    const hash = window.location.hash;
-    const match = hash.match(/^#W(\d+)$/);
-    if (match) {
-      const osmId = parseInt(match[1], 10);
-      // Wait for features to load, then find and select
-      source.once('change', () => {
-        const feat = source.getFeatures().find(f => f.get('osm_id') === osmId);
-        if (feat) selection.select(feat, defaultBackendUrl);
-      });
-    }
+    // Publish the source so dependent components (filter reactivity,
+    // NearbyPlaygrounds fallback, URL-hash restore in AppShell) can react.
+    playgroundSourceStore.set(source);
   });
 
   onDestroy(() => {
@@ -236,11 +202,6 @@
     playgroundSourceStore.set(null);
   });
 
-  // Toggle standalone pitch layer visibility from filter store.
-  $: if (pitchLayer) {
-    pitchLayer.setVisible($filterStore.standalonePitches);
-  }
-
   // Re-style the playground layer whenever filters change.
   $: if (playgroundLayer) {
     const filters = $filterStore;
@@ -248,32 +209,6 @@
       if (!matchesFilters(feature.getProperties(), filters)) return null;
       return playgroundStyleFn(feature);
     });
-  }
-
-  async function loadStandaloneData(source, view) {
-    // Fetch region info for map extent fitting
-    try {
-      const region = await fetchRegionInfo(osmRelationId);
-      view.fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
-        padding: [20, 20, 20, 380], // leave room for the side panel on desktop
-        duration: 0,
-      });
-      document.title = `Spielplatzkarte ${region.name}`;
-    } catch (err) {
-      console.warn('Nominatim region fetch failed, using default extent:', err);
-    }
-
-    // Load playground polygons
-    try {
-      const geojson = await fetchPlaygrounds();
-      const features = new GeoJSON().readFeatures(geojson, {
-        dataProjection: 'EPSG:4326',
-        featureProjection: 'EPSG:3857',
-      });
-      source.addFeatures(features);
-    } catch (err) {
-      console.error('Playground data could not be loaded:', err);
-    }
   }
 </script>
 

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -3,14 +3,25 @@
   import { transform } from 'ol/proj';
   import { playgroundSourceStore } from '../stores/playgroundSource.js';
   import { selection } from '../stores/selection.js';
-  import { fetchNearestPlaygrounds } from '../lib/api.js';
   import { playgroundCompleteness } from '../lib/completeness.js';
-  import { apiBaseUrl } from '../lib/config.js';
 
   export let lat;
   export let lon;
   /** Called when the panel should close (suggestion selected). */
   export let ondismiss = null;
+  /**
+   * Fetcher returning `{ osm_id, name, distance_m, ... }` items sorted by
+   * distance ascending. Standalone injects a single-backend PostgREST call;
+   * hub injects a merge across all registered backends. When null (e.g.
+   * local-dev mode with no API), the component falls back to a distance
+   * scan of the loaded vector source.
+   */
+  export let fetcher = null;
+  /**
+   * Backend URL to attach to the selection when the user picks a suggestion.
+   * Hub overrides this per-feature via the feature's `_backendUrl`.
+   */
+  export let defaultBackendUrl = '';
 
   let items = [];
   let loading = true;
@@ -53,8 +64,8 @@
     loading = true;
     items = [];
     try {
-      items = apiBaseUrl
-        ? await fetchNearestPlaygrounds(lt, lg)
+      items = fetcher
+        ? await fetcher(lt, lg)
         : nearestFromSource(lt, lg);
     } catch (err) {
       console.error('Nearest playgrounds fetch failed:', err);
@@ -80,7 +91,8 @@
     const source = $playgroundSourceStore;
     const feature = source?.getFeatures().find(f => f.get('osm_id') === item.osm_id);
     if (feature) {
-      selection.select(feature, apiBaseUrl);
+      const backendUrl = feature.get('_backendUrl') ?? defaultBackendUrl;
+      selection.select(feature, backendUrl);
     }
     if (ondismiss) ondismiss();
   }

--- a/app/src/lib/deeplink.js
+++ b/app/src/lib/deeplink.js
@@ -1,0 +1,57 @@
+// URL hash parser / writer supporting two forms:
+//
+//   #W<osm_id>             — legacy; no backend slug
+//   #<slug>/W<osm_id>      — new; <slug> identifies a backend in registry.json
+//
+// Standalone ignores any slug (there is only one backend). Hub uses the slug
+// to scope selection to a specific backend, falling back to broadcast search
+// when the slug is absent.
+//
+// Slug format: [a-z0-9-]+ (lowercase ASCII, digits, hyphens).
+
+const SLUG_RE = /^[a-z0-9-]+$/;
+const WITH_SLUG_RE = /^#([a-z0-9-]+)\/W(\d+)$/;
+const LEGACY_RE = /^#W(\d+)$/;
+
+/**
+ * Parse a URL hash into `{ slug, osmId }`, or return `null` if the hash does
+ * not match either supported form.
+ *
+ * @param {string} hash
+ * @returns {{ slug: string | null, osmId: number } | null}
+ */
+export function parseHash(hash) {
+  if (!hash) return null;
+  const h = hash.startsWith('#') ? hash : `#${hash}`;
+
+  const withSlug = h.match(WITH_SLUG_RE);
+  if (withSlug) {
+    return { slug: withSlug[1], osmId: parseInt(withSlug[2], 10) };
+  }
+
+  const legacy = h.match(LEGACY_RE);
+  if (legacy) {
+    return { slug: null, osmId: parseInt(legacy[1], 10) };
+  }
+
+  return null;
+}
+
+/**
+ * Build a URL hash for a selected playground. Emits the legacy form when the
+ * slug is missing or invalid; otherwise the prefixed form.
+ *
+ * @param {{ slug?: string | null, osmId: number }} selection
+ * @returns {string} the full hash including the leading `#`
+ */
+export function writeHash({ slug, osmId }) {
+  if (slug && SLUG_RE.test(slug)) {
+    return `#${slug}/W${osmId}`;
+  }
+  return `#W${osmId}`;
+}
+
+/** Returns true if `value` is a valid registry slug. */
+export function isValidSlug(value) {
+  return typeof value === 'string' && SLUG_RE.test(value);
+}

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -32,6 +32,7 @@
   const PITCH_MIN_ZOOM = 12;
   let pitchLayer = null;
   let detachPitchLayer = null;
+  let detachMapSub = null;
 
   // Readable store of the current map view in WGS84 for Nominatim `viewbox`.
   // Subscribes to the map's `moveend` when the map becomes available and
@@ -56,8 +57,11 @@
     };
   });
 
-  // Single-backend PostgREST call; unchanged behaviour.
-  const nearestFetcher = (lat, lon) => fetchNearestPlaygrounds(lat, lon, apiBaseUrl);
+  // Single-backend PostgREST call. Null in local-dev (no API) so
+  // NearbyPlaygrounds falls back to a distance scan of the loaded source.
+  const nearestFetcher = apiBaseUrl
+    ? (lat, lon) => fetchNearestPlaygrounds(lat, lon, apiBaseUrl)
+    : null;
 
   const dataContribLinks = {
     wikiUrl: regionPlaygroundWikiUrl,
@@ -67,9 +71,10 @@
   onMount(async () => {
     // Fit to the configured region and attach the pitch layer once the map
     // becomes available (Map.svelte publishes itself via mapStore on mount).
-    const unsub = mapStore.subscribe(async (map) => {
+    detachMapSub = mapStore.subscribe(async (map) => {
       if (!map) return;
-      unsub();
+      detachMapSub?.();
+      detachMapSub = null;
 
       // Region fit via Nominatim bbox.
       try {
@@ -134,6 +139,7 @@
   $: if (pitchLayer) pitchLayer.setVisible($filterStore.standalonePitches);
 
   onDestroy(() => {
+    if (detachMapSub) detachMapSub();
     if (detachPitchLayer) detachPitchLayer();
   });
 </script>

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -1,395 +1,147 @@
 <script>
-  import Map from '../components/Map.svelte';
-  import PlaygroundPanel from '../components/PlaygroundPanel.svelte';
-  import SearchBar from '../components/SearchBar.svelte';
-  import LocateButton from '../components/LocateButton.svelte';
-  import FilterPanel from '../components/FilterPanel.svelte';
-  import FilterChips from '../components/FilterChips.svelte';
-  import BottomSheet from '../components/BottomSheet.svelte';
-  import HoverPreview from '../components/HoverPreview.svelte';
-  import EquipmentTooltip from '../components/EquipmentTooltip.svelte';
-  import NearbyPlaygrounds from '../components/NearbyPlaygrounds.svelte';
-  import DataContributionModal from '../components/DataContributionModal.svelte';
-  import { onDestroy } from 'svelte';
-  import { Pencil, Plus, Minus } from 'lucide-svelte';
-  import { apiBaseUrl } from '../lib/config.js';
-  import { mapStore } from '../stores/map.js';
-  import { selection, hasSelection } from '../stores/selection.js';
+  import { onMount, onDestroy } from 'svelte';
+  import { readable } from 'svelte/store';
+  import VectorSource from 'ol/source/Vector.js';
+  import { Vector as VectorLayer } from 'ol/layer.js';
+  import GeoJSON from 'ol/format/GeoJSON.js';
   import { transformExtent } from 'ol/proj';
 
-  // Expose the current map extent in WGS84 to constrain Nominatim search.
-  let regionExtent = null;
-  $: if ($mapStore) {
-    const updateExtent = () => {
-      const size = $mapStore.getSize();
-      if (!size) return;
-      const ext = $mapStore.getView().calculateExtent(size);
-      regionExtent = transformExtent(ext, 'EPSG:3857', 'EPSG:4326');
-    };
-    $mapStore.on('moveend', updateExtent);
-    updateExtent();
-  }
+  import AppShell from '../components/AppShell.svelte';
+  import {
+    apiBaseUrl,
+    osmRelationId,
+    regionPlaygroundWikiUrl,
+    regionChatUrl,
+  } from '../lib/config.js';
+  import {
+    fetchPlaygrounds,
+    fetchNearestPlaygrounds,
+    fetchStandaloneEquipment,
+  } from '../lib/api.js';
+  import { fetchRegionInfo } from '../lib/region.js';
+  import { equipmentLayerStyleFn } from '../lib/vectorStyles.js';
+  import { debounce } from '../lib/utils.js';
+  import { mapStore } from '../stores/map.js';
+  import { filterStore } from '../stores/filters.js';
 
-  let dataModalOpen = false;
+  // Standalone owns its VectorSource — one per page, fed by a single backend.
+  const playgroundSource = new VectorSource();
 
-  // Nearest-playground suggestions panel
-  let nearbyLocation = null;  // { lat, lon } | null
-  let dismissUnsub = null;
+  // Standalone pitches (leisure=pitch outside any playground) — own layer,
+  // attached to the map when it becomes available and refreshed on moveend.
+  const PITCH_MIN_ZOOM = 12;
+  let pitchLayer = null;
+  let detachPitchLayer = null;
 
-  function handleLocation(lat, lon) {
-    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
-    if (lat === null) { nearbyLocation = null; return; }
-    nearbyLocation = { lat, lon };
-    // Dismiss the panel on the next selection-store change (map click or playground select)
-    let first = true;
-    dismissUnsub = selection.subscribe(() => {
-      if (first) { first = false; return; }
-      nearbyLocation = null;
-      if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
+  // Readable store of the current map view in WGS84 for Nominatim `viewbox`.
+  // Subscribes to the map's `moveend` when the map becomes available and
+  // re-emits the bounds each time the user pans or zooms.
+  const searchExtent = readable(null, (set) => {
+    let detach = null;
+    const unsub = mapStore.subscribe((map) => {
+      if (detach) { detach(); detach = null; }
+      if (!map) return;
+      const update = () => {
+        const size = map.getSize();
+        if (!size) return;
+        set(transformExtent(map.getView().calculateExtent(size), 'EPSG:3857', 'EPSG:4326'));
+      };
+      map.on('moveend', update);
+      detach = () => map.un('moveend', update);
+      update();
     });
-  }
+    return () => {
+      if (detach) detach();
+      unsub();
+    };
+  });
 
-  function dismissNearby() {
-    nearbyLocation = null;
-    if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
-  }
+  // Single-backend PostgREST call; unchanged behaviour.
+  const nearestFetcher = (lat, lon) => fetchNearestPlaygrounds(lat, lon, apiBaseUrl);
 
-  onDestroy(() => { if (dismissUnsub) dismissUnsub(); });
+  const dataContribLinks = {
+    wikiUrl: regionPlaygroundWikiUrl,
+    chatUrl: regionChatUrl,
+  };
 
-  // Responsive: track if we're on mobile
-  let isMobile = false;
-  function checkMobile() {
-    isMobile = typeof window !== 'undefined' && window.innerWidth < 1024;
-  }
-  
-  // Check on mount and resize
-  $: if (typeof window !== 'undefined') {
-    checkMobile();
-  }
+  onMount(async () => {
+    // Fit to the configured region and attach the pitch layer once the map
+    // becomes available (Map.svelte publishes itself via mapStore on mount).
+    const unsub = mapStore.subscribe(async (map) => {
+      if (!map) return;
+      unsub();
 
-  // Bottom sheet state for mobile
-  let bottomSheetOpen = false;
-  let bottomSheetSnap = 'half';
+      // Region fit via Nominatim bbox.
+      try {
+        const region = await fetchRegionInfo(osmRelationId);
+        map.getView().fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
+          padding: [20, 20, 20, 380], // leave room for the side panel on desktop
+          duration: 0,
+        });
+        document.title = `Spielplatzkarte ${region.name}`;
+      } catch (err) {
+        console.warn('Nominatim region fetch failed, using default extent:', err);
+      }
 
-  // Keep bottom-right controls above the sheet at each snap height
-  $: controlsBottomStyle = (() => {
-    if (!isMobile || !bottomSheetOpen) return '';
-    if (bottomSheetSnap === 'peek') return 'bottom: calc(140px + 1rem)';
-    if (bottomSheetSnap === 'half') return 'bottom: calc(50vh + 1rem)';
-    return '';
-  })();
-
-  // Sync bottom sheet with selection on mobile
-  $: if (isMobile && $hasSelection) {
-    bottomSheetOpen = true;
-    bottomSheetSnap = 'peek';
-    // Fit map with bottom padding for the peek sheet (140 px) + a little breathing room
-    const feat = $selection.feature;
-    if (feat && $mapStore) {
-      $mapStore.getView().fit(feat.getGeometry().getExtent(), {
-        padding: [40, 40, 180, 40],
-        maxZoom: 19,
-        duration: 400,
+      // Standalone pitch layer — viewport-scoped, refreshed on moveend.
+      const pitchSource = new VectorSource();
+      pitchLayer = new VectorLayer({
+        source: pitchSource,
+        zIndex: 9,
+        style: equipmentLayerStyleFn,
+        properties: { kind: 'overlay' },
       });
+      map.addLayer(pitchLayer);
+
+      const reloadPitches = debounce(async () => {
+        const zoom = map.getView().getZoom();
+        if (zoom < PITCH_MIN_ZOOM) { pitchSource.clear(); return; }
+        const extent = map.getView().calculateExtent(map.getSize());
+        try {
+          const geojson = await fetchStandaloneEquipment(extent);
+          const features = new GeoJSON().readFeatures(geojson, {
+            dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857',
+          });
+          pitchSource.clear();
+          pitchSource.addFeatures(features);
+        } catch (err) {
+          console.warn('Standalone pitch fetch failed:', err);
+        }
+      }, 300);
+
+      map.on('moveend', reloadPitches);
+      detachPitchLayer = () => {
+        map.un('moveend', reloadPitches);
+        map.removeLayer(pitchLayer);
+        pitchLayer = null;
+      };
+    });
+
+    // Load the playground polygons for this region.
+    try {
+      const geojson = await fetchPlaygrounds();
+      const features = new GeoJSON().readFeatures(geojson, {
+        dataProjection: 'EPSG:4326',
+        featureProjection: 'EPSG:3857',
+      });
+      playgroundSource.addFeatures(features);
+    } catch (err) {
+      console.error('Playground data could not be loaded:', err);
     }
-  }
-  $: if (isMobile && !$hasSelection) {
-    bottomSheetOpen = false;
-  }
+  });
 
-  // Hover preview state
-  let hoverFeature = null;
-  let hoverPosition = null;
+  // Toggle pitch-layer visibility from the filter store.
+  $: if (pitchLayer) pitchLayer.setVisible($filterStore.standalonePitches);
 
-  function handleHover(feature, pixel) {
-    if (isMobile) return; // No hover on mobile
-    hoverFeature = feature;
-    hoverPosition = pixel ? { x: pixel[0], y: pixel[1] } : null;
-  }
-
-  function clearHover() {
-    hoverFeature = null;
-    hoverPosition = null;
-  }
-
-  // Equipment hover tooltip state
-  let equipHoverFeature = null;
-  let equipHoverPosition = null;
-
-  function handleEquipHover(feature, pixel) {
-    if (isMobile) return;
-    equipHoverFeature = feature;
-    equipHoverPosition = pixel ? { x: pixel[0], y: pixel[1] } : null;
-  }
-
-  function clearEquipHover() {
-    equipHoverFeature = null;
-    equipHoverPosition = null;
-  }
-
-  // Zoom controls
-  function zoomIn() {
-    if ($mapStore) {
-      const view = $mapStore.getView();
-      view.animate({ zoom: view.getZoom() + 1, duration: 200 });
-    }
-  }
-
-  function zoomOut() {
-    if ($mapStore) {
-      const view = $mapStore.getView();
-      view.animate({ zoom: view.getZoom() - 1, duration: 200 });
-    }
-  }
+  onDestroy(() => {
+    if (detachPitchLayer) detachPitchLayer();
+  });
 </script>
 
-<svelte:window onresize={checkMobile} />
-
-<div class="app-root">
-  <!-- Full-screen map -->
-  <Map
-    defaultBackendUrl={apiBaseUrl}
-    onhover={handleHover}
-    onclearhover={clearHover}
-    onequipmenthover={handleEquipHover}
-    onclearequipmenthover={clearEquipHover}
-  />
-
-  {#if !(isMobile && bottomSheetSnap === 'full')}
-    <!-- Search bar: top-left, Google Maps style -->
-    <div class="search-area">
-      <SearchBar {regionExtent} onlocation={handleLocation} />
-      <FilterChips />
-      {#if nearbyLocation}
-        <NearbyPlaygrounds lat={nearbyLocation.lat} lon={nearbyLocation.lon} ondismiss={dismissNearby} />
-      {/if}
-    </div>
-
-    <!-- Top-right controls: filter, edit -->
-    <div class="controls-top-right">
-      <FilterPanel />
-      <button
-        class="control-btn"
-        onclick={() => dataModalOpen = true}
-        title="Daten ergänzen"
-        aria-label="Daten ergänzen"
-      >
-        <Pencil class="h-5 w-5" />
-      </button>
-    </div>
-
-    <!-- Bottom-right controls: locate, zoom (Google Maps style) -->
-    <div class="controls-bottom-right" style={controlsBottomStyle}>
-      <LocateButton onlocation={handleLocation} />
-      <div class="zoom-controls">
-        <button
-          class="zoom-btn zoom-in"
-          onclick={zoomIn}
-          title="Vergrößern"
-          aria-label="Vergrößern"
-        >
-          <Plus class="h-4 w-4" />
-        </button>
-        <button
-          class="zoom-btn zoom-out"
-          onclick={zoomOut}
-          title="Verkleinern"
-          aria-label="Verkleinern"
-        >
-          <Minus class="h-4 w-4" />
-        </button>
-      </div>
-    </div>
-  {/if}
-
-  <!-- Desktop: Side panel slides in from left -->
-  {#if !isMobile && $hasSelection}
-    <div class="side-panel">
-      <PlaygroundPanel />
-    </div>
-  {/if}
-
-  <!-- Mobile: Bottom sheet -->
-  {#if isMobile}
-    <BottomSheet
-      bind:open={bottomSheetOpen}
-      bind:snapPoint={bottomSheetSnap}
-      title=""
-    >
-      {#if $hasSelection}
-        <PlaygroundPanel embedded={true} />
-      {/if}
-    </BottomSheet>
-  {/if}
-
-  <!-- Hover preview card (desktop only, hidden when playground is selected) -->
-  <HoverPreview position={$hasSelection ? null : hoverPosition} feature={$hasSelection ? null : hoverFeature} />
-
-  <!-- Equipment hover tooltip (desktop only) -->
-  <EquipmentTooltip position={equipHoverPosition} feature={equipHoverFeature} />
-
-  <!-- Data contribution modal -->
-  <DataContributionModal bind:open={dataModalOpen} />
-</div>
-
-<style>
-  .app-root {
-    position: relative;
-    width: 100vw;
-    height: 100vh;
-    overflow: hidden;
-  }
-
-  /* Search area: top-left floating card */
-  .search-area {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    z-index: 100;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  /* Top-right controls: filter, edit */
-  .controls-top-right {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    z-index: 100;
-    display: flex;
-    flex-direction: row;
-    gap: 0.5rem;
-  }
-
-  /* Bottom-right controls: locate, zoom (Google Maps style) */
-  .controls-bottom-right {
-    position: absolute;
-    bottom: 7rem;
-    right: 1rem;
-    z-index: 100;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: center;
-    transition: bottom 0.3s ease-out;
-  }
-
-  /* Control button (for edit button, locate button) */
-  .control-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    background: white;
-    border: none;
-    border-radius: 50%;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-    cursor: pointer;
-    color: #666;
-    transition: background 0.15s, color 0.15s;
-  }
-
-  .control-btn:hover {
-    background: #f5f5f5;
-    color: #333;
-  }
-
-  /* Zoom controls container */
-  .zoom-controls {
-    display: flex;
-    flex-direction: column;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-    overflow: hidden;
-  }
-
-  .zoom-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    background: white;
-    border: none;
-    cursor: pointer;
-    color: #666;
-    transition: background 0.15s, color 0.15s;
-  }
-
-  .zoom-btn:hover {
-    background: #f5f5f5;
-    color: #333;
-  }
-
-  .zoom-in {
-    border-bottom: 1px solid #e0e0e0;
-  }
-
-  /* Side panel: slides in from left on desktop - always uses light theme */
-  .side-panel {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 380px;
-    z-index: 200;
-    background: var(--color-card);
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    overflow-y: auto;
-    animation: slideInLeft 0.3s ease-out;
-    color-scheme: light;
-    
-    /* Force light theme variables for the sidebar */
-    --color-background: #ffffff;
-    --color-foreground: #1f2937;
-    --color-card: #ffffff;
-    --color-card-foreground: #1f2937;
-    --color-popover: #ffffff;
-    --color-popover-foreground: #1f2937;
-    --color-muted: #f3f4f6;
-    --color-muted-foreground: #6b7280;
-    --color-border: #e5e7eb;
-    --color-input: #e5e7eb;
-  }
-
-  @keyframes slideInLeft {
-    from {
-      transform: translateX(-100%);
-    }
-    to {
-      transform: translateX(0);
-    }
-  }
-
-  /* Mobile adjustments */
-  @media (max-width: 1023px) {
-    .search-area {
-      top: 0.75rem;
-      left: 0.75rem;
-      right: 0.75rem;
-    }
-
-    .controls-top-right {
-      top: auto;
-      bottom: auto;
-      right: 0.75rem;
-      top: 0.75rem;
-    }
-
-    .controls-bottom-right {
-      bottom: 10rem;
-      right: 0.75rem;
-    }
-  }
-
-  /* When panel is open on desktop, shift search area */
-  @media (min-width: 1024px) {
-    .app-root:has(.side-panel) .search-area {
-      left: calc(380px + 1rem);
-      transition: left 0.3s ease-out;
-    }
-  }
-</style>
+<AppShell
+  {playgroundSource}
+  {searchExtent}
+  {nearestFetcher}
+  {dataContribLinks}
+  defaultBackendUrl={apiBaseUrl}
+/>

--- a/app/src/stores/selection.js
+++ b/app/src/stores/selection.js
@@ -9,6 +9,7 @@
 //                In hub mode this is the per-backend URL from the registry.
 
 import { writable, derived } from 'svelte/store';
+import { writeHash } from '../lib/deeplink.js';
 
 function createSelectionStore() {
     const { subscribe, set, update } = writable({ feature: null, backendUrl: '' });
@@ -19,7 +20,13 @@ function createSelectionStore() {
             set({ feature, backendUrl });
             if (feature) {
                 const osmId = feature.get('osm_id');
-                if (osmId) history.replaceState(null, '', `#W${osmId}`);
+                if (osmId) {
+                    // `_backendSlug` is set by the hub registry when it knows the
+                    // owning backend's slug; standalone never sets it, so this
+                    // falls back to the legacy `#W<osm_id>` form.
+                    const slug = feature.get('_backendSlug') ?? null;
+                    history.replaceState(null, '', writeHash({ slug, osmId }));
+                }
             }
         },
         clear() {


### PR DESCRIPTION
## Summary

- Extracts layout, widgets, responsive logic and URL-hash handling out of `StandaloneApp.svelte` into a new shared `AppShell.svelte`, so the hub can reuse it next.
- Strips all data-loading out of `Map.svelte` — it becomes a pure renderer fed by the shell.
- `StandaloneApp.svelte` now owns its `VectorSource`, the region fit, and the standalone-only pitch layer; composes `AppShell` with single-backend providers.
- Overlay hover hit-test switches from direct layer references (`l === equipmentLayer`, `l === pitchLayer`) to a `layer.get('kind') === 'overlay'` filter, so future overlays can participate without `Map` knowing about them.
- New `app/src/lib/deeplink.js` houses the `#W<osm_id>` / `#<slug>/W<osm_id>` hash parser, consumed by AppShell on mount.

**No user-visible behaviour change.** Unblocks the hub-ui-parity epic (tracker #143).

Part of the `hub-ui-parity` OpenSpec change, sections 1 + 2.

Refs #144.

## Test plan

- [x] `make build` — clean
- [x] `make test` — 10/10 Playwright specs pass (smoke, selection, hash-restore, xss)
- [ ] Manual smoke on standalone: search, filters, locate, nearby-playgrounds, hover preview, contribution modal, mobile bottom sheet, zoom, deep-link `#W<osm_id>`
- [ ] Manual smoke: standalone pitch layer still renders at zoom ≥ 12 and refreshes on pan/zoom
- [ ] Manual smoke: filter toggle for standalone pitches still hides/shows the layer