### PR TITLE
feat(hub): redesign InstancePanel as bottom-left pill + drawer

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -380,12 +380,20 @@
     border-bottom: 1px solid #e0e0e0;
   }
 
-  /* Bottom-left slot for the hub instance-pill (and any future bottom-left widget). */
+  /* Bottom-left slot for the hub instance-pill (and any future bottom-left
+     widget). Raised above the scale-line (bottom:24px + ~14px tall) with a
+     small gap so the two don't collide. */
   .instance-slot {
     position: absolute;
-    bottom: 1rem;
+    bottom: 3rem;
     left: 1rem;
     z-index: 100;
+  }
+
+  @media (max-width: 1023px) {
+    .instance-slot {
+      left: 0.75rem;
+    }
   }
 
   .side-panel {

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -55,33 +55,13 @@
   });
 </script>
 
-<div class="hub-root">
-  <AppShell
-    playgroundSource={sharedSource}
-    searchExtent={aggregatedBbox}
-    nearestFetcher={fetchNearestAcrossBackends}
-    {dataContribLinks}
-  />
-
-  <!-- Backend instance panel — top-right today; #147 redesigns it as a
-       bottom-left pill and moves it into the AppShell `instancePanel` slot. -->
-  <InstancePanel {backends} {registryError} />
-</div>
-
-<style>
-  /* Reserve room for the 240px-wide InstancePanel in the top-right corner
-     until #147 redesigns it. Scoped to hub-root so standalone is unaffected.
-     `!important` is required because AppShell's scoped `.controls-top-right`
-     rule has the same specificity (0,2,0) — source order would otherwise
-     decide the cascade. Remove this block when #147 moves the panel to
-     bottom-left and the collision disappears. */
-  :global(.hub-root .controls-top-right) {
-    right: calc(240px + 1.5rem) !important;
-  }
-
-  @media (max-width: 1023px) {
-    :global(.hub-root .controls-top-right) {
-      right: calc(240px + 1rem) !important;
-    }
-  }
-</style>
+<AppShell
+  playgroundSource={sharedSource}
+  searchExtent={aggregatedBbox}
+  nearestFetcher={fetchNearestAcrossBackends}
+  {dataContribLinks}
+>
+  {#snippet instancePanel()}
+    <InstancePanel {backends} {registryError} />
+  {/snippet}
+</AppShell>

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -1,122 +1,167 @@
 <script>
   import { _ } from 'svelte-i18n';
+  import { onDestroy } from 'svelte';
+  import { Globe, AlertTriangle } from 'lucide-svelte';
+  import InstancePanelDrawer from './InstancePanelDrawer.svelte';
 
   /** @type {import('svelte/store').Readable<Array>} */
   export let backends;
   /** @type {import('svelte/store').Readable<string|null>} */
   export let registryError;
+
+  let open = false;
+  let pillEl;
+  let wrapperEl;
+
+  // Reachable = backend responded without error and isn't still loading. Drives
+  // both the region count in the pill and the zero-reachable messaging.
+  $: reachable = $backends.filter(b => !b.error && !b.loading);
+  $: regionCount = reachable.length;
+  $: playgroundCount = reachable.reduce((acc, b) => acc + (b.featureCount || 0), 0);
+  $: isLoading = !$registryError && $backends.length === 0;
+  $: hasRegistryError = !!$registryError;
+
+  function toggle() {
+    open = !open;
+  }
+
+  function close() {
+    if (!open) return;
+    open = false;
+    // Return focus to the pill so keyboard users aren't stranded.
+    pillEl?.focus();
+  }
+
+  function handleDocKey(e) {
+    if (e.key === 'Escape') close();
+  }
+
+  function handleDocClick(e) {
+    if (!open) return;
+    if (wrapperEl && !wrapperEl.contains(e.target)) close();
+  }
+
+  $: if (typeof document !== 'undefined') {
+    if (open) {
+      document.addEventListener('keydown', handleDocKey);
+      document.addEventListener('mousedown', handleDocClick);
+    } else {
+      document.removeEventListener('keydown', handleDocKey);
+      document.removeEventListener('mousedown', handleDocClick);
+    }
+  }
+
+  onDestroy(() => {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('keydown', handleDocKey);
+      document.removeEventListener('mousedown', handleDocClick);
+    }
+  });
 </script>
 
