### PR TITLE
chore: bump version to 0.2.1-rc

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spielplatzkarte-app",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1-rc",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Advance `main` onto the next release-candidate after v0.2.0. Standard post-release bump per CLAUDE.md release procedure step 3.

- `app/package.json`: `0.2.0` → `0.2.1-rc`

## Test plan

- [x] Version bumped in `app/package.json`
- [ ] CI green

Assisted-by: ClaudeCode:claude-opus-4-7