### PR TITLE
chore(hub): address hub-ui-parity review nits (#184)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -62,9 +62,10 @@
   /**
    * Hub-only slug → backend URL resolver. When a deep-link carries a slug,
    * the shell uses this to narrow the feature search to that backend. Returns
-   * the URL, or `null` if the slug is unknown (in which case we wait for more
-   * backends to populate). Standalone passes `null` — any slug in the hash is
-   * silently ignored.
+   * the URL, or `null` if the slug is unknown — in which case we keep retrying
+   * on every source `change` event as more backends populate, but only log the
+   * "unknown slug" warning once. Standalone passes `null`, so any slug in the
+   * hash is silently ignored.
    * @type {((slug: string) => string | null) | null}
    */
   export let resolveSlugToBackendUrl = null;
@@ -115,7 +116,7 @@
     // If features are already loaded (sync fetch or test fixture), try now.
     tryRestoreFromHash();
     // Otherwise wait for the source to populate.
-    const key = playgroundSource.on('change', tryRestoreFromHash);
+    playgroundSource.on('change', tryRestoreFromHash);
     return () => playgroundSource.un('change', tryRestoreFromHash);
   });
 
@@ -471,10 +472,8 @@
     }
 
     .controls-top-right {
-      top: auto;
-      bottom: auto;
-      right: 0.75rem;
       top: 0.75rem;
+      right: 0.75rem;
     }
 
     .controls-bottom-right {

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -98,17 +98,14 @@
 </div>
 
 <style>
+  /* The drawer lives above the pill in document order (and so above in the
+     flex column), so it appears to slide up from the pill when toggled. */
   .panel {
     position: relative;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-  }
-
-  .panel__drawer {
-    /* The drawer lives above the pill in document order so it appears to slide
-       up from the pill when toggled. */
   }
 
   .pill {

--- a/docs/reference/registry-json.md
+++ b/docs/reference/registry-json.md
@@ -6,7 +6,7 @@ The Hub reads a `registry.json` file at startup and on a short poll interval (`H
 
 - **Served from**: the nginx container under `/registry.json` (path configurable via `HUB_REGISTRY_URL`).
 - **Source file**: `app/public/registry.json` in the repo. In production, replace or bind-mount with your own registry.
-- **Served as**: `application/json`. CORS is not needed — the Hub fetches from its own origin.
+- **Served as**: `application/json`. CORS is not needed for the registry file itself — the Hub fetches it from its own origin. The *backends* the registry points at are typically cross-origin and must enable CORS on `/api/` (covered in [Federation endpoints](federation.md#federation-endpoints)).
 
 ## Schema
 

--- a/tests/hub-deeplink.spec.js
+++ b/tests/hub-deeplink.spec.js
@@ -62,6 +62,12 @@ test.describe('Hub deep-link', () => {
     await expect(panel).toBeVisible({ timeout: 8000 });
     // Which backend wins depends on which registry fetch resolves first — the
     // guarantee from the spec is just that *some* valid match is selected.
+    //
+    // We deliberately do NOT assert the "duplicate osm_id" console.warn here:
+    // it only fires when both backends' features land before hashRestored
+    // latches. In practice Playwright's route-fulfilled responses resolve
+    // one-at-a-time, so Backend A typically wins with matches.length === 1 and
+    // the warning never triggers. Pinning this would make the test flaky.
     await expect(panel).toContainText(/Shared [AB] copy/);
   });
 });


### PR DESCRIPTION
Closes #184.

Low-risk hygiene follow-ups from the code review of PRs #174, #178, #179, #182, #183. No behaviour change.

## Summary

- **AppShell.svelte** — drop unused capture of `playgroundSource.on('change', …)` return value; collapse the mobile `.controls-top-right` rule (was redundantly resetting `top`/`bottom` to `auto` and then re-setting `top`).
- **AppShell.svelte** — clarify the `resolveSlugToBackendUrl` JSDoc so it's explicit that the retry loop continues on every source `change`, while the unknown-slug `console.warn` is intentionally suppressed after the first hit.
- **InstancePanel.svelte** — remove the empty `.panel__drawer` rule; lift its explanatory comment onto `.panel` where the behaviour it describes actually lives.
- **hub-deeplink.spec.js** — document why the duplicate-osm_id test deliberately doesn't assert the `console.warn` (route-fulfill timing would make it flaky).
- **docs/reference/registry-json.md** — cross-link the CORS caveat to `federation.md#federation-endpoints`; the registry is same-origin but the backends it points at are typically cross-origin.

## Test plan

- [x] `mkdocs build --strict` (docs link + anchor valid)
- [ ] `make test` (Playwright) — no runtime change expected, but the test-file comment edit lives in a spec that's part of the suite
- [ ] Quick visual check of the hub bottom-left pill to confirm the empty-rule removal didn't shift layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)