-<aside class="instance-panel">
-  <h6 class="instance-panel__title">
-    <i class="bi bi-map me-1"></i> {$_('hub.title')}
-  </h6>
-
-  {#if $registryError}
-    <p class="text-danger small px-2 mb-0">
-      <i class="bi bi-exclamation-triangle-fill me-1"></i>
-      {$_('hub.registryError')}
-    </p>
-  {:else if $backends.length === 0}
-    <p class="text-muted small px-2 mb-0">
-      <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-      {$_('hub.loading')}
-    </p>
-  {:else}
-    <ul class="instance-list">
-      {#each $backends as b (b.url)}
-        <li class="instance-item">
-          <div class="instance-row">
-            <span class="instance-name">{b.name}</span>
-            {#if b.version}
-              <span class="badge instance-badge text-bg-secondary">{b.version}</span>
-            {/if}
-          </div>
-
-          {#if b.loading}
-            <div class="instance-status text-muted">
-              <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-              {$_('details.loading')}
-            </div>
-          {:else if b.error}
-            <div class="instance-status text-danger">
-              <i class="bi bi-exclamation-triangle-fill me-1"></i>
-              {$_('hub.instanceError')}
-            </div>
-          {:else}
-            <div class="instance-status text-muted">
-              <i class="bi bi-geo-alt-fill me-1"></i>
-              {$_('hub.playgroundCount', { values: { count: b.featureCount } })}
-            </div>
-          {/if}
-        </li>
-      {/each}
-    </ul>
+<div class="panel" bind:this={wrapperEl}>
+  {#if open}
+    <div class="panel__drawer">
+      <InstancePanelDrawer
+        backends={$backends}
+        registryError={$registryError}
+        onclose={close}
+      />
+    </div>
   {/if}
-</aside>
+
+  <button
+    class="pill"
+    class:pill--error={hasRegistryError}
+    class:pill--loading={isLoading}
+    type="button"
+    onclick={toggle}
+    aria-expanded={open}
+    aria-label={open ? $_('hub.pillCollapse') : $_('hub.pillExpand')}
+    bind:this={pillEl}
+  >
+    {#if hasRegistryError}
+      <AlertTriangle class="pill__icon" aria-hidden="true" />
+      <span class="pill__text">{$_('hub.registryError')}</span>
+    {:else if isLoading}
+      <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+      <span class="pill__text">{$_('hub.loading')}</span>
+    {:else}
+      <Globe class="pill__icon" aria-hidden="true" />
+      <span class="pill__text">
+        {$_('hub.regionCount', { values: { count: regionCount } })}
+        <span class="pill__sep">·</span>
+        {$_('hub.playgroundCount', { values: { count: playgroundCount } })}
+      </span>
+    {/if}
+  </button>
+</div>
 
 <style>
-  .instance-panel {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    width: 240px;
-    max-height: calc(100vh - 2rem);
-    background: #fff;
-    border-radius: 0.5rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-    z-index: 100;
-    overflow-y: auto;
-    padding: 0.75rem 0;
-  }
-
-  .instance-panel__title {
-    padding: 0 0.75rem 0.5rem;
-    border-bottom: 1px solid #dee2e6;
-    margin-bottom: 0.4rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: #495057;
-  }
-
-  .instance-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .instance-item {
-    padding: 0.35rem 0.75rem;
-    border-bottom: 1px solid #f1f3f5;
-    font-size: 0.8rem;
-  }
-
-  .instance-item:last-child {
-    border-bottom: none;
-  }
-
-  .instance-row {
+  .panel {
+    position: relative;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.4rem;
-    margin-bottom: 0.1rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
-  .instance-name {
-    font-weight: 500;
+  .panel__drawer {
+    /* The drawer lives above the pill in document order so it appears to slide
+       up from the pill when toggled. */
+  }
+
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    height: 36px;
+    padding: 0 0.85rem;
+    background: #fff;
+    border: none;
+    border-radius: 999px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+    cursor: pointer;
     color: #212529;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font-size: 0.8rem;
+    font-weight: 500;
+    line-height: 1;
+    transition: background 0.15s, box-shadow 0.15s;
     white-space: nowrap;
   }
 
-  .instance-badge {
-    font-size: 0.65rem;
+  .pill:hover,
+  .pill:focus-visible {
+    background: #f8f9fa;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+  }
+
+  .pill:focus-visible {
+    outline: 2px solid #4c9aff;
+    outline-offset: 2px;
+  }
+
+  .pill--error {
+    color: #b91c1c;
+  }
+
+  .pill--loading {
+    color: #6b7280;
+  }
+
+  :global(.pill__icon) {
+    width: 16px;
+    height: 16px;
     flex-shrink: 0;
   }
 
-  .instance-status {
-    font-size: 0.75rem;
+  .pill__text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .pill__sep {
+    color: #adb5bd;
   }
 </style>

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -1,0 +1,204 @@
+<script>
+  import { _ } from 'svelte-i18n';
+  import { X } from 'lucide-svelte';
+
+  /** @type {Array<{ url: string, name: string, version: string|null, loading: boolean, error: string|null, featureCount: number }>} */
+  export let backends;
+  /** @type {string | null} */
+  export let registryError;
+  /** @type {() => void} */
+  export let onclose;
+
+  let drawerEl;
+
+  // Focus trap: keep keyboard focus inside the drawer while it's open. The
+  // pill's own ESC handling closes the drawer — here we only trap Tab.
+  function handleKeydown(e) {
+    if (e.key !== 'Tab' || !drawerEl) return;
+    const focusable = drawerEl.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+</script>
+
+<div
+  class="drawer"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="instance-drawer-title"
+  tabindex="-1"
+  bind:this={drawerEl}
+  onkeydown={handleKeydown}
+>
+  <header class="drawer__header">
+    <h6 id="instance-drawer-title" class="drawer__title">{$_('hub.drawerTitle')}</h6>
+    <button
+      class="drawer__close"
+      type="button"
+      onclick={onclose}
+      aria-label={$_('hub.closeBtn')}
+    >
+      <X class="h-4 w-4" />
+    </button>
+  </header>
+
+  {#if registryError}
+    <p class="drawer__message drawer__message--error">
+      <i class="bi bi-exclamation-triangle-fill me-1"></i>
+      {$_('hub.registryError')}
+    </p>
+  {:else if backends.length === 0}
+    <p class="drawer__message">
+      <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+      {$_('hub.loading')}
+    </p>
+  {:else}
+    <ul class="instance-list">
+      {#each backends as b (b.url)}
+        <li class="instance-item">
+          <div class="instance-row">
+            <span class="instance-name">{b.name}</span>
+            {#if b.version}
+              <span class="badge instance-badge text-bg-secondary">{b.version}</span>
+            {/if}
+          </div>
+
+          {#if b.loading}
+            <div class="instance-status text-muted">
+              <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+              {$_('details.loading')}
+            </div>
+          {:else if b.error}
+            <div class="instance-status text-danger">
+              <i class="bi bi-exclamation-triangle-fill me-1"></i>
+              {$_('hub.instanceError')}
+            </div>
+          {:else}
+            <div class="instance-status text-muted">
+              <i class="bi bi-geo-alt-fill me-1"></i>
+              {$_('hub.playgroundCount', { values: { count: b.featureCount } })}
+            </div>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .drawer {
+    width: 280px;
+    max-height: min(60vh, 520px);
+    background: #fff;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+    overflow-y: auto;
+    animation: slideUp 0.15s ease-out;
+    display: flex;
+    flex-direction: column;
+  }
+
+  @keyframes slideUp {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .drawer__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  .drawer__title {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #495057;
+  }
+
+  .drawer__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: #6b7280;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+
+  .drawer__close:hover,
+  .drawer__close:focus-visible {
+    background: #f1f3f5;
+    color: #212529;
+  }
+
+  .drawer__message {
+    margin: 0;
+    padding: 0.75rem;
+    font-size: 0.8rem;
+    color: #6b7280;
+  }
+
+  .drawer__message--error {
+    color: #b91c1c;
+  }
+
+  .instance-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem 0;
+    overflow-y: auto;
+  }
+
+  .instance-item {
+    padding: 0.45rem 0.75rem;
+    border-bottom: 1px solid #f1f3f5;
+    font-size: 0.8rem;
+  }
+
+  .instance-item:last-child {
+    border-bottom: none;
+  }
+
+  .instance-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+    margin-bottom: 0.15rem;
+  }
+
+  .instance-name {
+    font-weight: 500;
+    color: #212529;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .instance-badge {
+    font-size: 0.65rem;
+    flex-shrink: 0;
+  }
+
+  .instance-status {
+    font-size: 0.75rem;
+  }
+</style>

--- a/locales/de.json
+++ b/locales/de.json
@@ -353,7 +353,12 @@
     "registryError": "Registry nicht erreichbar",
     "loading": "Instanzen werden geladen …",
     "instanceError": "Nicht erreichbar",
-    "playgroundCount": "{count, plural, one {# Spielplatz} other {# Spielplätze}}"
+    "playgroundCount": "{count, plural, one {# Spielplatz} other {# Spielplätze}}",
+    "regionCount": "{count, plural, one {# Region} other {# Regionen}}",
+    "pillExpand": "Instanz-Liste öffnen",
+    "pillCollapse": "Instanz-Liste schließen",
+    "drawerTitle": "Verfügbare Instanzen",
+    "closeBtn": "Schließen"
   },
   "details": {
     "sizeLabel": "Größe",

--- a/locales/en.json
+++ b/locales/en.json
@@ -353,7 +353,12 @@
     "registryError": "Registry unreachable",
     "loading": "Loading instances …",
     "instanceError": "Unreachable",
-    "playgroundCount": "{count, plural, one {# playground} other {# playgrounds}}"
+    "playgroundCount": "{count, plural, one {# playground} other {# playgrounds}}",
+    "regionCount": "{count, plural, one {# region} other {# regions}}",
+    "pillExpand": "Show instance list",
+    "pillCollapse": "Hide instance list",
+    "drawerTitle": "Available instances",
+    "closeBtn": "Close"
   },
   "details": {
     "sizeLabel": "Size",


### PR DESCRIPTION
## Summary

- Replaces the 240px top-right instance list with a compact **pill** at the bottom-left showing `<N> Regionen · <M> Spielplätze`.
- Clicking the pill opens a **slide-up drawer** (`InstancePanelDrawer.svelte`) with the existing per-backend detail list (name, version, status, count).
- Pill rendered via `AppShell`'s `instancePanel` snippet slot — HubApp no longer needs the `.hub-root` wrapper or the `!important` CSS scaffold that #146 added as temporary positioning for the old top-right panel.
- `.instance-slot` raised to `bottom: 3rem` so the scale-line (bottom-left at ~24px) and the pill don't collide.

### Pill states

- **Loading** (`backends.length === 0`): spinner + `Instanzen werden geladen …`
- **Registry error**: warning icon + `Registry nicht erreichbar`
- **Normal**: globe icon + `<N> Regionen · <M> Spielplätze` where N is the count of reachable backends and M is the sum of their `featureCount`

### Accessibility

- `aria-expanded` on pill; switches between `hub.pillExpand` / `hub.pillCollapse` labels
- Drawer is `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at the drawer title, with `tabindex="-1"` so focus is managed programmatically
- Tab / Shift+Tab trap focus inside the drawer
- ESC, outside click, or second pill tap collapses the drawer and returns focus to the pill

### Test plan

- [x] `make build` — clean, no a11y warnings
- [x] `make test` — 10/10 Playwright specs green (standalone regressions)
- [ ] Local hub smoke: set `appMode: 'hub'` in `app/public/config.js`, verify
  - pill appears bottom-left, scale-line below it, no overlap
  - pill shows `2 Regionen · <M> Spielplätze` once backends load
  - click pill → drawer opens above it, lists both instances with counts
  - ESC / outside click / click pill again → drawer closes, focus returns to pill
  - set registry URL to a 404 → pill shows `Registry nicht erreichbar`

## Related

Closes #147
Refs #143 (epic)

Design: `openspec/changes/hub-ui-parity/design.md` (D3)
Tasks: `openspec/changes/hub-ui-parity/tasks.md` (Section 6 — all 8 items)

---

Assisted-by: ClaudeCode:claude-opus-4-7