### PR TITLE
feat(hub): deep-link scheme #<slug>/W<osm_id> with strict + broadcast restore

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -59,23 +59,56 @@
    */
   export let instancePanel = null;
 
+  /**
+   * Hub-only slug → backend URL resolver. When a deep-link carries a slug,
+   * the shell uses this to narrow the feature search to that backend. Returns
+   * the URL, or `null` if the slug is unknown (in which case we wait for more
+   * backends to populate). Standalone passes `null` — any slug in the hash is
+   * silently ignored.
+   * @type {((slug: string) => string | null) | null}
+   */
+  export let resolveSlugToBackendUrl = null;
+
   // ── URL hash restore ──────────────────────────────────────────────────────
   //
-  // On first load the shell inspects `location.hash` and — once the injected
-  // source has features — selects the matching osm_id. The slug is accepted
-  // but not enforced here; hub mode layers its own slug→backend resolution on
-  // top (see #148).
+  // Runs once on first load and again on every `change` event from the
+  // injected source until a match is found. Supports both `#W<osm_id>` and
+  // `#<slug>/W<osm_id>`: with a slug, selection is scoped to the matching
+  // backend; without a slug, we broadcast-search across all loaded features
+  // and warn on duplicate osm_ids (rare — same OSM entity present in two
+  // overlapping regional databases).
   let hashRestored = false;
+  let warnedUnknownSlug = false;
   function tryRestoreFromHash() {
     if (hashRestored) return;
     const parsed = parseHash(window.location.hash);
     if (!parsed) { hashRestored = true; return; }
-    const feat = playgroundSource.getFeatures().find(f => f.get('osm_id') === parsed.osmId);
-    if (feat) {
-      const backendUrl = feat.get('_backendUrl') ?? defaultBackendUrl;
-      selection.select(feat, backendUrl);
-      hashRestored = true;
+
+    let candidates = playgroundSource.getFeatures();
+
+    if (parsed.slug && resolveSlugToBackendUrl) {
+      const targetUrl = resolveSlugToBackendUrl(parsed.slug);
+      if (!targetUrl) {
+        if (!warnedUnknownSlug) {
+          console.warn(`[deeplink] unknown registry slug "${parsed.slug}" — will retry as backends load`);
+          warnedUnknownSlug = true;
+        }
+        return;
+      }
+      candidates = candidates.filter(f => f.get('_backendUrl') === targetUrl);
     }
+
+    const matches = candidates.filter(f => f.get('osm_id') === parsed.osmId);
+    if (matches.length === 0) return;
+
+    if (matches.length > 1 && !parsed.slug) {
+      console.warn(`[deeplink] osm_id ${parsed.osmId} matched ${matches.length} backends — selecting the first`);
+    }
+
+    const feat = matches[0];
+    const backendUrl = feat.get('_backendUrl') ?? defaultBackendUrl;
+    selection.select(feat, backendUrl);
+    hashRestored = true;
   }
 
   onMount(() => {

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -1,6 +1,7 @@
 <script>
   import VectorSource from 'ol/source/Vector.js';
   import { onDestroy, onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { transformExtent } from 'ol/proj';
 
   import AppShell from '../components/AppShell.svelte';
@@ -21,6 +22,13 @@
   } = createRegistry(sharedSource);
 
   const dataContribLinks = { wikiUrl: HUB_WIKI_URL, chatUrl: null };
+
+  // Sync resolver for deep-link slug → backend URL. Reads the current backends
+  // list via `get()` so AppShell can call it from its restore loop without
+  // taking a store subscription of its own.
+  function resolveSlugToBackendUrl(slug) {
+    return get(backends).find(b => b.slug === slug)?.url ?? null;
+  }
 
   // Initial region fit: once both the map and the first aggregated bbox are
   // available, fit the view and then stop listening. Until that point the map
@@ -59,6 +67,7 @@
   playgroundSource={sharedSource}
   searchExtent={aggregatedBbox}
   nearestFetcher={fetchNearestAcrossBackends}
+  {resolveSlugToBackendUrl}
   {dataContribLinks}
 >
   {#snippet instancePanel()}


### PR DESCRIPTION
## Summary

Completes the `#<slug>/W<osm_id>` deep-link loop for hub mode. Most of the primitives landed with earlier epic PRs:

- `parseHash` / `writeHash` in `deeplink.js` already accept both forms (#145).
- Features carry `_backendSlug` once the registry knows the owning backend's slug (#145).
- `selection.select()` already calls `writeHash({ slug: feature.get('_backendSlug') ?? null, osmId })` (#146).

What was missing: the **restore path** blindly broadcast-searched across all backends even when the hash carried a slug. This PR makes restore slug-aware.

## Changes

- `AppShell` exposes a new optional prop `resolveSlugToBackendUrl(slug)`.
- `HubApp` passes a sync resolver that reads the current `backends` store via `get()`.
- `tryRestoreFromHash()`:
  - With slug + resolver → narrow feature search to the matching backend's URL. Unknown slug → one-time console warning, keep retrying on future `change` events (the backend may still be loading).
  - Without slug → broadcast search as before; now also warns to the console if more than one backend has the same `osm_id` (design D4, acceptance criterion 3).
- Standalone passes no resolver → any slug in a shared link is silently ignored, as specified.

## Test plan

- [x] `make build` — clean
- [x] `make test` — 10/10 Playwright green; existing `hash-restore.spec.js` still passes (uses legacy `#W<id>` form)
- [ ] Local hub smoke with two backends:
  - paste `#fulda-a/W<id>` → selects the fulda-a copy
  - paste `#fulda-b/W<id>` with same id → selects the fulda-b copy (no collision)
  - paste `#W<id>` (legacy) → selects first hit, console warns on duplicate
  - paste `#unknown/W<id>` → console warns, then (if id is loaded in any backend) does not select (slug is strict)
- [ ] Standalone smoke: paste `#fulda-a/W<id>` → selects, slug silently ignored

## Related

Closes #148
Refs #143 (epic)

Design: `openspec/changes/hub-ui-parity/design.md` (D4, D8)
Tasks: `openspec/changes/hub-ui-parity/tasks.md` (Section 7 — all 6 items)

---

Assisted-by: ClaudeCode:claude-opus-4-7