### PR TITLE
chore: release v0.2.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spielplatzkarte-app",
   "private": true,
-  "version": "0.1.8-rc",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Bump `app/package.json` from `0.1.8-rc` to `0.2.0` for release.

## Highlights since v0.1.7

- **Federation (hub mode)** — aggregated bbox, slug-based deep-links, multi-backend nearest search, AppShell refactor
- **InstancePanel redesign** — bottom-left pill + drawer with per-backend status
- **K/N progress indicator** on the pill while backends are still loading (#186 → #187)
- **i18n epic complete** — all UI strings localised via svelte-i18n (#157 → #177)
- **MkDocs Material site** with federation + `registry.json` reference (#120, #183)
- **Hub Playwright coverage** — deep-link, pill, drawer (#345aa90)
- **Deployment modes** — data-node / ui / data-node-ui (#6846e0d)
- Thumbnail inline-preview fix (#108 → #123)

## Next steps

After merge:
1. Tag `v0.2.0` on main → CI publishes `:latest`, `:0.2.0`, `:0.2`
2. Follow-up PR to bump main to `0.2.1-rc`

## Test plan

- [x] Version bumped in `app/package.json`
- [ ] CI green on this PR

Assisted-by: ClaudeCode:claude-opus-4-7