### PR TITLE
docs(federation): add registry.json reference and hub UI section

### DIFF
--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -19,3 +19,32 @@ Each regional instance exposes two endpoints (available since v0.2.1):
 | `GET /api/rpc/get_meta` | Instance metadata: OSM relation name, playground count, bounding box |
 
 CORS is enabled on `/api/` so the Hub can query instances cross-origin from the browser.
+
+## Registry
+
+The Hub discovers instances from a `registry.json` file — see the [`registry.json` reference](registry-json.md) for schema, slug rules, and the derived aggregate behaviours (aggregated bounding box, multi-backend nearest search).
+
+## Hub UI
+
+The Hub renders the same layout as a standalone regional map, with two additions:
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  [search]   [filters]               [filter]  [contribute] │
+│                                                            │
+│                                                            │
+│                      ( map canvas )                        │
+│                                                            │
+│                                               [locate]     │
+│                                               [zoom +/−]   │
+│                                                            │
+│  [🌐 2 Regionen · 413 Spielplätze]                         │
+│   └ scale-line                                             │
+└────────────────────────────────────────────────────────────┘
+```
+
+- **Instance pill** (bottom-left): collapsed view shows a globe icon plus aggregated `<N> Regionen · <M> Spielplätze`. While the registry is loading the pill shows a spinner; if the registry can't be fetched the pill turns red and reads "Registry nicht erreichbar".
+- **Instance drawer**: clicking the pill slides up a drawer listing each backend with its name, version badge (from `get_meta`), and individual playground count. ESC, outside-click, or re-clicking the pill collapses it.
+- **Deep-link scheme**: see the [deep-link behaviour table](registry-json.md#deep-link-behaviour) in the registry reference.
+
+The scale-line sits just below the pill in the same bottom-left corner. All other controls (search, filters, locate, zoom, contribute) are shared with standalone mode and behave identically.

--- a/docs/reference/registry-json.md
+++ b/docs/reference/registry-json.md
@@ -1,0 +1,83 @@
+# `registry.json` Reference
+
+The Hub reads a `registry.json` file at startup and on a short poll interval (`HUB_POLL_INTERVAL`, default 5 min). Each entry points to one regional PostgREST backend. The Hub fetches `get_playgrounds` and `get_meta` from each backend, merges them onto a shared map, and tags every feature with its source backend so deep-links round-trip.
+
+## Location
+
+- **Served from**: the nginx container under `/registry.json` (path configurable via `HUB_REGISTRY_URL`).
+- **Source file**: `app/public/registry.json` in the repo. In production, replace or bind-mount with your own registry.
+- **Served as**: `application/json`. CORS is not needed — the Hub fetches from its own origin.
+
+## Schema
+
+Two top-level shapes are accepted:
+
+=== "Object form (recommended)"
+
+    ```json
+    {
+      "instances": [
+        {
+          "slug": "fulda",
+          "url":  "https://spielplatz.fulda.de/api",
+          "name": "Fulda"
+        },
+        {
+          "slug": "berlin",
+          "url":  "https://spielplatz.berlin.de/api",
+          "name": "Berlin"
+        }
+      ]
+    }
+    ```
+
+=== "Bare array form (legacy)"
+
+    ```json
+    [
+      { "slug": "fulda",  "url": "https://spielplatz.fulda.de/api",  "name": "Fulda"  },
+      { "slug": "berlin", "url": "https://spielplatz.berlin.de/api", "name": "Berlin" }
+    ]
+    ```
+
+Both forms are supported indefinitely. New registries should prefer the object form so future top-level metadata (e.g. a registry version) can be added without a breaking change.
+
+## Entry fields
+
+| Field | Required | Description |
+|---|---|---|
+| `url`  | yes | Base URL of the backend's PostgREST `/api` (no trailing slash). The Hub appends `/rpc/get_playgrounds`, `/rpc/get_meta`, and `/rpc/get_nearest_playgrounds`. |
+| `name` | yes | Human-readable label. Shown in the instance drawer and — until `get_meta` returns — used as the backend's displayed region name. Falls back to `url` if omitted. |
+| `slug` | no  | Short stable identifier used in deep-links (`#<slug>/W<osm_id>`). If present, features from this backend round-trip their slug back into the URL hash on selection. See [validation rules](#slug-validation) below. |
+
+### Slug validation
+
+Slugs must match `^[a-z0-9-]+$` — lowercase ASCII letters, digits, and hyphens only. Invalid slugs are logged as a console warning and treated as *absent* — the entry still works (playgrounds still load from that backend), but deep-links won't be slug-scoped and selections on features from that backend will fall back to the bare `#W<osm_id>` form.
+
+Slugs should be **stable** — they are persisted in URLs shared by users. Rename with care; there's no redirect mechanism.
+
+## Derived capabilities
+
+Once the registry is loaded, the Hub derives two aggregate behaviours:
+
+### Aggregated bounding box
+
+The Hub unions every backend's `get_meta().bbox` into a single extent and uses it to fit the initial map view. Backends that haven't yet reported (still loading, failed, or running a version older than v0.2.1) are ignored. Until at least one backend reports a bbox, the map stays on its default Germany-wide view.
+
+### Multi-backend nearest search
+
+The "nearby playgrounds" panel fans `get_nearest_playgrounds` out to every registered backend in parallel with a 3 s per-backend timeout. Results are merged, deduplicated by `osm_id` (keeping the closest distance), sorted by distance, and truncated to the top 10. A slow or unreachable backend contributes zero results but never stalls the response.
+
+## Deep-link behaviour
+
+| URL hash                  | Hub behaviour                                                                 |
+|---------------------------|-------------------------------------------------------------------------------|
+| `#<slug>/W<osm_id>`       | Resolves slug → backend URL, waits for that backend's features, selects the matching `osm_id`. Unknown slug: logs once and retries as more backends load. |
+| `#W<osm_id>`              | Broadcast search across every loaded backend. First match wins; duplicate `osm_id` across backends triggers a console warning. |
+| `#<anything>/W<osm_id>`   | Standalone mode ignores the slug prefix and selects the `osm_id` from its sole configured backend. |
+
+When a user selects a playground, the Hub rewrites the hash to its canonical slug-scoped form if the backend has a slug, otherwise to the bare `W<osm_id>` form.
+
+## See also
+
+- [Federation](federation.md) — Hub deployment and the `APP_MODE=hub` switch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Architecture: reference/architecture.md
       - Tech Stack: reference/tech-stack.md
       - Federation: reference/federation.md
+      - registry.json: reference/registry-json.md
       - Glossary: reference/glossary.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
Section 9 of `hub-ui-parity`: documentation for the registry schema and the new Hub UI.

- **New** `docs/reference/registry-json.md`: both top-level shapes, `slug`/`name`/`url` fields, slug validation rules, the two registry-derived capabilities (aggregated bbox, multi-backend nearest), and a deep-link behaviour table.
- **Updated** `docs/reference/federation.md`: new Registry and Hub UI sections with an ASCII layout sketch (pill bottom-left, scale-line below). Cross-links to `registry-json.md`.
- **Updated** `mkdocs.yml`: adds the new page to the Reference nav.

`mkdocs build --strict` renders both pages with zero warnings.

Closes #150

## Test plan
- [x] `mkdocs build --strict` — no warnings
- [ ] GitHub Pages preview renders the Reference nav with the new entry
- [ ] Links `federation.md → registry-json.md` and back are navigable

Assisted-by: ClaudeCode:claude-opus-4-7