### PR TITLE
feat(hub): show K/N progress on instance pill while backends load (#186)

### DIFF
--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -21,6 +21,24 @@
   $: isLoading = !$registryError && $backends.length === 0;
   $: hasRegistryError = !!$registryError;
 
+  // Fractional progress while the first load is still in flight. `completed`
+  // counts every backend that has settled (success or error) so the fraction
+  // grows monotonically; errors still surface per-row in the drawer.
+  //
+  // `firstLoadSettled` is a one-way latch: once every backend has settled once,
+  // we never re-enter the progress state. Without it the 5-min refresh poll
+  // (which re-sets `loading: true`) would briefly flash the fraction every
+  // tick, which looks broken.
+  let firstLoadSettled = false;
+  $: completedCount = $backends.filter(b => !b.loading).length;
+  $: totalCount = $backends.length;
+  $: if (totalCount > 0 && completedCount === totalCount) firstLoadSettled = true;
+  $: showProgress = !firstLoadSettled
+                 && !hasRegistryError
+                 && !isLoading
+                 && totalCount > 0
+                 && completedCount < totalCount;
+
   function toggle() {
     open = !open;
   }
@@ -73,10 +91,11 @@
   <button
     class="pill"
     class:pill--error={hasRegistryError}
-    class:pill--loading={isLoading}
+    class:pill--loading={isLoading || showProgress}
     type="button"
     onclick={toggle}
     aria-expanded={open}
+    aria-busy={isLoading || showProgress}
     aria-label={open ? $_('hub.pillCollapse') : $_('hub.pillExpand')}
     bind:this={pillEl}
   >
@@ -86,6 +105,11 @@
     {:else if isLoading}
       <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
       <span class="pill__text">{$_('hub.loading')}</span>
+    {:else if showProgress}
+      <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+      <span class="pill__text">
+        {$_('hub.regionProgress', { values: { completed: completedCount, total: totalCount } })}
+      </span>
     {:else}
       <Globe class="pill__icon" aria-hidden="true" />
       <span class="pill__text">

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -43,7 +43,7 @@ The Hub renders the same layout as a standalone regional map, with two additions
 └────────────────────────────────────────────────────────────┘
 ```
 
-- **Instance pill** (bottom-left): collapsed view shows a globe icon plus aggregated `<N> Regionen · <M> Spielplätze`. While the registry is loading the pill shows a spinner; if the registry can't be fetched the pill turns red and reads "Registry nicht erreichbar".
+- **Instance pill** (bottom-left): collapsed view shows a globe icon plus aggregated `<N> Regionen · <M> Spielplätze`. While the registry is loading the pill shows a spinner; once the registry is known but backends are still fetching their data, the pill shows `<completed>/<total> Regionen` with a spinner until every backend has settled (success or error) — the fraction only appears on the first load, not on subsequent 5-min refresh polls. If the registry can't be fetched the pill turns red and reads "Registry nicht erreichbar".
 - **Instance drawer**: clicking the pill slides up a drawer listing each backend with its name, version badge (from `get_meta`), and individual playground count. ESC, outside-click, or re-clicking the pill collapses it.
 - **Deep-link scheme**: see the [deep-link behaviour table](registry-json.md#deep-link-behaviour) in the registry reference.
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -355,6 +355,7 @@
     "instanceError": "Nicht erreichbar",
     "playgroundCount": "{count, plural, one {# Spielplatz} other {# Spielplätze}}",
     "regionCount": "{count, plural, one {# Region} other {# Regionen}}",
+    "regionProgress": "{completed}/{total, plural, one {# Region} other {# Regionen}}",
     "pillExpand": "Instanz-Liste öffnen",
     "pillCollapse": "Instanz-Liste schließen",
     "drawerTitle": "Verfügbare Instanzen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -355,6 +355,7 @@
     "instanceError": "Unreachable",
     "playgroundCount": "{count, plural, one {# playground} other {# playgrounds}}",
     "regionCount": "{count, plural, one {# region} other {# regions}}",
+    "regionProgress": "{completed}/{total, plural, one {# region} other {# regions}}",
     "pillExpand": "Show instance list",
     "pillCollapse": "Hide instance list",
     "drawerTitle": "Available instances",


### PR DESCRIPTION
Closes #186.

## Summary

Fills the gap between "registry loading" and the aggregated-count steady state. Once the registry is known but individual backends are still fetching, the pill shows ``<completed>/<total> Regionen`` with a spinner instead of silently displaying partial counts.

```
[⏳ Lade Instanzen …]         pre-registry
      │
      ▼  registry.json arrives
[⏳ 0/2 Regionen]              ← new
      │
      ▼  backend A returns
[⏳ 1/2 Regionen]              ← new
      │
      ▼  backend B returns
[🌐 2 Regionen · 13 849 Spielplätze]   steady state (unchanged)
```

## Design decisions

- **Denominator = total configured backends.** Numerator = backends that have *settled* (success *or* error) — errors still surface per-row in the drawer.
- **First-load latch.** `registry.js` flips `loading: true` at the start of every 5-min refresh poll. Without the latch the pill would blink back to fractional on every tick. Once `completed === total` once, we never re-enter the progress state.
- **Playground count hidden during progress.** It's the most volatile number (jumps by orders of magnitude when a large backend lands). The fraction alone is the honest signal.
- **Spinner retained.** The fraction tells you *how much*, the spinner tells you *something is still happening* — both on the same pill, same `spinner-border-sm` component used by the pre-registry state.
- **`aria-busy="true"`** on the pill while `isLoading || showProgress`, so screen-readers get the right hint.

## Locale keys

One new ICU key per locale, pluralised on `total` (the grammatical subject):

- `de`: `"{completed}/{total, plural, one {# Region} other {# Regionen}}"`
- `en`: `"{completed}/{total, plural, one {# region} other {# regions}}"`

## Test plan

- [x] `npm run build` (vite) — clean
- [x] `mkdocs build --strict` — clean
- [ ] Existing Playwright `hub-pill.spec.js` — final-state assertions should still pass (the test waits up to 8s for the aggregated count text, which arrives after the brief progress window)
- [ ] Manual: verify the brief fractional flash on dev server; confirm no flicker during the 5-min refresh poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)