### PR TITLE
docs(adr): revise #0001 to track active openspec proposals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ playwright-report/
 # AI tools
 _bmad-output/
 _bmad/
-openspec/
 
 # Claude Code — per-user overlays
 .claude/settings.local.json

--- a/docs/adr/0001-openspec-sharing-policy.md
+++ b/docs/adr/0001-openspec-sharing-policy.md
@@ -1,6 +1,6 @@
 # ADR-0001: Share OpenSpec specs and archive in git
 
-- **Status:** Accepted
+- **Status:** Revised (see ## Revision 2026-04-20 below)
 - **Date:** 2026-04-19
 - **Deciders:** @mfuhrmann
 
@@ -138,3 +138,91 @@ Tracked in issue [#193]. Summary:
 - [OpenSpec](https://github.com/tbwiss/openspec)
 - Issue [#190] — handoff workaround that motivated this ADR
 - Issue [#193] — implementation
+
+## Revision 2026-04-20
+
+- **Status:** Accepted (supersedes the original Decision above)
+- **Deciders:** @mfuhrmann, @ronnytrommer
+
+### Trigger
+
+The "real friction" scenario anticipated in **Negative / to manage**
+above has fired sooner than expected. During a collaborative `/opsx:explore`
+session, @ronnytrommer drafted two multi-file change proposals
+(`add-tiered-playground-delivery`, `add-federated-playground-clustering`)
+that each span four files: `proposal.md`, `design.md`, `tasks.md`, and a
+nested `specs/<capability>/spec.md`. The original ADR's prescribed
+handoff — paste the proposal inline into a GitHub issue (pattern from
+#190) — does not scale to multi-file proposals: eight files pasted into
+one issue body is unreadable, and round-tripping edits between issue
+comments and local `openspec/changes/` diverges almost immediately.
+
+Waiting to see whether this pattern recurs before revisiting would
+create the same single-laptop-knowledge problem the original ADR was
+written to fix, just one level down.
+
+### Revised decision
+
+Track the whole `openspec/` tree in git, including active
+`openspec/changes/<name>/` directories. Replace the selective pattern
+with a simple removal of the `openspec/` line from `.gitignore`.
+
+| Path | Tracked? | Change from original |
+|---|---|---|
+| `openspec/specs/**` | yes | unchanged |
+| `openspec/changes/archive/**` | yes | unchanged |
+| `openspec/changes/<active>/**` | **yes** | **new** — was excluded |
+| `openspec/config.yaml`, `openspec/AGENTS.md`, top-level | yes | unchanged |
+
+### Consequences of the revision
+
+**Positive (additive to the original Consequences):**
+
+- Multi-file proposals can be handed off via ordinary branch + PR
+  workflow, not issue-paste.
+- Every commit that touches a proposal surfaces in normal code-review
+  tooling.
+- Claude Code agents on any account read the same active-proposal set
+  on a fresh clone.
+
+**Accepted costs:**
+
+- *Noisy diffs on every exploration session.* Mitigated by branch
+  discipline: exploratory thinking stays on an unpushed local branch
+  until it is "worth showing." Only merge to `main` when a proposal is
+  ready for collaboration or ready to implement.
+- *"Is my WIP ready for a teammate?" as a constant judgment call.*
+  Resolved by the same branch discipline. Local branch = private
+  thinking; pushed branch / draft PR = ready for collaboration;
+  `main` = shared baseline.
+- *Active-change churn in `main` history.* Accepted. Use draft PRs for
+  in-progress proposals so the history of the proposal is legible
+  (one PR per proposal is the default; multiple commits within the PR
+  are fine).
+
+### Coordination for the baseline commit
+
+Both contributors already have local `openspec/` directories that
+diverge (see original **Negative / to manage**). The original ADR
+proposed Option A (one contributor lands the baseline, the other
+rebases) with @mfuhrmann as the default baseliner.
+
+Under this revision the baseline includes active proposals too, which
+amplifies the divergence risk. We switch to a coordinated baseline:
+
+1. @ronnytrommer opens a PR containing: (a) this ADR revision,
+   (b) the `.gitignore` change, (c) his local `openspec/` tree.
+2. @mfuhrmann reviews the PR, resolves any conflict with his own local
+   tree in review (if his active proposals differ from what @ronnytrommer
+   has captured, he commits the authoritative versions onto the PR
+   branch before merge).
+3. On merge, both contributors hard-reset their local `openspec/` to
+   the committed tree, then cherry-pick any diverged local commits back
+   on top.
+
+### When to revert
+
+If the branch-discipline cost outlives the collaboration benefit,
+revert by restoring the `.gitignore` pattern from the original Decision
+and going back to issue-paste handoff. The original Decision remains
+available verbatim above this revision block.

--- a/openspec/changes/add-federated-playground-clustering/design.md
+++ b/openspec/changes/add-federated-playground-clustering/design.md
@@ -1,0 +1,117 @@
+## Context
+
+The hub is the user-facing front for a federation of regional backends. It currently loads every playground polygon from every registered backend simultaneously — a pattern inherited from standalone mode, which works up to a few thousand features total but fundamentally does not scale to Europe-coverage (plausibly 300–500k playgrounds across 30+ regional instances).
+
+Proposal `add-tiered-playground-delivery` gives each backend a contract that can answer viewport-shaped questions cheaply. This proposal is the hub-side consumer of that contract. The two live in the same architecture but have different concerns:
+
+- **P1** is per-backend: what is the shape of an answer? How does a single backend honour a bbox request at different zooms?
+- **P2** (this proposal) is hub-side: given that every backend speaks the P1 contract, how does the hub orchestrate across them, merge their answers, and render a coherent continent-wide view?
+
+The hub has firm operational constraints: it is a static-file + registry deployment (nginx + Svelte build + `registry.json`), with a small shell-cron script adding `federation-status.json` via `add-federation-health-exposition`. This proposal honours those constraints — no hub-side service, no hub-side DB, no change to the registry directory beyond what `get_meta` already exposes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Hub scales gracefully from 1 backend (single-country trial) to 30+ backends (Europe).
+- At any zoom level, fan-out load is proportional to backends intersecting the viewport, not total backends.
+- Partial-failure tolerance: offline or slow backends do not block the paint loop.
+- Border seams between backends are invisible in cluster and centroid tiers (one coherent continent view, not a tiling of regional maps).
+- No new hub-side runtime beyond the existing nginx + static build + cron script.
+- Country-level macro view at zoom 0–5 is cheap — constant cost in backends, not features.
+
+**Non-Goals:**
+
+- A hub-side aggregator service. If we wanted to re-cluster server-side across backends, we'd need one. We don't; Supercluster handles it client-side at the merge step.
+- A hub-side database or persistent state. Everything is derived from `get_meta` + `federation-status.json` + per-viewport fetches.
+- Cross-backend filter pre-aggregation. Each backend returns its own centroids with filter attrs; filter counts are computed after merge.
+- Country-level filter awareness. The macro view shows unconditional completeness counts from `get_meta`.
+- Changes to the per-backend contract (belongs in P1 or its successor).
+- Multi-hub topologies (hub-of-hubs). One hub, N backends.
+
+## Decisions
+
+### D1 — Bbox-based backend selection, auto-populated from get_meta
+
+On hub load, the existing `registry.json` fetch kicks off `get_meta` calls per backend (the instance-pill already does this). The hub caches each backend's `bbox` from that response, keyed by URL. On each `moveend`, the viewport bbox is intersected with each cached backend bbox (simple `[minLon, minLat, maxLon, maxLat]` overlap test, microseconds). Only intersecting backends receive a tier fetch.
+
+Rejected alternatives:
+
+- **Bbox in `registry.json`**: bloats the directory, introduces a second source of truth (what happens when a backend's actual region is extended after an import?). Keep the registry pure.
+- **Server-side routing service at the hub**: violates the static-file hub invariant. No.
+- **No routing — query every backend always**: fan-out cost grows O(backends). Unacceptable at 30+.
+
+Bbox is refreshed whenever `get_meta` is re-fetched (the existing 5-minute registry poll).
+
+### D2 — Re-cluster after merge, using Supercluster weighted points
+
+At the cluster tier, each backend returns pre-aggregated buckets (`get_playground_clusters`). Naively concatenating them produces visible seams at borders — each backend's bucket grid aligned to its own region. Instead, the hub treats each returned bucket as a single "weighted point" with `count`, `complete`, `partial`, `missing` properties, feeds the merged set into Supercluster with `map`/`reduce` callbacks that preserve those counts, and renders the output.
+
+Two important properties:
+
+- Supercluster's kd-bush runs in sub-100ms for even 40k input points. A fan-out of 30 backends each returning 50 buckets is 1500 points — negligible.
+- Supercluster is deterministic given the same input, so cluster positions are stable across re-renders (no visual flicker on pan).
+
+Rejected alternatives:
+
+- **Enforce a shared bucket grid across backends**: requires backend coordination and couples release cycles across operators. No.
+- **Re-bucket via PostGIS at merge time**: we're client-side; PostGIS isn't available.
+- **Skip re-clustering, show backend seams**: visually unacceptable at borders.
+
+### D3 — Progressive render on fan-out arrival, single AbortController
+
+Each fan-out invocation creates one `AbortController`. Per-backend requests are fired in parallel; as each response settles, its contribution is merged into the relevant Supercluster index (or polygon source), and the map repaints. Users see features appear progressively, not all-or-nothing.
+
+On the next `moveend`, the previous `AbortController` aborts; any in-flight requests cancel together. This is the same idiom used by P1's per-backend standalone orchestrator.
+
+Rejected alternatives:
+
+- **Wait for all backends before first paint**: one slow peer holds the whole viewport hostage. Unacceptable.
+- **Per-backend AbortControllers**: more complex lifecycle, no real benefit.
+
+### D4 — Skip offline backends silently; show outline in macro view
+
+The `federation-status.json` signal (from `add-federation-health-exposition`) identifies backends whose last poll failed. The hub's bbox router filters these out — no request is attempted until the backend recovers. This avoids 3-second timeouts on every moveend for a dead peer.
+
+In the zoom 0–5 macro view, offline backends still render as country rings, but outlined (not filled), with a small "offline" indicator. The user sees "there is data here, it's just currently unreachable" rather than a silent hole.
+
+When a backend recovers, the next `moveend` (or the next registry-poll tick) picks it up automatically. No cache invalidation dance.
+
+### D5 — Zoom tiers: 0–5 macro, 6–10 server clusters, 11–13 centroids, 14+ polygons
+
+The macro-view tier is new in this proposal; tiers 6–14+ delegate to P1's per-backend RPCs. Threshold 5 is the break below which a viewport bbox at continental aspect ratio covers most of Europe — there is no request that is cheaper than macro-view at this zoom.
+
+Between macro (5) and cluster (6), there's a narrow band where we're displaying many backend bboxes but not yet fetching their data. The one-zoom gap is a deliberate cheap zone — zoom 5 uses the `get_meta` snapshot (already in memory); zoom 6 is the first tier that issues a bbox-filtered fan-out. Users zooming in from continental view see rings dissolve into server clusters at the threshold.
+
+### D6 — Country-level macro view uses get_meta, not a separate RPC
+
+`get_meta` already returns `playground_count` and `bbox`; P1 extends it with `{complete, partial, missing}`. That is all the macro view needs. No separate "macro summary" RPC.
+
+The ring centre is the bbox centroid. For oddly-shaped backends (e.g. a backend that covers a long coastal strip) the centroid can be over the sea — acceptable; this is a continental view, not a cartographic one. If it turns out to be a real problem, we can add an optional `centroid_lat/lon` to `get_meta` in a future tiny proposal.
+
+### D7 — Initial map fit must not spuriously drop into macro view for one-backend hubs
+
+When a hub is configured with only one backend (e.g. during federation bootstrapping, or a single-country deployment that nonetheless uses hub mode for future-proofing), the initial map fit based on the backend's bbox at standard padding typically lands at zoom 10–12 — above the macro threshold. Good.
+
+But on very small regions (e.g. a single city backend), the fit might land above zoom 5 but *visually* look continental because there's so little data. We explicitly clamp the initial-fit zoom to be ≥ `clusterMaxZoom + 1` (i.e. zoom 6) when only one backend is registered. This ensures the user lands in a tier that issues real fetches, not the macro view.
+
+### D8 — No hub-side caching beyond HTTP
+
+Per-viewport responses from each backend are HTTP-cached by the browser (leveraging P1's `Cache-Control` and `data_version`-busting query param). The hub's Supercluster indexes are rebuilt per tier-change, not kept across moveends — simpler lifecycle, no stale-data risk, and clustering is cheap enough that rebuilding is fine.
+
+## Risks / Trade-offs
+
+- **Burst load on borders.** Panning across a border where two backends both carry data doubles the fan-out for one moveend. Mitigated by debounce (300 ms, same as standalone) — rapid pans collapse to a single fetch per backend.
+- **Re-cluster perf at max federation size.** At 30 backends each returning 100 cluster buckets, merged input is 3000 weighted points. Supercluster handles that easily; benchmark on Europe-sized test registry before release to confirm.
+- **Stale offline-backend display.** If a backend goes offline mid-session, the user may see some stale features for up to one `federation-status.json` poll interval (60s) before the offline marker appears. Acceptable — the data itself isn't wrong, just a few seconds out of date.
+- **Border seams at cluster tier despite re-clustering.** Edge case: if one backend's cluster has `count = 1500` and another's has `count = 2` right at the border, Supercluster may still visually group them into one mega-cluster. The stacked-ring proportions are correct (hub computes them from the weighted counts); the visual is a little lopsided. Accept.
+- **AbortController browser support.** Fine on every browser we target.
+- **Macro-view centroid over water / disputed borders.** See D6. If painful, add `centroid_lat/lon` to `get_meta` later.
+- **Registry-poll coupling.** Bboxes are refreshed on the 5-minute registry poll. A backend that changes its bbox mid-session (e.g. an operator extends the relation) sees the change only on the next poll. Acceptable.
+
+## Open Questions
+
+- **What does an in-progress `registry.json` update look like?** If an operator is editing the registry during a user session, does the hub drop removed backends immediately or on the next poll? Probably the next poll (mirrors all other registry semantics). Document either way.
+- **Should the hub surface aggregate counts in the macro view centre too, or only in the instance pill?** A zoom-3 ring over France showing "48k" is useful; the same information is already in the pill. Leaning "yes, show it" — the ring is the primary visual at that zoom. Confirm in UX review.
+- **Granularity of the filter badge post-merge.** At zoom 11, across 3 backends, filter-match count is accurate but slow if filter attrs require client-side evaluation for every centroid. Budget: 50k centroids × constant-time filter = ~1 ms. Fine.
+- **Behaviour if `federation-status.json` is absent** (e.g. hub hasn't deployed `add-federation-health-exposition` yet). Fall back to "assume all backends reachable, rely on per-request timeout"? Yes — describe in the spec as a required fallback so the proposals can deploy in either order.

--- a/openspec/changes/add-federated-playground-clustering/proposal.md
+++ b/openspec/changes/add-federated-playground-clustering/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+The hub shipped in v0.2.0 fans out feature-fetching across multiple regional backends but has no clustering and no zoom-tier awareness — at Europe scale that means a Paris user's browser holds every polygon in DE, FR, NL, CH, IT, etc. simultaneously, which is not tractable.
+
+Proposal `add-tiered-playground-delivery` gives each backend a zoom-scoped contract (clusters / centroids / polygons, all bbox-scoped). This proposal adds the hub layer on top: a bbox router that only queries backends whose region intersects the viewport, a fan-out + progressive-render pipeline that tolerates slow or offline peers, a client-side re-clusterer that merges server clusters across backends (so the seam between DE and FR disappears in the output), and a country-level macro view for the zoom-0-to-5 "continent overview".
+
+The trigger to do this now is the Europe-coverage ambition: federation scale goes from 1–3 backends (the current trial topology) to plausibly 30+. Every architectural assumption that works in the small breaks in the large — most notably the "fetch everything, let the browser sort it out" pattern in hub-mode feature loading. This proposal closes that gap without introducing a new server tier or a central aggregator service — the hub stays a static-file + registry directory, as the federation deployment docs promise.
+
+## What Changes
+
+- **Hub — backend-bbox routing**:
+    - On hub load, fetch `api.get_meta` for every backend in `registry.json` (already done for the instance-pill); extract each backend's `bbox` and cache in a `backends` store.
+    - On each `moveend`, compute the viewport bbox in WGS84 and filter to the subset of backends whose bbox intersects — only those are queried.
+    - Bboxes are auto-populated from `get_meta`; `registry.json` stays a URL directory. Operators do not hand-edit bboxes.
+
+- **Hub — parallel fan-out with progressive render**:
+    - Each tier's fetcher (clusters / centroids / polygons from P1) is wrapped in a hub-level `fanOut(fetcher, bboxFilter, signal)` that invokes the underlying fetcher in parallel across selected backends.
+    - Results stream back as they arrive; the merged source is incrementally updated so the map repaints as each backend responds.
+    - A single `AbortController` per fan-out; all pending backend requests cancel together on the next `moveend`.
+    - Offline backends (per the `federation-status.json` signal from `add-federation-health-exposition`) are skipped silently — no request is issued until health returns.
+
+- **Hub — client-side re-clustering across backends**:
+    - Cluster tier: each backend returns its own bucketed clusters (via `get_playground_clusters`). The hub re-indexes the merged results through Supercluster as weighted points, using `map`/`reduce` callbacks that preserve the complete/partial/missing counts. The rendered clusters therefore span backends seamlessly at borders.
+    - Centroid tier: each backend returns raw centroids; the hub builds one Supercluster index over the union.
+    - Polygon tier: no re-merging needed; polygons from different backends never overlap geographically (relations are disjoint).
+
+- **Hub — country-level macro view (zoom 0–5)**:
+    - Below `clusterMaxZoom`, no backend fetches happen. Instead, one ring per backend is rendered at the backend's bbox centroid, sized by `playground_count` and segmented by the `{complete, partial, missing}` fields from `get_meta` (added in P1).
+    - Clicking a country-ring zooms to that backend's bbox.
+    - Offline backends render as outlined (not filled) rings with a small "offline" badge, sourced from `federation-status.json`.
+
+- **Hub — filter-aware cluster badge** (carried from P1 into the federated context):
+    - Filter-matching count is computed client-side after re-clustering over the merged centroids. Works seamlessly across backends because the filter attributes are on the centroid rows.
+    - Not rendered on the country-level view (the `get_meta` macro summary doesn't carry filter attrs).
+
+- **Docs**:
+    - Extend `docs/reference/federation.md` with a "Scale and clustering" section describing the three tiers and the country-level view.
+    - Update `docs/ops/federated-deployment.md` (in-flight in `document-federated-hub-deployment`) with a note on the bbox auto-population requirement (backends must implement P1).
+
+Out of scope (explicit non-goals):
+
+- A hub-side aggregator service. The hub remains static-file + registry.
+- A hub-side database or cache beyond HTTP and in-memory Supercluster indexes.
+- Cross-backend filter pre-aggregation.
+- Country-level filter awareness.
+- Changes to P1's per-backend contract — anything touching the RPCs belongs in P1 or its successor.
+
+## Dependencies
+
+- **Blocks on `add-tiered-playground-delivery`** (P1). The bbox-scoped RPCs are pre-requisites for any hub-side fan-out beyond what v0.2.0 already does.
+- **Blocks on `add-federation-health-exposition`**. Skipping offline backends silently — and rendering them as outline-only in the macro view — depends on the `federation-status.json` signal that change introduces.
+- **Soft dep on `document-federated-hub-deployment`**. Operator docs need to reflect the scale target; can land in either order without blocking.
+
+## Capabilities
+
+### New Capabilities
+
+- `federated-playground-clustering`: Hub-side bbox routing, fan-out + progressive render, client-side re-clustering of multi-backend results, and the country-level macro view at zoom 0–5.
+
+### Modified Capabilities
+
+- `hub-ui-parity`: the hub's initial map fit logic gains a "zoom not lower than `clusterMaxZoom + 1` when only one backend is registered" clause, so single-backend hubs don't spuriously drop into the macro view. Existing scenarios remain correct.
+
+## Impact
+
+- `app/src/hub/HubApp.svelte` — replaces one-shot multi-backend fetchPlaygrounds with a zoom-tier orchestrator (hub equivalent of P1's standalone orchestrator).
+- `app/src/hub/backends.js` (new or extension of `registry.js`) — bbox routing, health-signal integration, per-backend AbortController management.
+- `app/src/hub/fanOut.js` (new) — parallel-fetcher utility with progressive merge.
+- `app/src/hub/macroView.svelte` (new) — country-level ring renderer for zoom 0–5.
+- `app/src/components/ClusterLayer.svelte` (from P1) — extended to consume weighted points from the hub's merge.
+- `docs/reference/federation.md` — new scaling section.
+- `docs/ops/federated-deployment.md` — cross-reference to this proposal (once the parent change lands).

--- a/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
@@ -1,0 +1,168 @@
+## ADDED Requirements
+
+### Requirement: Hub routes fetches by backend bounding box
+
+The hub SHALL fetch playground data only from backends whose bounding box intersects the current viewport, and SHALL source those bounding boxes from each backend's `get_meta` response (not from `registry.json`).
+
+#### Scenario: Viewport inside one backend queries only that backend
+
+- **WHEN** the viewport falls entirely inside the bbox of backend A, and backends B and C have bboxes disjoint from the viewport
+- **THEN** the hub issues a tier-appropriate fetch to backend A only
+- **AND** backends B and C receive no request for this moveend
+
+#### Scenario: Viewport crossing a border queries every intersecting backend
+
+- **WHEN** the viewport intersects the bboxes of backends A and B but not of backend C
+- **THEN** the hub issues parallel fetches to A and B
+- **AND** backend C receives no request
+
+#### Scenario: Bounding boxes are auto-populated from get_meta
+
+- **WHEN** the hub loads `registry.json` and fetches `get_meta` for each entry
+- **THEN** each backend's `bbox` field is cached in the in-memory backends store
+- **AND** no `bbox` field is read from `registry.json` (even if one is present)
+
+#### Scenario: Bounding boxes refresh on registry poll
+
+- **WHEN** the existing 5-minute registry poll fires
+- **THEN** `get_meta` is re-fetched per backend
+- **AND** any changes in `bbox` are reflected in the backends store for subsequent moveends
+
+### Requirement: Hub fans out fetches in parallel with progressive render
+
+For any tier that requires a per-backend fetch, the hub SHALL invoke each selected backend's fetcher in parallel, render incrementally as responses arrive, and cancel all in-flight requests together on the next moveend.
+
+#### Scenario: Progressive render
+
+- **WHEN** the hub fans out a centroid fetch to backends A, B, and C, and C takes 2 seconds while A and B respond in 100 ms
+- **THEN** the centroid layer renders data from A and B within ~100 ms (plus debounce)
+- **AND** C's contribution appears when its response settles, without re-rendering the whole map
+
+#### Scenario: Slow backend does not block the paint
+
+- **WHEN** one backend exceeds the 5-second per-request timeout
+- **THEN** that backend's contribution is omitted from the current tier
+- **AND** a console warning is emitted once per backend per session
+- **AND** the map remains interactive throughout
+
+#### Scenario: Moveend cancels previous fan-out
+
+- **WHEN** a new moveend fires before the previous fan-out has settled for every backend
+- **THEN** every in-flight per-backend request from the previous fan-out is aborted
+- **AND** only the new fan-out's results contribute to the current render
+
+#### Scenario: Single error does not reject the fan-out
+
+- **WHEN** one backend returns HTTP 500 during a fan-out while others succeed
+- **THEN** the successful backends' contributions render as normal
+- **AND** the failed backend is logged as an error entry but does not propagate as a rejection
+
+### Requirement: Offline backends are skipped silently
+
+When `federation-status.json` reports a backend as `ok: false`, the hub's bbox router SHALL exclude that backend from tier fetches. In the macro view, the backend's ring SHALL still render, outlined rather than filled, with a visible offline marker.
+
+#### Scenario: Offline backend excluded from fetches
+
+- **WHEN** `federation-status.json` reports backend B as `ok: false`
+- **THEN** fan-out does not issue any tier-fetch to backend B
+- **AND** backend A and C (reachable) respond normally
+- **AND** no timeout error is logged for B on this moveend
+
+#### Scenario: Offline backend visible in macro view
+
+- **WHEN** the zoom is in the macro tier (≤ 5) and backend B is offline
+- **THEN** backend B's country ring still renders at its bbox centroid
+- **AND** the ring is outlined (stroke only, no fill), rendered in a muted colour
+- **AND** a small "offline" label is visible on the ring
+- **AND** the counts displayed on B's ring are the last known counts from its most recent successful `get_meta` response
+
+#### Scenario: Backend recovers without page reload
+
+- **WHEN** a previously offline backend recovers (federation-status reports `ok: true` at the next poll)
+- **THEN** the next moveend includes that backend in the fan-out
+- **AND** the macro-view ring transitions from outlined to filled
+
+#### Scenario: Fallback when federation-status.json is absent
+
+- **WHEN** `GET /federation-status.json` returns 404
+- **THEN** the hub assumes every backend is reachable
+- **AND** logs a one-time console warning naming the missing endpoint
+- **AND** fan-out proceeds with per-request timeouts as the only health signal
+
+### Requirement: Hub re-clusters merged server results across backends
+
+At the cluster tier, merged cluster buckets from multiple backends SHALL be re-clustered client-side so that no visible seam appears at a backend boundary.
+
+#### Scenario: Re-cluster preserves total counts
+
+- **WHEN** backend A returns buckets summing to count 2000 and backend B returns buckets summing to count 1500 inside the viewport
+- **THEN** the rendered cluster layer, after re-clustering, shows a total count of 3500 across its rings
+- **AND** the sum of `complete` segments equals the sum of `complete` inputs from A and B
+- **AND** likewise for `partial` and `missing`
+
+#### Scenario: Border clusters merge visually
+
+- **WHEN** two clusters from different backends sit within a visual threshold distance at the border
+- **THEN** the re-clusterer may merge them into a single rendered ring whose count is the sum
+- **AND** the ring's segment proportions reflect the combined counts
+
+### Requirement: Hub renders a country-level macro view at zoom 0–5
+
+At zoom levels at or below `clusterMaxZoom` (default 10; the macro tier starts at 5), the hub SHALL render one stacked-ring feature per registered backend, sized and segmented by the backend's `get_meta` aggregate counts, without fetching any per-playground data.
+
+#### Scenario: Macro view renders one ring per backend
+
+- **WHEN** the zoom is 3 (within the macro tier) and the registry contains N backends
+- **THEN** exactly N rings are rendered, one per backend
+- **AND** no per-playground fetch is issued at this zoom
+
+#### Scenario: Macro ring position and sizing
+
+- **WHEN** backend A has `bbox = [5, 47, 15, 55]` and `playground_count = 65000`
+- **THEN** A's ring is centred at approximately `(10, 51)` (bbox centroid)
+- **AND** the ring's radius is drawn from the same size scale used for individual clusters (bucketed by count; large buckets for higher counts)
+
+#### Scenario: Macro ring segments reflect completeness
+
+- **WHEN** backend A has `{complete: 12000, partial: 30000, missing: 23000}` in its `get_meta` response
+- **THEN** A's ring displays three segments proportional to 12 : 30 : 23
+- **AND** colours match the playground polygon completeness colours
+
+#### Scenario: Macro ring click zooms to backend bbox
+
+- **WHEN** the user clicks a macro-view ring
+- **THEN** the map view animates to fit the backend's bbox with standard padding
+- **AND** the zoom lands in the cluster or centroid tier (depending on bbox size)
+- **AND** a tier fetch is issued to (only) that backend after the moveend debounce
+
+### Requirement: Hub polygon tier concatenates without re-merging
+
+At the polygon tier (zoom ≥ 14), the hub SHALL render polygons from every contributing backend in a single vector source, without attempting cross-backend merging.
+
+#### Scenario: Polygon features tagged by source backend
+
+- **WHEN** the polygon tier is active and two backends contribute features
+- **THEN** every feature carries a `_backendUrl` property equal to its source backend
+- **AND** selection events route to the correct backend by reading this property
+
+#### Scenario: Polygon source is replaced on every tier fetch
+
+- **WHEN** a new polygon-tier moveend fires
+- **THEN** the polygon source is cleared and replaced with the merged fan-out result
+- **AND** no stale features from a previous viewport linger
+
+### Requirement: Initial hub map fit does not land in macro view for small deployments
+
+When only one backend is registered, the hub's initial `view.fit` SHALL clamp to zoom `clusterMaxZoom + 1` or higher, so single-backend hubs do not spuriously land in the macro view.
+
+#### Scenario: Single-backend hub lands above macro threshold
+
+- **WHEN** a hub starts with exactly one backend whose bbox corresponds to a small region (e.g. a single city)
+- **THEN** the initial map fit zoom is at least `clusterMaxZoom + 1` (default 11)
+- **AND** the user sees cluster or centroid features on first paint, not macro rings
+
+#### Scenario: Multi-backend hub lands in whatever tier the union bbox dictates
+
+- **WHEN** a hub starts with multiple backends whose union bbox spans multiple regions
+- **THEN** the initial fit is not clamped beyond standard padding
+- **AND** the resulting zoom may be in the macro tier (correctly showing the continent overview)

--- a/openspec/changes/add-federated-playground-clustering/tasks.md
+++ b/openspec/changes/add-federated-playground-clustering/tasks.md
@@ -1,0 +1,65 @@
+## 1. Hub — bbox routing and backend metadata
+
+- [ ] 1.1 Extend `app/src/hub/registry.js` (or add `app/src/hub/backends.js`) to cache each backend's `bbox` field from its `get_meta` response
+- [ ] 1.2 Expose a readable `backendsStore` emitting `{ url, slug, name, bbox, playgroundCount, completeness: {complete, partial, missing} }` per backend
+- [ ] 1.3 Add `app/src/hub/bboxRouter.js` — pure function `selectBackends(viewportBbox, backends) => backends[]` that returns only backends whose cached bbox intersects the viewport
+- [ ] 1.4 Keep bboxes fresh by re-invoking `get_meta` on the existing 5-minute registry poll
+- [ ] 1.5 Integrate `federation-status.json` as a filter: backends with `ok: false` are excluded from the router's output (soft fallback when the status file is absent — treat every backend as reachable)
+
+## 2. Hub — fan-out with progressive render
+
+- [ ] 2.1 Create `app/src/hub/fanOut.js` — `fanOut(fetcher, backends, signal)` invokes `fetcher(backendUrl, signal)` in parallel across `backends`, emits each response as it settles via an async iterator or callback
+- [ ] 2.2 Fan-out shares a single `AbortController` across its invocations; on cancel, every in-flight request is aborted
+- [ ] 2.3 Per-backend per-request timeout (default 5s); timed-out backends are logged once per session and excluded from the current fan-out
+- [ ] 2.4 Errors from one backend do not reject the fan-out promise; they are surfaced as `{ ok: false, error, backendUrl }` entries
+
+## 3. Hub — zoom-tier orchestrator
+
+- [ ] 3.1 Replace the existing "fetch all playgrounds from every backend" logic in `HubApp.svelte` with a moveend-driven orchestrator mirroring P1's standalone pattern but using `fanOut`
+- [ ] 3.2 Three tiers (cluster / centroid / polygon) map to `fetchPlaygroundClusters`, `fetchPlaygroundCentroids`, `fetchPlaygroundsBbox` fanned-out across the selected backends
+- [ ] 3.3 Below `clusterMaxZoom` (zoom 0–5), the orchestrator dispatches nothing — the macro view renders from the cached `backendsStore` only
+- [ ] 3.4 On tier transition, abort the previous fan-out before kicking off the new tier's
+- [ ] 3.5 Expose hub-tier bookkeeping via a `hubLoadingStore` so the instance pill can show partial-loaded state (e.g. "3/5 regions loaded")
+
+## 4. Hub — client-side re-clustering
+
+- [ ] 4.1 Cluster tier: merged buckets from all backends' `get_playground_clusters` are fed into a Supercluster instance as weighted points; `map`/`reduce` callbacks preserve `{count, complete, partial, missing}`
+- [ ] 4.2 Centroid tier: merged centroids from all backends' `get_playground_centroids` fed into a single Supercluster index; filter attrs preserved per-feature
+- [ ] 4.3 Polygon tier: per-backend `get_playgrounds_bbox` results are concatenated into a single `VectorSource` (no re-clustering needed); each feature tagged with `_backendUrl` for selection routing
+- [ ] 4.4 On each fan-out partial arrival, the relevant Supercluster index is incrementally updated (`load` with the accumulated set) and the map repaints
+
+## 5. Hub — country-level macro view (zoom 0–5)
+
+- [ ] 5.1 Create `app/src/hub/MacroView.svelte` — renders one OL feature per backend at the backend's bbox centroid
+- [ ] 5.2 Macro-view features use the same stacked-ring renderer from P1 (`stackedRingRenderer`) with count, complete, partial, missing from the backend's cached `get_meta` completeness counts
+- [ ] 5.3 Backends with `ok: false` (from federation-status) render as outlined (stroke-only) rings with a muted colour and a small "offline" label
+- [ ] 5.4 Clicking a macro-view ring animates `view.fit` to the backend's bbox, which naturally lands in the cluster or centroid tier
+- [ ] 5.5 Hover over a macro ring shows a tooltip with region name, playground count, and data freshness (from `federation-status.json` or `get_meta.data_version`)
+- [ ] 5.6 Macro view visibility is gated on `zoom <= clusterMaxZoom`
+
+## 6. Hub — initial map fit clamp
+
+- [ ] 6.1 When only one backend is registered, clamp the initial `view.fit` to `maxZoom: clusterMaxZoom + 1` or higher (so single-backend hubs don't land in the macro view spuriously)
+- [ ] 6.2 When multiple backends are registered, initial fit uses the union of their bboxes as today; if that union sits at or below `clusterMaxZoom`, the macro view takes over and the fit is correct by construction
+
+## 7. Hub — filter-aware cluster badge under federation
+
+- [ ] 7.1 At the centroid tier, the filter badge computation runs over merged centroids from all contributing backends; no per-backend change needed beyond P1
+- [ ] 7.2 At the cluster tier, no filter badge (same rule as P1)
+- [ ] 7.3 At the macro tier, no filter badge (decision D6 in design.md)
+
+## 8. Docs
+
+- [ ] 8.1 Add a "Scale and clustering" section to `docs/reference/federation.md` describing the zoom tiers, bbox routing, and the country-level macro view
+- [ ] 8.2 Update `docs/ops/federated-deployment.md` (coming in `document-federated-hub-deployment`) with a note that backends must implement `add-tiered-playground-delivery` before joining a hub running this code
+- [ ] 8.3 Add an architecture diagram (mermaid or simple ASCII) showing hub → bbox-router → fan-out → re-cluster → render
+
+## 9. Verification
+
+- [ ] 9.1 Playwright: on a two-backend test registry, load the hub at zoom 4, assert macro rings appear for both backends with correct counts; zoom in and assert transitions to cluster tier trigger fan-out to both backends
+- [ ] 9.2 Playwright: disable one backend mid-test (via a proxy that returns 503); assert the macro-view ring becomes outlined and subsequent moveends skip that backend
+- [ ] 9.3 Playwright: moveend across the border between two backends; assert combined clusters render without visible seams and counts sum correctly
+- [ ] 9.4 Manual: on a simulated 10-backend registry, confirm fan-out completes within 2s at cluster tier over a Europe-wide viewport
+- [ ] 9.5 Manual: pan rapidly across borders, confirm cancelled fetches do not leak features from previous viewports
+- [ ] 9.6 Lifecycle: `federation-status.json` is removed mid-session (simulate by stopping cron); fall back to "assume reachable", log warning once
+- [ ] 9.7 `openspec validate add-federated-playground-clustering` passes before archive

--- a/openspec/changes/add-federation-health-exposition/design.md
+++ b/openspec/changes/add-federation-health-exposition/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Federation shipped in v0.2.0 with zero observability infrastructure. Every answer to "is it working?" lives either in a user's browser session (the InstancePanel drawer's per-backend error/loading state) or in per-container Docker logs that nobody aggregates. The hub container itself is pure static — nginx + Svelte build + `registry.json` — so there is no server-side vantage point from which federation health can be observed, let alone persisted.
+
+The trigger for investing now is the onboarding of **backend #2 by an external operator** — the moment a second human depends on the hub's operational state. That's the threshold where "browser is the dashboard" stops being acceptable and where the absence of federation-level telemetry becomes a trust barrier rather than a convenience gap. Federation docs (`docs/ops/federated-deployment.md`, in flight in the `document-federated-hub-deployment` change) exist precisely to enable that onboarding; this proposal closes the operational gap the docs expose.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Minimum viable observation that covers the two pains most likely to bite first: **importer failure** (silent data staleness) and **backend-down-unnoticed**.
+- A scrape hook for operators who already run Prometheus/Grafana, with no in-repo dashboards or alerting.
+- **Zero new services** in `compose.yml`.
+- **Zero new databases.** Reuse the existing per-backend Postgres for the one timestamp we need.
+- Deployment recipe unchanged from the operator's perspective — `make up` continues to work with no new prerequisites.
+
+**Non-Goals:**
+
+- Frontend error reporting. Docs will recommend Sentry free tier; no in-repo wiring.
+- Distributed tracing across hub → backend fetches. OpenTelemetry is too heavy for this tier; revisit when a concrete debug story demands it.
+- In-repo Grafana dashboards or alerting rules. BYO.
+- Multi-hub coordination. The hub is single-instance.
+- Historical time-series. The hub exposes current state; BYO Prometheus stores history.
+- A sidecar service or embedded database (SQLite). See D1.
+
+## Decisions
+
+### D1 — Hub stays operationally stateless; cron + flat JSON + /metrics
+
+The hub container gains `busybox-suid` (or equivalent cron provider) and a poll script. No long-running service, no database, no new compose entry. Output is two flat files under the nginx document root, refreshed every 60 seconds.
+
+Rejected alternatives:
+
+- **Sidecar service**: adds supervision, crash recovery, language runtime, and migration concerns for a capability that current scale does not justify. Reserve for when Level 1 proves insufficient (e.g. when we need rich history, webhooks, or auth-scoped endpoints).
+- **Client-only observation posted to a hub ingest endpoint**: would require a POST target, auth, and abuse handling. Client browsers are untrusted observers; server-side polling from a known location is the right shape.
+
+The cost of this decision is a small surface-area bump in the image (one binary + one shell script). If that becomes a pain, the poll loop can migrate to a tiny Go binary behind the same nginx locations without changing any external contract.
+
+### D2 — Exporter pattern, not time-series DB
+
+The hub exposes *current* state; history is the problem of whoever runs the scraper. This is standard Prometheus architecture. Operators without Prometheus still get a scrape-friendly flat JSON (`/federation-status.json`) that any external uptime tool can poll — so the hub serves both the "BYO metrics stack" and "BYO uptime monitor" operator paths without in-repo aggregation.
+
+### D3 — Freshness stored in the DB, not the filesystem
+
+`last_import_at` is written to an `api.import_status` table, not a timestamp file on disk. Rationale: the importer container is ephemeral (`docker compose run --rm importer`), so a filesystem timestamp would not survive container removal. The DB is already the durable store for imported data — co-locating the freshness marker there avoids a second persistence mechanism.
+
+Singleton enforced via `CHECK (id = 1)`; `UPSERT` via `INSERT ... ON CONFLICT (id) DO UPDATE`.
+
+### D4 — Prometheus text format for `/metrics`
+
+Chosen over OpenMetrics, JSON, or a custom format:
+
+- De-facto standard scraped by every metrics tool worth mentioning.
+- Trivial to generate from shell (`printf` lines), no code generator required.
+- Easy for operators to inspect manually with `curl`.
+- OpenMetrics adds features (exemplars, native histograms) we don't need here; backward-compatible drift is unnecessary.
+
+### D5 — Poll interval: 60 seconds
+
+Balances freshness against backend load. At N backends, each sees 1 extra request per minute from the hub. Negligible at federation scales we anticipate (≤10 backends).
+
+The hub UI's existing 5-minute refresh poll is **unchanged** — that's a per-browser mechanism for displaying up-to-date *data* to users; this new 60-second poll is a server-side mechanism for observing backend *health*. Keeping them separate avoids coupling UX freshness to ops freshness.
+
+### D6 — `generated_at` timestamp in status JSON is mandatory
+
+A stale `federation-status.json` (cron died, container frozen) is indistinguishable from a fresh one unless the file self-reports when it was written. External tools scraping the JSON MUST be able to compute "age of the observation" to avoid trusting stale data. The UI similarly uses this field to gate the "observation stale" banner (see `hub-ui-parity` delta).
+
+### D7 — Scope is "minimum cut for backend #2 onboarding", not "observability v1"
+
+Explicit scope discipline: the two in-scope pains (importer failure + backend-down-unnoticed) are the minimum an external backend operator needs to trust the federation. Latency regression is covered only as a side effect of the `/metrics` shape — no in-repo dashboards. Frontend errors and cross-boundary traces are deferred entirely. This prevents the proposal from drifting into a general-purpose observability effort that would easily absorb weeks of work.
+
+## Risks / Trade-offs
+
+- **Cron in the nginx container** adds surface area (busybox-cron binary + script + entrypoint hook). Mitigation: minimal image delta, poll script is <50 lines of shell, reviewable end-to-end. Migration path to a tiny Go binary exists if shell hits its limits.
+- **Poll fan-out on backends.** At N=5 backends × 60 s, each backend sees 1 extra request/minute. Negligible; `get_meta` is cached-friendly and already public.
+- **Data-model drift between `/federation-status.json` and `/metrics`.** Both files are generated in the same poll run; single shell function emits both to keep them in lockstep. Any schema change touches one place.
+- **`api.import_status` table is one row.** Using a `CHECK (id = 1)` singleton prevents accidental multi-row drift (e.g. from a mistyped `INSERT`).
+- **Cron silently dies, status freezes.** Caught by `generated_at`: external monitors alert on stale observation, UI shows a banner. The failure mode is observable rather than silent.
+- **CORS on the status endpoint.** Hub UI fetches from its own origin (no CORS issue). External tools scraping cross-origin would need CORS headers; adding them matches `/registry.json` behaviour and costs nothing.
+- **Freshness-banner UX noise.** If the threshold for "stale observation" is too tight, users see a banner during transient hub hiccups. Start conservative (2× poll interval = 120 s) and loosen based on observed false-positive rate.
+
+## Open Questions
+
+- **Should `/metrics` be gated behind a bearer token?** Current `/api/rpc/*` federation endpoints are public, so metrics are no more sensitive. Revisit if any per-user data lands in them.
+- **Exponential backoff on unreachable backends?** Linear retry every 60 s is simplest; a failing backend gets scraped 1440×/day. Probably fine. Exponential backoff is a future improvement, not load-bearing for v1.
+- **Should the importer also write `pbf_etag` and `source_pbf_url`?** Recommended for debugging "did this importer run pick up the right file?", but strictly optional for this proposal — defer if scope pressure mounts.

--- a/openspec/changes/add-federation-health-exposition/proposal.md
+++ b/openspec/changes/add-federation-health-exposition/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The federation architecture shipped in v0.2.0 has no way to answer operator questions like "is the Berlin backend reachable from the hub?", "when did this region last import data?", or "which backends are the slowest?" Every answer lives transiently in a user's browser memory or is unavailable entirely.
+
+Before the first external backend operator is onboarded (i.e. before backend #2 is run by someone other than the hub operator), the federation needs a minimum-viable observation hook so that (a) outages can be detected without a support ticket, (b) stale data is visible, and (c) operators using their own Prometheus/Grafana stacks have a scrape target.
+
+This proposal delivers exactly that minimum — covering importer-failure and backend-down-unnoticed directly, giving a hook for latency monitoring via BYO Prometheus, and explicitly deferring frontend error reporting, distributed tracing, and in-repo dashboards to future proposals.
+
+## What Changes
+
+- **Backend (per data-node)**:
+    - Importer records a `last_import_at` timestamp after each successful osm2pgsql run (persisted in a small DB table).
+    - `api.get_meta` response gains `last_import_at` (and derived `data_age_seconds`) so the hub can observe freshness.
+
+- **Hub container**:
+    - Poll script (busybox cron, every 60 seconds) reads `registry.json`, fetches `get_meta` from each backend, records reachability + latency + data age.
+    - Output written to two files served by the existing nginx:
+        - `/federation-status.json` — human-readable rollup (per-backend status, last success, latency sample, data age, `generated_at`).
+        - `/metrics` — the same data in Prometheus text exposition format.
+    - Hub container image gains `busybox-suid` (or equivalent cron provider) and the poll script (no new compose services).
+
+- **Hub UI**:
+    - `InstancePanel` drawer surfaces per-backend `data_age` and "last reachable" timestamps from the new endpoint, alongside the existing per-session error/loading state.
+
+- **Docs**:
+    - New page `docs/ops/monitoring.md` — three recipes: (a) external uptime monitor on `/federation-status.json`, (b) BYO Prometheus scrape of `/metrics`, (c) Sentry free tier for frontend errors (link only).
+    - `federation.md` and `registry-json.md` cross-link the new page.
+
+Out of scope (explicit non-goals):
+
+- In-repo Grafana dashboards, alerting rules, or Prometheus config.
+- Frontend error reporting or RUM wired in-repo.
+- Distributed tracing (OpenTelemetry).
+- Multi-hub coordination.
+- Sidecar service or database for observation history.
+
+## Capabilities
+
+### New Capabilities
+
+- `federation-health-exposition`: Hub-side polling and exposition of per-backend federation health via `/federation-status.json` and `/metrics`, plus the `last_import_at` field on backend `get_meta` responses.
+
+### Modified Capabilities
+
+- `scheduled-importer`: importer records a persistent last-successful-run timestamp after each import.
+- `hub-ui-parity`: instance drawer displays data age and last-reachable timestamps from the federation-status endpoint.
+
+## Impact
+
+- `importer/api.sql` — new `api.import_status` table; `get_meta` joins it in.
+- `importer/` (script/container) — writes `last_import_at` on successful run.
+- `oci/app/` — Dockerfile gains cron provider; adds poll script + crontab; nginx config serves `/federation-status.json` and `/metrics`.
+- `app/src/hub/registry.js` (or new `federationStatus.js`) — fetches `/federation-status.json` alongside `/registry.json`, merges into the backends store.
+- `app/src/hub/InstancePanelDrawer.svelte` — renders freshness info.
+- `docs/ops/monitoring.md` — new file.
+- `docs/reference/federation.md`, `docs/reference/registry-json.md` — cross-links.
+- `mkdocs.yml` — nav entry.
+- `compose.yml` — no changes.

--- a/openspec/changes/add-federation-health-exposition/specs/federation-health-exposition/spec.md
+++ b/openspec/changes/add-federation-health-exposition/specs/federation-health-exposition/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Backend exposes last-import timestamp
+
+Each data-node SHALL expose the timestamp of its most recent successful import via `api.get_meta`, so the hub (and any external client) can observe data freshness per backend.
+
+#### Scenario: `get_meta` includes `last_import_at` after an import
+
+- **WHEN** a client calls `/api/rpc/get_meta` after at least one successful importer run
+- **THEN** the response contains `last_import_at` as an ISO-8601 timestamp
+- **AND** the response contains `data_age_seconds` as a non-negative integer equal to `now() - last_import_at` rounded to whole seconds
+
+#### Scenario: `get_meta` before any import
+
+- **WHEN** a client calls `/api/rpc/get_meta` on a freshly provisioned backend that has never completed an importer run
+- **THEN** `last_import_at` is present in the response with value `null`
+- **AND** `data_age_seconds` is present with value `null`
+- **AND** no other fields are affected (backward-compatible extension)
+
+### Requirement: Hub container polls backends and exposes status JSON
+
+The hub container SHALL poll every registered backend on a fixed 60-second interval and write the aggregated observation to `/federation-status.json`, served over HTTP at the hub's origin.
+
+#### Scenario: Status JSON is populated within 90 seconds of hub start
+
+- **WHEN** the hub container starts with a populated `registry.json`
+- **THEN** within 90 seconds `GET /federation-status.json` returns a valid JSON document with one entry per backend in the registry
+
+#### Scenario: Status JSON records reachability
+
+- **WHEN** a backend returns a successful `get_meta` response during a poll
+- **THEN** that backend's entry includes `ok: true`, `last_success` (ISO-8601 UTC), `latency_ms` (observed round-trip in milliseconds), `data_age_seconds` (carried through from the backend's `get_meta` response)
+
+#### Scenario: Status JSON records unreachable backends
+
+- **WHEN** a backend fails to respond within the 3-second timeout, or returns a non-2xx HTTP status
+- **THEN** that backend's entry includes `ok: false` and a short `error` string (e.g. `"timeout"`, `"http 502"`, `"dns"`)
+- **AND** the previously recorded `last_success` value is preserved unchanged (not overwritten by a failed poll)
+
+#### Scenario: Status JSON self-reports freshness
+
+- **WHEN** a client fetches `/federation-status.json`
+- **THEN** the top-level object includes `generated_at` as an ISO-8601 UTC timestamp naming the start of the most recent poll cycle
+- **AND** the top-level object includes `poll_interval_seconds` as an integer (currently 60) so clients can compute staleness without hard-coding the interval
+
+#### Scenario: CORS mirrors the registry
+
+- **WHEN** a client fetches `/federation-status.json` cross-origin
+- **THEN** the response carries the same CORS headers as `/registry.json`, so any client able to read the registry is able to read the status
+
+### Requirement: Hub exposes Prometheus metrics endpoint
+
+The hub container SHALL expose `/metrics` in Prometheus text exposition format, derived from the same poll as `/federation-status.json`.
+
+#### Scenario: Metrics endpoint responds with correct content type
+
+- **WHEN** a client calls `GET /metrics`
+- **THEN** the response has content type `text/plain; version=0.0.4` and is well-formed Prometheus text exposition (each metric has `# HELP` and `# TYPE` lines)
+
+#### Scenario: Metrics include per-backend labels
+
+- **WHEN** the metrics endpoint is scraped
+- **THEN** per-backend samples carry a `backend` label — value equal to the registry entry's `slug` when present, falling back to the entry's `url` otherwise
+- **AND** labels match those exposed in `/federation-status.json` entries one-to-one
+
+#### Scenario: Minimum metric set is emitted
+
+- **WHEN** the metrics endpoint is scraped
+- **THEN** the output includes at minimum:
+    - `spielplatz_backend_up{backend}` — gauge, `1` if last poll succeeded, `0` otherwise
+    - `spielplatz_backend_latency_seconds{backend}` — gauge, observed round-trip from the last successful poll
+    - `spielplatz_backend_data_age_seconds{backend}` — gauge, `data_age_seconds` from the last successful poll
+    - `spielplatz_poll_generated_timestamp` — gauge, unix timestamp of the last poll cycle start
+
+#### Scenario: Metrics survive a cron gap
+
+- **WHEN** the cron daemon has not run for longer than the poll interval
+- **THEN** `/metrics` still responds with the most recent successfully generated content (not a 404), and `spielplatz_poll_generated_timestamp` reveals the staleness
+
+### Requirement: Hub image includes cron provider and poll script
+
+The hub container image SHALL include a cron provider (`busybox-suid`, `dcron`, or equivalent) and a poll script installed under a well-known path, without requiring any `compose.yml` changes.
+
+#### Scenario: Cron runs in the same container as nginx
+
+- **WHEN** the hub container is started
+- **THEN** both nginx and the cron daemon are running in-container
+- **AND** no additional service is declared in `compose.yml`
+
+#### Scenario: Poll script path is stable
+
+- **WHEN** an operator inspects the running container
+- **THEN** the poll script is located at `/usr/local/bin/poll-federation.sh` and is executable
+- **AND** the crontab entry invokes exactly that path

--- a/openspec/changes/add-federation-health-exposition/specs/hub-ui-parity/spec.md
+++ b/openspec/changes/add-federation-health-exposition/specs/hub-ui-parity/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Instance drawer shows data freshness and last-reachable
+
+The hub instance drawer SHALL display per-backend data age and last-reachable time sourced from `/federation-status.json`, alongside the existing per-session error and loading indicators.
+
+#### Scenario: Reachable backend shows data age
+
+- **WHEN** the drawer is opened and a backend has `ok: true` in the status endpoint
+- **THEN** the backend's row shows a humanised data-age label (e.g. "data: 2 days old") derived from `data_age_seconds`
+
+#### Scenario: Unreachable backend shows last-reachable
+
+- **WHEN** the drawer is opened and a backend has `ok: false` in the status endpoint but a non-null `last_success`
+- **THEN** the backend's row shows a humanised last-reachable label (e.g. "last reachable 8 min ago")
+
+#### Scenario: Never-reachable backend shows explicit state
+
+- **WHEN** the drawer is opened and a backend has `ok: false` with no prior `last_success`
+- **THEN** the backend's row shows an explicit "never reachable" label (distinct from a loading state)
+
+#### Scenario: Stale observation banner
+
+- **WHEN** the status endpoint's `generated_at` is older than 2× `poll_interval_seconds`
+- **THEN** the drawer shows a subtle banner indicating the server-side observation is stale
+- **AND** the in-session browser observation remains the primary source of truth for the current drawer state (the banner is informational, not blocking)
+
+#### Scenario: Status endpoint unavailable
+
+- **WHEN** `/federation-status.json` is unreachable, returns non-2xx, or fails to parse
+- **THEN** the drawer renders exactly as it does today — per-session error/loading state from the user's own browser polling, no freshness labels
+- **AND** a single warning is logged to the console; no per-poll log spam

--- a/openspec/changes/add-federation-health-exposition/specs/scheduled-importer/spec.md
+++ b/openspec/changes/add-federation-health-exposition/specs/scheduled-importer/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Importer records successful-run timestamp
+
+The importer SHALL record the timestamp of each successful run into a persistent, SQL-queryable location so that downstream clients (federation hub, monitoring tools) can observe data freshness per backend.
+
+#### Scenario: Successful run writes a timestamp
+
+- **WHEN** the importer container completes an osm2pgsql run with exit code 0
+- **THEN** the `api.import_status` singleton row is upserted with `last_import_at = now()`
+
+#### Scenario: Failed run does not update timestamp
+
+- **WHEN** the importer exits with a non-zero status, is killed, or aborts partway through osm2pgsql
+- **THEN** the previous `last_import_at` value is preserved unchanged
+- **AND** no partial or speculative timestamp is written
+
+#### Scenario: Singleton integrity enforced at schema level
+
+- **WHEN** any client attempts to `INSERT` a second row into `api.import_status`
+- **THEN** the insertion fails with a CHECK violation
+- **AND** the existing row is unaffected

--- a/openspec/changes/add-federation-health-exposition/tasks.md
+++ b/openspec/changes/add-federation-health-exposition/tasks.md
@@ -1,0 +1,46 @@
+## 1. Backend — import status tracking
+
+- [ ] 1.1 Add `api.import_status` table in `importer/api.sql` — columns `id int PRIMARY KEY CHECK (id = 1)`, `last_import_at timestamptz NOT NULL`, `source_pbf_url text`, `pbf_etag text`
+- [ ] 1.2 Modify the importer entrypoint (shell script that invokes osm2pgsql) to `UPSERT` into `api.import_status` with `NOW()` on exit code 0 only
+- [ ] 1.3 Extend `api.get_meta` to LEFT JOIN `api.import_status` and include `last_import_at` and derived `data_age_seconds` (`EXTRACT(EPOCH FROM (now() - last_import_at))::int`) in the JSON output
+- [ ] 1.4 Grant SELECT on `api.import_status` to `web_anon` (only if PostgREST exposes it; otherwise inline into `get_meta` with `SECURITY DEFINER` reach)
+- [ ] 1.5 Update `dev/seed/seed.sql` so `make seed-load` populates a plausible `last_import_at` (e.g. `now() - interval '3 days'`) so the dev experience matches production
+- [ ] 1.6 Document the new field in `docs/reference/registry-json.md` under the `get_meta` response section
+
+## 2. Hub container — poll + exposition
+
+- [ ] 2.1 Add `busybox-suid` (or `dcron`, whichever is smaller on the existing base image) to `oci/app/Dockerfile`
+- [ ] 2.2 Create `oci/app/poll-federation.sh` — reads `/usr/share/nginx/html/registry.json`, curls each backend's `get_meta` with a 3s timeout, measures latency, writes `/usr/share/nginx/html/federation-status.json` and `/usr/share/nginx/html/metrics` atomically (write to `.tmp`, rename)
+- [ ] 2.3 Install a crontab entry (`* * * * * /usr/local/bin/poll-federation.sh >/dev/null 2>&1`) into the hub image
+- [ ] 2.4 Start cron in the nginx container via `oci/app/docker-entrypoint.app.sh` (background the daemon before exec-ing nginx)
+- [ ] 2.5 Add an nginx `location = /metrics` block setting `Content-Type: text/plain; version=0.0.4`
+- [ ] 2.6 Ensure `/federation-status.json` is served with CORS headers matching `/registry.json`
+- [ ] 2.7 Include `generated_at` ISO-8601 UTC timestamp as a top-level field in both outputs
+- [ ] 2.8 On first start, generate an empty placeholder file so a hub queried before the first cron tick does not 404
+
+## 3. Hub UI — surface freshness in the drawer
+
+- [ ] 3.1 Extend `app/src/hub/registry.js` (or add `app/src/hub/federationStatus.js`) to fetch `/federation-status.json` on hub-mode startup, refresh on the same 5-min interval as the existing registry poll, merge into the existing `backends` readable store
+- [ ] 3.2 Update `app/src/hub/InstancePanelDrawer.svelte` to render per-backend `data_age` (e.g. "data: 2 days old") and `last_ok` (e.g. "last reachable 3 min ago")
+- [ ] 3.3 Show a subtle "observation stale" hint in the drawer if `generated_at` is older than 2× poll interval (default 120 s)
+- [ ] 3.4 Add i18n strings for new drawer labels (`hub.dataAge`, `hub.lastReachable`, `hub.observationStale`, `hub.neverReachable`)
+- [ ] 3.5 Graceful fallback: if `/federation-status.json` 404s or fails to parse, the drawer renders exactly as it does today (no freshness labels, no error noise in console beyond one-time warning)
+
+## 4. Docs
+
+- [ ] 4.1 Create `docs/ops/monitoring.md` with three recipes:
+    - **External uptime monitor** — point UptimeRobot / healthchecks.io / similar at `https://<hub>/federation-status.json`, alert on any `ok: false` or stale `generated_at`
+    - **BYO Prometheus** — example scrape config block for `/metrics`, list of emitted metrics + labels, one-paragraph Grafana panel suggestion (no in-repo dashboards)
+    - **Frontend error reporting** — link to Sentry free tier; paste-ready snippet for `app.html` if the operator chooses to add it; explicitly noted as *not* wired in-repo
+- [ ] 4.2 Add a "Health exposition" section to `docs/reference/federation.md` cross-linking to the new page
+- [ ] 4.3 Note `last_import_at` in `docs/reference/registry-json.md` under the `get_meta` fields
+- [ ] 4.4 Add `Monitoring: ops/monitoring.md` to the `mkdocs.yml` nav under Operations
+
+## 5. Verification
+
+- [ ] 5.1 `make docker-build && make up` locally with two-backend `registry.json`; `/federation-status.json` appears within 90s and contains both backends
+- [ ] 5.2 `curl http://localhost:8080/metrics` returns well-formed Prometheus text exposition with `# HELP` and `# TYPE` lines for `spielplatz_backend_up`, `spielplatz_backend_latency_seconds`, `spielplatz_backend_data_age_seconds`, `spielplatz_poll_generated_timestamp`
+- [ ] 5.3 Stop one backend container, wait one poll cycle, verify `ok: false` in status JSON and `spielplatz_backend_up{backend="..."} 0` in metrics
+- [ ] 5.4 `make docs-build --strict` passes with `monitoring.md` in nav and no broken internal links
+- [ ] 5.5 Manual smoke test of the drawer in hub mode: reachable backends show "data: N days old"; unreachable backend shows "last reachable N min ago"
+- [ ] 5.6 Validate the change with `openspec validate add-federation-health-exposition` before archive

--- a/openspec/changes/add-tiered-playground-delivery/design.md
+++ b/openspec/changes/add-tiered-playground-delivery/design.md
@@ -1,0 +1,93 @@
+## Context
+
+Today, `StandaloneApp.svelte:126–135` fetches every playground polygon for the configured relation at startup, adds them to a single `VectorSource`, and lets OpenLayers render the whole set at every zoom level. `app/src/lib/api.js::fetchPlaygrounds` is the only entry point. For Fulda this is ~100 features; for a region the size of Berlin it's ~2.5k; for Germany it would be 50k+ and tens of megabytes on first paint.
+
+The project has chosen to expand toward Europe-scale coverage via a federation of regional backends (see `add-federated-playground-clustering`). That decision forces a pre-requisite: regardless of federation, every backend must be able to answer viewport-shaped questions — clusters at low zoom, centroids mid-zoom, polygons high-zoom — instead of region-shaped ones. This proposal delivers exactly that per-backend contract, without touching hub orchestration.
+
+The UX anchor is the completeness signal: the playground polygon fill (green / amber / red) is the map's primary information channel. A clustering design that loses this information would be a regression. The stacked-ring cluster is the chosen visual compromise — each cluster is a ring segmented by count-of-complete / count-of-partial / count-of-missing, with the count in the centre. At 40+ children the ring is readable; at single digits the segments remain distinguishable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Per-backend data contract that scales from one playground to Germany without changing request shape.
+- Preserve the red/amber/green completeness scan at every zoom level.
+- No new services, no new datastores; everything lives in the existing Postgres + PostgREST.
+- Backward-compatible for one release: existing `get_playgrounds(relation_id)` stays callable to unblock tests and external tooling.
+- Client orchestration is self-contained: a page refresh does not refetch what is already in view.
+
+**Non-Goals:**
+
+- Federation — P2 (`add-federated-playground-clustering`) depends on this proposal and lands separately.
+- Vector tiles (MVT). Revisit only if Phase 1 payloads grow beyond ~500 KB per viewport request at mid-zoom. PostGIS + gzipped JSON is expected to carry Germany-sized regions comfortably.
+- Server-side filter-aware clustering. Pre-aggregating by every filter combination is combinatorial and premature; filter count is computed client-side over the returned centroids.
+- Changes to equipment / tree / POI RPCs. Those already take a bbox and work fine.
+- Changes to the selection panel, deep-link, or search — they remain polygon-path features operating at zoom ≥ 14.
+
+## Decisions
+
+### D1 — Three-tier server contract, bucket clusters via ST_SnapToGrid
+
+The server exposes exactly three tiers: clusters, centroids, polygons. Clusters are bucketed by `ST_SnapToGrid(way, cell_size)` where `cell_size` is a function of the requested zoom (roughly `156543.03 / 2^z` metres × a constant, tuned so a bucket maps to ~60 CSS pixels at the requested zoom). Each bucket emits `{lon, lat, count, complete, partial, missing}`.
+
+Rejected alternatives:
+
+- **PostGIS `ST_ClusterKMeans` / `ST_ClusterDBSCAN`**: produce better-looking clusters but require per-request computation over all features in the bbox; cost grows with density. Grid bucketing is `O(n)` with trivial constants and its results cache perfectly by `(z, bbox)`.
+- **H3 / S2 bucketing**: attractive but adds a PG extension dependency. Keep the stack lean. Grid snap in Web Mercator is close enough; visual jitter at bucket boundaries is masked by the client-side re-cluster tier.
+- **Emit pre-clustered points already merged across zooms**: over-constrains clients. Keeping `get_playground_clusters(z, bbox)` stateless and deterministic lets the hub cache per `(z, bbox)` HTTP key.
+
+### D2 — Client-side clustering engine is Supercluster, not OL `Cluster`
+
+OpenLayers' native `Cluster` source degrades past ~10k points per viewport and recomputes on every view change. Supercluster (Mapbox) uses a KD-bush and handles 100k+ points with sub-100 ms clustering. It also supports `map`/`reduce` callbacks, which we rely on (a) to preserve completeness counts when clustering centroids, and (b) in P2 to re-cluster across federated backends.
+
+Cost: one new dependency (`supercluster`, ~15 KB gzipped, no transitive deps). Worth it.
+
+### D3 — Stacked-ring renderer is canvas via OL `Style.renderer`, cached by shape
+
+OL `Icon` / `Circle` styles can't draw the segmented ring. We use `Style({ renderer: (coords, state) => ... })` which gets the 2D context and draws the ring directly.
+
+To keep frame cost down, the rendered bitmap is cached keyed on `(count_bucket, r_frac, p_frac, m_frac)` rounded to a fixed palette (say, 4 count buckets × 10% segment buckets = ~400 distinct bitmaps). On cache hit, the renderer blits; on miss, it draws once and stores. Memory cost is bounded; frame cost drops to draw-image calls.
+
+### D4 — Zoom thresholds: ≤ 10 clusters, 11–13 centroids, ≥ 14 polygons
+
+These numbers are calibrated, not fixed:
+
+- At zoom ≤ 10 a single playground polygon occupies less than one CSS pixel. Clusters are the only sensible representation.
+- At zoom 11–13 individual playgrounds are visible as dots but polygon outlines carry no useful detail. Centroids + client-side clustering provide responsive pan/zoom with completeness colour.
+- At zoom ≥ 14 polygon boundaries matter for "which street is this on" wayfinding, and the selection UI relies on the polygon geometry to fit-to-extent.
+
+The thresholds are surfaced as `config.js` constants (`clusterMaxZoom = 10`, `centroidMaxZoom = 13`) so operators can tune per deployment.
+
+### D5 — Layer visibility is gated; non-active layers stay in memory
+
+Rather than destroying the unused layers on zoom transitions, we hide them via `setVisible(false)`. This prevents flicker during pan-at-zoom-boundary (when two tiers are both potentially relevant within one frame) and lets the OL render pipeline keep its cached geometry.
+
+The exception is the polygon source: it is bbox-scoped and refetched on each `moveend` that lands in the polygon tier, because the same bbox may produce different features (a pan brings new playgrounds in). The cluster and centroid sources similarly refetch on `moveend` inside their tier.
+
+### D6 — Filter-awareness is two-tier
+
+Clusters always show the completeness breakdown in the ring (what's on the map). When any filter is active, a small badge below the count shows "N match filter" — computed client-side from centroid attributes for the centroid tier, and requested from the server alongside the cluster bucket for the cluster tier (each cluster bucket ships filter-match counts for the current filter hash, server-side).
+
+Actually: the cluster tier does **not** ship filter counts. Cluster-tier is zoom ≤ 10, where individual filter precision is visually meaningless — at that scale, a badge that says "147 match in this cluster" is noise, not signal. The badge appears only on the centroid tier (zoom 11–13) and above. At zoom ≤ 10 the filter state changes the ring display to neutral grey when a filter is active, communicating "filter doesn't resolve at this scale."
+
+### D7 — Legacy `get_playgrounds(relation_id)` retained one release, then removed
+
+Dropping it immediately breaks Playwright fixtures and any external consumer. Mark deprecated in `importer/api.sql` with a `COMMENT`, and log a one-time warning from `fetchPlaygrounds` in the client. Remove in the release after next; track via a separate tiny proposal.
+
+Keeping it indefinitely is rejected: the materialised view behind it (`playground_stats`) then has to stay in lockstep with the new centroid attrs, and "which path does this client use?" becomes a support question.
+
+## Risks / Trade-offs
+
+- **Flicker at zoom boundary.** Mitigated by D5 (keep layers alive and hidden). A secondary mitigation: within ±0.5 of a threshold, both tiers render, with the inactive one at 40% opacity, for 200 ms. Hide behind a setting; default off until we observe it's actually a problem.
+- **Cluster-grid jitter at bucket boundaries.** A cluster's centroid "jumps" to a different bucket when the bbox pans across a grid line. Mitigated by the client-side re-cluster on the centroid tier taking over at zoom 11. At the cluster tier this is below the threshold of user perception.
+- **Memory at maximum centroid response.** A bbox covering 30k playgrounds returns ~3 MB of centroid GeoJSON. Supercluster's index is ~N × 40 bytes, so ~1.2 MB. Total well under the budget we'd worry about, but we cap response sizes server-side with `LIMIT` + a warning field so the client can hint "zoom in for accuracy".
+- **Cache invalidation on import.** `get_playground_clusters` responses are HTTP-cached aggressively (no `Cache-Control` header → nginx/PostgREST defaults). After an osm2pgsql import, stale bucket responses linger. Mitigated by adding a short `Cache-Control: max-age=300` and, on import completion, touching a bump timestamp surfaced in `get_meta` that the client uses as a cache-bust query param.
+- **Breakage for external tooling calling `get_playgrounds(relation_id)`.** Deprecation window covers this; removal will be its own proposal with a migration note.
+- **Selection + deeplink flow depends on polygon features.** At zoom < 14, if a deeplink lands on `#W<osm_id>`, the polygon feature isn't loaded yet. Fix: deeplink restore triggers a single `get_playgrounds_bbox` call centred on the osm_id's known location (via `get_nearest_playgrounds`-style lookup) to hydrate just that feature, then selects it. Smaller hop than fetching the region.
+
+## Open Questions
+
+- **Exact grid-cell sizing per zoom level.** Initial proposal: `cell_size_m = 156543.03 × cos(lat) / 2^z × 60` (where 60 is the target pixel size of a bucket). Needs a feedback loop against real data density — Fulda, Berlin, and a Germany-sized test extract — before final tuning.
+- **Should `get_playground_centroids` include the osm_id or only per-tier aggregates?** Currently specified to include `osm_id` so the client can select a playground from a centroid click without a round-trip. Adds ~15 bytes per feature. Worth it.
+- **Response compression.** PostgREST emits JSON; nginx does gzip. Verify `br` (brotli) is on in the OCI image — a 40% size win for free. If not, add it in this proposal or spawn a tiny follow-up.
+- **Playground `access=private` hatch fills.** Style fn still needs these at polygon tier. For centroid/cluster tier, do we distinguish at all? Leaning "no" — private playgrounds still contribute to counts; hatch is a high-zoom detail. Confirm with an eyeball test on Berlin data.

--- a/openspec/changes/add-tiered-playground-delivery/proposal.md
+++ b/openspec/changes/add-tiered-playground-delivery/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The current data path — `api.get_playgrounds(relation_id)` returns every polygon in a region in a single call — worked for Fulda (~100 features), was tolerable for Berlin (~2.5k), and breaks completely at Germany scale (~50–70k, 30–100 MB GeoJSON on first paint). The stated ambition is Europe-wide coverage via a federation of regional backends. Before federation can be clustered (see `add-federated-playground-clustering`), each backend needs to serve data that can survive a viewport-shaped request, not a region-shaped one.
+
+This proposal delivers the per-backend half: zoom-tiered, bbox-scoped RPCs plus a client that swaps representations as the user zooms. Standalone deployments benefit immediately — a Berlin-sized instance stops shipping a 5 MB payload on load, Germany becomes viable single-instance, and the stacked-ring cluster UX preserves the red/yellow/green completeness scan that the whole map is built around.
+
+## What Changes
+
+- **Backend (per data-node)**:
+    - New `api.get_playground_clusters(z, bbox)` — pre-aggregated count buckets with per-bucket completeness breakdown `{complete, partial, missing}`, bucketed by a zoom-appropriate grid (PostGIS `ST_SnapToGrid` on the web-mercator geometry).
+    - New `api.get_playground_centroids(bbox)` — lightweight per-feature rows: `osm_id`, centroid lon/lat, completeness, and a small packed set of filter attributes (`has_water`, `for_baby`, `for_toddler`, `for_wheelchair`, `has_soccer`, `has_basketball`, `access_restricted`).
+    - New `api.get_playgrounds_bbox(bbox)` — same response shape as today's `get_playgrounds`, scoped to an intersecting bbox instead of a relation.
+    - `api.get_meta` gains `{complete, partial, missing}` counts so the hub's low-zoom macro view (proposal P2) has a precomputed source.
+    - Existing `api.get_playgrounds(relation_id)` is marked deprecated but retained one release for Playwright fixtures and external tooling; removal tracked separately.
+
+- **Client — frontend**:
+    - `StandaloneApp` replaces the one-shot `fetchPlaygrounds` with a zoom-tier orchestrator driven by `moveend`. Three tiers:
+        - zoom ≤ 10 → cluster layer fed by `get_playground_clusters`
+        - zoom 11–13 → centroid layer fed by `get_playground_centroids`, clustered client-side via Supercluster
+        - zoom ≥ 14 → polygon layer fed by `get_playgrounds_bbox`, rendered with the existing `playgroundStyleFn`
+    - A new `ClusterLayer` component wraps a `VectorLayer` whose style function renders the stacked ring (complete/partial/missing proportional segments + count) via a cached canvas renderer.
+    - Layer visibility is zoom-gated; the layer not in use is hidden, not destroyed, so a zoom-out does not discard in-flight centroid data.
+    - Filter awareness: clusters display completeness breakdown unconditionally; a small "N match filter" badge appears only when a filter is active.
+    - `app/src/lib/api.js` gains `fetchPlaygroundClusters`, `fetchPlaygroundCentroids`, `fetchPlaygroundsBbox`; `fetchPlaygrounds` is deprecated but retained one release.
+    - Existing features that iterate `playgroundSource.getFeatures()` — URL-hash restore, `NearbyPlaygrounds` fallback — gracefully no-op when the polygon layer isn't populated, falling back to the PostgREST `get_nearest_playgrounds` path.
+
+- **Docs**:
+    - `docs/reference/api.md` (new) — documents the three tiered RPCs, zoom thresholds, and response shapes.
+    - `CLAUDE.md` "Key frontend architecture" section updated to describe the zoom-tier layer orchestration.
+
+Out of scope (explicit non-goals):
+
+- Federation — covered by `add-federated-playground-clustering` (P2), which layers on top of this proposal.
+- Vector tiles (MVT) — reconsidered only if Phase 1 payloads grow beyond the viewport budget.
+- Changes to equipment/tree/POI RPCs — those are already bbox-scoped and unchanged.
+- Server-side filter pre-aggregation — clusters carry completeness only; filter counts are derived client-side.
+
+## Capabilities
+
+### New Capabilities
+
+- `tiered-playground-delivery`: Zoom-tiered, bbox-scoped playground data contract and the client-side orchestrator that consumes it. Covers the three new RPCs, the zoom-tier layer swap, and the stacked-ring cluster renderer.
+
+### Modified Capabilities
+
+- None. The playground-rendering logic in `Map.svelte` is not currently covered by a capability spec; `hub-ui-parity` concerns hub-specific widgets and is untouched here.
+
+## Impact
+
+- `importer/api.sql` — three new functions, extension to `get_meta`, one new spatial index (geohash or grid column on `planet_osm_polygon` restricted to `leisure=playground`).
+- `app/src/lib/api.js` — three new fetchers; `fetchPlaygrounds` deprecated.
+- `app/src/lib/vectorStyles.js` — new `stackedRingStyleFn` for clusters, new `centroidStyleFn`.
+- `app/src/components/Map.svelte` — swap from single polygon layer to three zoom-gated layers.
+- `app/src/standalone/StandaloneApp.svelte` — moveend-driven orchestrator; one-shot fetch removed.
+- `app/src/components/ClusterLayer.svelte` — new, encapsulates Supercluster + canvas renderer.
+- `app/src/stores/playgroundSource.js` — now published only when the polygon tier is active.
+- `package.json` — adds `supercluster` dependency.
+- Playwright tests — updated to exercise zoom-tier transitions; legacy fixtures call `get_playgrounds_bbox` against the seed region.
+- `docs/reference/api.md` — new page; `mkdocs.yml` nav updated.

--- a/openspec/changes/add-tiered-playground-delivery/specs/tiered-playground-delivery/spec.md
+++ b/openspec/changes/add-tiered-playground-delivery/specs/tiered-playground-delivery/spec.md
@@ -1,0 +1,165 @@
+## ADDED Requirements
+
+### Requirement: Backend exposes cluster aggregates scoped to zoom and bbox
+
+Each data-node SHALL expose a function that returns pre-aggregated playground count buckets for a given zoom level and bounding box, so clients at low zoom can render cluster representations without fetching individual features.
+
+#### Scenario: Clusters RPC returns bucketed counts
+
+- **WHEN** a client calls `api.get_playground_clusters(z, min_lon, min_lat, max_lon, max_lat)` with a zoom level and a WGS84 bbox intersecting the configured region
+- **THEN** the response is a JSON array of bucket objects, each containing `lon`, `lat`, `count`, `complete`, `partial`, and `missing` fields
+- **AND** `count = complete + partial + missing` for every bucket
+- **AND** bucket centres are deterministic for a given `(z, bbox)` input (grid-aligned)
+
+#### Scenario: Clusters RPC honours bbox filter
+
+- **WHEN** the caller supplies a bbox that covers only a subset of the region
+- **THEN** only buckets whose centres fall within the bbox are returned
+- **AND** no playgrounds outside the bbox contribute to any returned bucket
+
+#### Scenario: Clusters RPC scales cell size with zoom
+
+- **WHEN** the caller requests the same bbox at `z = 6` and at `z = 10`
+- **THEN** the `z = 10` response contains more (smaller) buckets than the `z = 6` response
+- **AND** the total `count` across all buckets is identical across zoom levels (no features lost to bucketing)
+
+### Requirement: Backend exposes centroid features scoped to bbox
+
+Each data-node SHALL expose a function returning lightweight per-playground rows (centroid + identity + completeness + filter attributes) for a bounding box, sized so that mid-zoom clients can render every playground without fetching polygon geometry.
+
+#### Scenario: Centroids RPC returns per-feature rows
+
+- **WHEN** a client calls `api.get_playground_centroids(min_lon, min_lat, max_lon, max_lat)` against a region with N playgrounds in the bbox
+- **THEN** the response contains exactly N rows
+- **AND** each row contains `osm_id`, `lon`, `lat`, `completeness` (one of `"complete"`, `"partial"`, `"missing"`), and `filter_attrs` (an object with boolean keys `has_water`, `for_baby`, `for_toddler`, `for_wheelchair`, `has_soccer`, `has_basketball`, `access_restricted`)
+
+#### Scenario: Centroid payload is compact
+
+- **WHEN** the response is measured for a 1000-playground bbox
+- **THEN** the uncompressed JSON is under 200 KB
+- **AND** no polygon geometry, no tag hstore, and no stats counts are included
+
+### Requirement: Backend exposes bbox-scoped playground polygons
+
+Each data-node SHALL expose a function returning full playground polygons scoped to an intersecting bbox, in the same response shape as the legacy `get_playgrounds`, so high-zoom clients can render polygons without fetching the whole region.
+
+#### Scenario: Bbox polygons RPC matches legacy shape
+
+- **WHEN** a client calls `api.get_playgrounds_bbox(min_lon, min_lat, max_lon, max_lat)` for a bbox intersecting the region
+- **THEN** the response is a GeoJSON `FeatureCollection`
+- **AND** each feature has the same properties as a feature from `api.get_playgrounds(relation_id)` — `osm_id`, `name`, `leisure`, `operator`, `access`, `surface`, `area`, `tree_count`, `bench_count`, and the rest
+
+#### Scenario: Bbox polygons RPC honours intersection
+
+- **WHEN** the bbox intersects only part of the region
+- **THEN** only playgrounds whose geometry intersects the bbox are returned
+- **AND** a playground whose polygon partially overlaps the bbox edge is still returned in full (not clipped)
+
+### Requirement: get_meta includes completeness counts and data version
+
+The `api.get_meta` response SHALL include per-backend aggregate completeness counts and a data-version bump timestamp, so clients can render a macro view (proposal P2) and clients can invalidate cached responses after an import.
+
+#### Scenario: get_meta carries completeness counts
+
+- **WHEN** a client calls `api.get_meta`
+- **THEN** the response includes `complete`, `partial`, `missing` integer fields in addition to the existing `playground_count`
+- **AND** `playground_count = complete + partial + missing`
+
+#### Scenario: get_meta carries data_version
+
+- **WHEN** the importer successfully completes
+- **THEN** the next call to `api.get_meta` returns a `data_version` ISO-8601 timestamp equal to the import completion time
+- **AND** repeated calls return the same `data_version` until the next successful import
+
+### Requirement: Legacy get_playgrounds is retained one release, marked deprecated
+
+The existing `api.get_playgrounds(relation_id)` function SHALL remain callable and correct for one release cycle after this change lands, so tests and external consumers can migrate. It SHALL be annotated as deprecated at the database level.
+
+#### Scenario: Legacy RPC still responds
+
+- **WHEN** a client calls `api.get_playgrounds(relation_id)` after this change is deployed
+- **THEN** the response is unchanged from before this change
+- **AND** a SQL `COMMENT` on the function names the intended replacement (`get_playgrounds_bbox`) and signals deprecation
+
+### Requirement: Client orchestrates three layers by zoom
+
+The standalone client SHALL render playground data through exactly three zoom-scoped layers (cluster, centroid, polygon) whose visibility is determined by the current map zoom, and SHALL refetch the relevant layer's source on each debounced `moveend`.
+
+#### Scenario: Zoom ≤ 10 shows the cluster layer only
+
+- **WHEN** the map zoom is less than or equal to `clusterMaxZoom` (default 10)
+- **THEN** the cluster layer is visible
+- **AND** the centroid layer and polygon layer are hidden (but not destroyed)
+
+#### Scenario: Zoom 11–13 shows the centroid layer only
+
+- **WHEN** the map zoom is between `clusterMaxZoom + 1` and `centroidMaxZoom` (default 11 to 13)
+- **THEN** the centroid layer is visible
+- **AND** the cluster layer and polygon layer are hidden
+
+#### Scenario: Zoom ≥ 14 shows the polygon layer only
+
+- **WHEN** the map zoom is greater than `centroidMaxZoom`
+- **THEN** the polygon layer is visible, rendered with `playgroundStyleFn`
+- **AND** the cluster layer and centroid layer are hidden
+- **AND** `playgroundSourceStore` is set to the polygon layer's source
+
+#### Scenario: Moveend refetches the active layer
+
+- **WHEN** the user pans or zooms and the resulting `moveend` settles
+- **THEN** within 300 ms (debounce) the active tier's fetcher is invoked with the new bbox
+- **AND** any in-flight request for the same layer from a previous `moveend` is cancelled via `AbortController`
+
+#### Scenario: Tier not available falls back
+
+- **WHEN** the active tier's RPC returns HTTP 404 (backend older than this change)
+- **THEN** the client logs a one-time warning and falls back to `api.get_playgrounds(relation_id)` for that backend
+- **AND** the cluster / centroid layers remain empty for the affected backend
+
+### Requirement: Clusters are rendered as completeness-segmented stacked rings
+
+Cluster features SHALL be rendered on the map as a ring divided into three segments proportional to the complete / partial / missing counts, with the total count as a number at the centre.
+
+#### Scenario: Ring segments are proportional
+
+- **WHEN** a cluster has `complete = 6`, `partial = 19`, `missing = 22` (count = 47)
+- **THEN** the rendered ring has three segments whose arc lengths are proportional to 6 : 19 : 22
+- **AND** segment colours match the polygon completeness colours (`#155215`, `#92400e`, `#991b1b`)
+- **AND** the centre displays `47` in bold tabular numerals
+
+#### Scenario: Single-feature cluster collapses to a dot
+
+- **WHEN** a cluster has `count = 1`
+- **THEN** no ring is drawn
+- **AND** a solid dot is rendered in the single feature's completeness colour
+- **AND** the dot size matches the centroid tier's default point size
+
+#### Scenario: Ring renders scale with count
+
+- **WHEN** cluster counts are 5, 25, 100, and 500 respectively
+- **THEN** the outer ring radius is 12, 14, 18, and 22 CSS pixels respectively
+- **AND** the number remains readable at every size
+
+#### Scenario: Filter-badge appears only when filters are active and zoom is centroid or above
+
+- **WHEN** the filter store has any active filter and the zoom is in the centroid tier (11–13)
+- **THEN** each rendered cluster shows a small "N match" pill below the count, where N is the filter-matching child count
+- **WHEN** the zoom is in the cluster tier (≤ 10) or no filter is active
+- **THEN** no filter badge is rendered
+
+#### Scenario: Cluster click zooms to extent
+
+- **WHEN** the user clicks a cluster
+- **THEN** the map view animates to fit the cluster's child-feature bounding extent
+- **AND** no selection is created (the hash is not modified)
+
+### Requirement: Deeplink restore hydrates the polygon tier on demand
+
+URL-hash restore of a specific playground SHALL work even when the polygon layer is not currently populated (i.e. the user's initial zoom is below 14).
+
+#### Scenario: Deeplink at low zoom hydrates one feature
+
+- **WHEN** a user opens `/#W1234567` on a page that loads at zoom 6
+- **THEN** the client locates the playground's position via `api.get_nearest_playgrounds` (or equivalent lookup)
+- **AND** fetches a small `get_playgrounds_bbox` response centred on that position
+- **AND** selects the matched feature, fitting the view to its extent at a zoom in the polygon tier

--- a/openspec/changes/add-tiered-playground-delivery/tasks.md
+++ b/openspec/changes/add-tiered-playground-delivery/tasks.md
@@ -1,0 +1,62 @@
+## 1. Backend — tiered RPCs
+
+- [ ] 1.1 Add `api.get_playground_clusters(z int, min_lon float8, min_lat float8, max_lon float8, max_lat float8)` in `importer/api.sql` — buckets features by `ST_SnapToGrid` using `cell_size_m` derived from `z`; returns `{lon, lat, count, complete, partial, missing}` per bucket as a JSON array
+- [ ] 1.2 Add `api.get_playground_centroids(min_lon, min_lat, max_lon, max_lat)` returning per-playground rows: `osm_id`, `lon`, `lat`, `completeness` ('complete'|'partial'|'missing'), packed filter-attrs object
+- [ ] 1.3 Add `api.get_playgrounds_bbox(min_lon, min_lat, max_lon, max_lat)` — same response shape as `get_playgrounds` but scoped to bbox intersection; reuses the `playground_stats` materialised view
+- [ ] 1.4 Extend `api.get_meta` to include `{complete, partial, missing}` alongside the existing `playground_count` (sums over `playground_stats`)
+- [ ] 1.5 Add `COMMENT ON FUNCTION api.get_playgrounds(bigint) IS 'DEPRECATED: use get_playgrounds_bbox. Scheduled for removal in the release after next.'`
+- [ ] 1.6 Add a computed `grid_cell` column or expression to `playground_stats` (or inline in the cluster function) — whichever benchmarks faster on a Germany-sized dataset
+- [ ] 1.7 Add `import_version` (or `data_version`) bump timestamp, written on successful import and surfaced via `get_meta`, for client-side cache-bust
+- [ ] 1.8 Grant EXECUTE on all three new functions to `web_anon`
+- [ ] 1.9 Update `dev/seed/seed.sql` so `make seed-load` exercises all three new RPCs with the 4-playground fixture
+
+## 2. Client — API layer + fetchers
+
+- [ ] 2.1 Add `fetchPlaygroundClusters(zoom, extentEPSG3857, baseUrl)`, `fetchPlaygroundCentroids(extentEPSG3857, baseUrl)`, `fetchPlaygroundsBbox(extentEPSG3857, baseUrl)` in `app/src/lib/api.js`
+- [ ] 2.2 All three fetchers accept an `AbortSignal` so moveend handlers can cancel in-flight requests
+- [ ] 2.3 Mark `fetchPlaygrounds` deprecated with a JSDoc `@deprecated` tag and a one-time console warning on first call
+- [ ] 2.4 Extend `fetchMeta` typing to surface the new `{complete, partial, missing}` and `data_version` fields
+- [ ] 2.5 Add `clusterMaxZoom` and `centroidMaxZoom` to `app/src/lib/config.js` (defaults 10 and 13); surface via `window.APP_CONFIG` and the nginx entrypoint
+
+## 3. Client — zoom-tier orchestrator
+
+- [ ] 3.1 Replace the `fetchPlaygrounds` call in `StandaloneApp.svelte:onMount` with a `moveend`-driven orchestrator that dispatches to the right fetcher based on `view.getZoom()`
+- [ ] 3.2 Orchestrator debounces by 300 ms and uses `AbortController` to cancel any request superseded by a later moveend
+- [ ] 3.3 Three layers are created up front: `clusterLayer`, `centroidLayer`, `polygonLayer`; visibility is toggled on zoom transition, not recreated
+- [ ] 3.4 `clusterLayer` source is populated from `get_playground_clusters` with no client-side clustering (server buckets are authoritative at that zoom)
+- [ ] 3.5 `centroidLayer` wraps a Supercluster instance fed from `get_playground_centroids`; on zoom change within the centroid tier, re-project Supercluster output; on pan, refetch centroids for the new bbox and reindex
+- [ ] 3.6 `polygonLayer` continues to use the existing `playgroundStyleFn`; `playgroundSourceStore` is published only when this layer is active
+- [ ] 3.7 Gracefully fall back: if a tier's RPC 404s (backend upgrade in progress), the orchestrator tries the next tier up and logs a one-time warning
+
+## 4. Client — cluster renderer + Supercluster integration
+
+- [ ] 4.1 Add `supercluster` to `app/package.json` dependencies; run `npm install` in `app/`
+- [ ] 4.2 Create `app/src/components/ClusterLayer.svelte` — encapsulates a Supercluster instance, the OL source/layer pair, and the canvas renderer
+- [ ] 4.3 Implement `stackedRingRenderer` in `app/src/lib/clusterStyle.js` — canvas 2D draw of the ring with complete/partial/missing segments + count; cached by `(count_bucket, r_frac, p_frac, m_frac)` with a WeakMap-keyed bitmap pool
+- [ ] 4.4 Single-child clusters render as a single completeness-colour dot (no ring, matches polygon colour at higher zoom)
+- [ ] 4.5 Cluster click zooms to the cluster's bounding extent with `view.fit`, same padding behaviour as the existing polygon select
+- [ ] 4.6 Filter badge: below the count, a small pill "N match" rendered in the same canvas when `$filterStore` has any active filter; only on the centroid tier and above (not at zoom ≤ 10)
+- [ ] 4.7 Hover on a cluster shows a small tooltip (reuse `HoverPreview`) listing aggregate counts
+
+## 5. Client — selection + deeplink adaptation
+
+- [ ] 5.1 `AppShell.svelte::tryRestoreFromHash` falls back to a hydration fetch (`get_playgrounds_bbox` centred on the osm_id's last-known position from `get_nearest_playgrounds`) when the polygon layer is empty
+- [ ] 5.2 `NearbyPlaygrounds` fallback (distance scan of `playgroundSource.getFeatures()`) is removed — it's been a soft fallback since Overpass mode; the PostgREST `get_nearest_playgrounds` path is always available now
+- [ ] 5.3 Cluster-click does not set a hash (it's a navigation gesture, not a selection)
+
+## 6. Docs
+
+- [ ] 6.1 Create `docs/reference/api.md` documenting the three tiered RPCs with request/response examples and zoom thresholds
+- [ ] 6.2 Update `CLAUDE.md` "Key frontend architecture" section to describe the three layers and the moveend orchestrator; keep the old description under a `<!-- legacy -->` comment until archive
+- [ ] 6.3 Update `docs/reference/api.md` cross-link from the main federation / architecture doc
+- [ ] 6.4 Add `Reference → API` to `mkdocs.yml` nav
+
+## 7. Verification
+
+- [ ] 7.1 Unit: `stackedRingRenderer` bitmap cache keys round-trip for a sample of count/ratio tuples
+- [ ] 7.2 Playwright: zoom-in from 6 to 18, assert cluster → centroid → polygon transitions happen at the configured thresholds and no visible gap in count
+- [ ] 7.3 Playwright: pan at zoom 12 across the Fulda seed region, assert centroid layer refetches and count matches expected
+- [ ] 7.4 Manual: `make docker-build && make up` on the 4-playground seed; click a cluster at zoom 10, verify fit-to-extent works
+- [ ] 7.5 Manual: performance sanity on a Berlin-sized extract — `npm run build` + serve, confirm first-paint map is interactive in under 2 seconds
+- [ ] 7.6 Legacy: `fetchPlaygrounds` calls log the deprecation warning exactly once per session
+- [ ] 7.7 `openspec validate add-tiered-playground-delivery` passes before archive

--- a/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/design.md
+++ b/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Spielplatzkarte uses `docker compose run --rm importer` (wrapped as `make import`) to download a PBF file and load OSM data into PostGIS. This is a one-shot operation with no scheduling built in. On a typical Linux server deployment, systemd is the standard init and scheduling system. A service + timer unit pair is the idiomatic way to run recurring Docker Compose tasks on such systems.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide ready-to-use `spielplatzkarte-import.service` and `spielplatzkarte-import.timer` unit files under `deploy/`
+- Fire the importer once a week; catch missed runs on next boot (`Persistent=true`)
+- Pick up project path and credentials from the deployed `.env` file — no hardcoded values
+- Document how to install and enable the units in `CLAUDE.md`
+
+**Non-Goals:**
+- Cron-based scheduling (systemd timer is sufficient and more capable on modern Linux)
+- Kubernetes / cloud-native scheduling (out of scope for this self-hosted project)
+- Alerting or failure notifications (can be layered on top later via `OnFailure=`)
+- Modifying the importer container or `Makefile` itself
+
+## Decisions
+
+**1. `docker compose run --rm importer` vs `make import`**
+Use `docker compose run --rm importer` directly in the unit file. `make` may not be installed on all servers; `docker compose` is a direct dependency that must already be present.
+
+**2. `WorkingDirectory` + `EnvironmentFile` vs hardcoded paths**
+Set `WorkingDirectory=/opt/spielplatzkarte` as a placeholder comment that operators must adjust. Load `.env` via `EnvironmentFile=%h/.env` where `%h` expands to the service user's home, keeping secrets out of the unit file. Document this clearly.
+
+**3. `OnCalendar=weekly` vs explicit day/time**
+`OnCalendar=weekly` (Sunday 00:00 local time) is the simplest expression. Operators can override to e.g. `OnCalendar=Sun 03:00` in an override drop-in without editing the shipped file.
+
+**4. `User=` in the service unit**
+Leave `User=` commented out as a placeholder. The operator must run `docker compose` as the user that owns the deployment directory and is in the `docker` group. A hardcoded value would be wrong for most setups.
+
+## Risks / Trade-offs
+
+- **Operator must edit `WorkingDirectory`** — the unit will fail silently (or not start) if the path is wrong. Mitigation: add a clear comment and document the required edit step.
+- **`docker` group membership** — if the service user isn't in the `docker` group the run will fail with a permission error. Mitigation: document this prerequisite.
+- **Long-running import blocks concurrent `make up` restarts** — the importer is a separate container so it won't affect the running stack, but a simultaneous `make import` call could conflict. Mitigation: low risk in practice (weekly cadence); note in docs.
+
+## Migration Plan
+
+1. Copy `deploy/spielplatzkarte-import.service` and `deploy/spielplatzkarte-import.timer` to `/etc/systemd/system/`
+2. Edit `WorkingDirectory=` and `User=` in the service unit to match the deployment
+3. `systemctl daemon-reload`
+4. `systemctl enable --now spielplatzkarte-import.timer`
+5. Verify with `systemctl status spielplatzkarte-import.timer`
+
+Rollback: `systemctl disable --now spielplatzkarte-import.timer && rm /etc/systemd/system/spielplatzkarte-import.*`

--- a/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/proposal.md
+++ b/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Spielplatzkarte deployments require OSM data to be kept fresh, but the importer must currently be triggered manually. Operators need a drop-in scheduling solution so data is updated automatically without custom cron jobs or manual intervention.
+
+## What Changes
+
+- Add `deploy/spielplatzkarte-import.service` — a systemd service unit that runs `docker compose run --rm importer` in the project directory, picking up credentials from `.env`
+- Add `deploy/spielplatzkarte-import.timer` — a systemd timer unit that fires the service weekly (`OnCalendar=weekly`) and is `Persistent=true` so missed runs are caught on next boot
+- Document the install/enable procedure in `CLAUDE.md`
+
+## Capabilities
+
+### New Capabilities
+- `scheduled-importer`: Automated weekly OSM data import via systemd service + timer unit pair
+
+### Modified Capabilities
+
+## Impact
+
+- New files under `deploy/` (no changes to existing source code)
+- Operators must have systemd available on the host (standard on most Linux servers)
+- Requires the project to be checked out at a known path on the server (set via `WorkingDirectory=` in the service unit)
+- `.env` must exist at the project root (already required for `make up`)

--- a/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/specs/scheduled-importer/spec.md
+++ b/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/specs/scheduled-importer/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Service unit runs the importer via Docker Compose
+The system SHALL provide a `deploy/spielplatzkarte-import.service` systemd service unit that executes `docker compose run --rm importer` in the project directory, loading credentials from the `.env` file via `EnvironmentFile=`.
+
+#### Scenario: Service unit executes the importer container
+- **WHEN** the service unit is started (manually or by the timer)
+- **THEN** `docker compose run --rm importer` is invoked in the configured `WorkingDirectory`
+- **THEN** the importer container runs to completion and is removed afterwards
+
+#### Scenario: Service unit picks up environment from .env
+- **WHEN** the service unit starts
+- **THEN** environment variables from `.env` (e.g. `OSM_RELATION_ID`, `PBF_URL`) are available to the Docker Compose invocation
+
+### Requirement: Timer unit triggers the importer weekly
+The system SHALL provide a `deploy/spielplatzkarte-import.timer` systemd timer unit that activates the service unit once a week with `Persistent=true`.
+
+#### Scenario: Timer fires on the weekly schedule
+- **WHEN** the configured weekly calendar expression elapses
+- **THEN** `spielplatzkarte-import.service` is started automatically
+
+#### Scenario: Missed run is caught on next boot
+- **WHEN** the system was offline during a scheduled run
+- **THEN** `spielplatzkarte-import.service` is started once on the next boot due to `Persistent=true`
+
+### Requirement: Unit files are documented for installation
+The project documentation SHALL describe how to copy, configure, and enable the unit files so operators can set up automated imports without prior systemd expertise.
+
+#### Scenario: Operator follows the documented install steps
+- **WHEN** an operator follows the documented procedure (copy units, edit `WorkingDirectory` and `User=`, `systemctl enable --now`)
+- **THEN** the timer is active and the importer runs automatically each week

--- a/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/tasks.md
+++ b/openspec/changes/archive/2026-04-13-systemd-weekly-importer-timer/tasks.md
@@ -1,0 +1,21 @@
+## 1. Create deploy directory and service unit
+
+- [x] 1.1 Create `deploy/` directory at the project root
+- [x] 1.2 Create `deploy/spielplatzkarte-import.service` with `ExecStart=docker compose run --rm importer`, `WorkingDirectory=` placeholder, `EnvironmentFile=` pointing to `.env`, and a commented-out `User=` placeholder
+- [x] 1.3 Verify the service unit passes `systemd-analyze verify` (or manual review for correctness)
+
+## 2. Create timer unit
+
+- [x] 2.1 Create `deploy/spielplatzkarte-import.timer` with `OnCalendar=weekly`, `Persistent=true`, and `[Install] WantedBy=timers.target`
+- [x] 2.2 Ensure the timer unit references `spielplatzkarte-import.service` via `Unit=` (or relies on the matching name convention)
+
+## 3. Document installation
+
+- [x] 3.1 Add a "Automated weekly import" section to `CLAUDE.md` documenting: copy units to `/etc/systemd/system/`, edit `WorkingDirectory=` and `User=`, run `systemctl daemon-reload && systemctl enable --now spielplatzkarte-import.timer`
+- [x] 3.2 Document the rollback/disable procedure in the same section
+- [x] 3.3 Add a prerequisite note: service user must be in the `docker` group
+
+## 4. Verification
+
+- [x] 4.1 Confirm `deploy/spielplatzkarte-import.service` and `deploy/spielplatzkarte-import.timer` exist in the repo
+- [x] 4.2 Confirm documentation covers all acceptance criteria from issue #60

--- a/openspec/changes/archive/2026-04-17-add-playwright-ci/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-add-playwright-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/archive/2026-04-17-add-playwright-ci/design.md
+++ b/openspec/changes/archive/2026-04-17-add-playwright-ci/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The project currently has a single CI workflow (`build.yml`) that verifies the Vite build succeeds and publishes Docker images on merge. There are no automated browser tests. The frontend is a plain JS ES Modules app (no framework) that loads playground data from either PostgREST or Overpass. When `apiBaseUrl` is empty the app uses Overpass directly — this "local dev mode" means the full UI can be exercised in CI without a running database.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Run Playwright tests against the production Vite build on every PR and push to main
+- Cover the critical user paths: map load, playground selection, info panel rendering, ESC / URL hash behaviour
+- Upload a Playwright HTML report as a CI artefact on test failure for easy debugging
+- Keep CI fast: single browser (Chromium), parallel test workers, cached browser binaries
+
+**Non-Goals:**
+- Cross-browser coverage (Firefox / WebKit) — can be added incrementally
+- Testing the PostgREST / Docker stack — Overpass fallback is sufficient for frontend correctness
+- Visual regression / screenshot diffing
+- 100% coverage — a focused smoke suite is the goal
+
+## Decisions
+
+### Run against `vite preview` (production build), not `vite dev`
+
+**Why**: `vite preview` serves the actual production bundle, matching what users see. `vite dev` uses HMR transforms that don't exist in production; catching production-only issues (e.g. broken imports after tree-shaking) is valuable.
+
+**Alternative considered**: `vite dev` — faster startup, but tests against a different artefact.
+
+### Use Playwright's built-in `webServer` config
+
+**Why**: Playwright starts and stops the preview server automatically, handles port conflicts, and retries the health check before running tests. No manual process management in the workflow.
+
+**Alternative considered**: `&` backgrounding in shell + `sleep` — fragile, harder to debug.
+
+### Cache Playwright browsers by `@playwright/test` version
+
+**Why**: Browser binaries are ~100–300 MB each. Caching by the package version means re-download only on version bumps, keeping CI fast.
+
+**Cache key**: `playwright-${{ hashFiles('package-lock.json') }}` — regenerates when any dep changes (safe over-invalidation, simpler than hashing only `@playwright/test`).
+
+### Chromium only for the initial suite
+
+**Why**: Single browser keeps the suite fast and the initial signal clear. The security-critical paths (XSS escaping, href validation) are browser-agnostic at the JS level — Chromium is sufficient to validate them.
+
+### Separate workflow file (`playwright.yml`), not merged into `build.yml`
+
+**Why**: Playwright tests need a built app (`needs: build` or its own build step). Keeping them separate makes it easy to re-run tests independently, add manual triggers, or adjust concurrency without touching the Docker-publishing workflow.
+
+## Risks / Trade-offs
+
+- **Overpass API reliability in CI**: tests that load live playground data from Overpass can flake if Overpass is slow or rate-limits CI runners. Mitigation: use `page.route()` to intercept Overpass requests and return a small fixture for data-dependent tests; leave smoke tests (map renders, URL hash) against the live API.
+- **`vite preview` port conflicts**: If another job on the same runner holds port 4173, tests fail. Mitigation: Playwright `webServer.port` config will pick a free port; set `reuseExistingServer: false` in CI.
+- **Test flakiness from map tile loading**: OpenLayers tile requests are async. Mitigation: wait for `networkidle` or assert on DOM state (panel visibility) rather than tile rendering.
+
+## Open Questions
+
+- Should the workflow post a comment to the PR with a link to the test report? (Nice-to-have, not in scope for initial cut.)

--- a/openspec/changes/archive/2026-04-17-add-playwright-ci/proposal.md
+++ b/openspec/changes/archive/2026-04-17-add-playwright-ci/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The project has no automated browser tests — correctness is verified manually, which means regressions in the playground detail panel, map interactions, and security fixes (XSS escaping, contact links) can silently ship. Adding Playwright in CI provides a fast safety net that runs on every pull request.
+
+## What Changes
+
+- Add Playwright as a dev dependency with a base configuration
+- Add a GitHub Actions workflow that installs dependencies, builds the app, starts a preview server, and runs Playwright tests against it
+- Add an initial test suite covering the critical user paths: map loads, playground selection, info panel rendering, ESC key / URL hash behaviour
+- Add `make test` target wiring into the existing Makefile
+
+## Capabilities
+
+### New Capabilities
+
+- `playwright-ci`: GitHub Actions workflow that runs Playwright browser tests on every PR and push to main; reports results as a workflow summary and uploads HTML report as an artefact on failure
+
+### Modified Capabilities
+
+<!-- none — no existing spec-level behaviour changes -->
+
+## Impact
+
+- **New files**: `.github/workflows/playwright.yml`, `playwright.config.js`, `tests/` directory
+- **Modified files**: `package.json` (dev dependency + test script), `Makefile` (`make test` target)
+- **Dependencies**: `@playwright/test` added as a dev dependency; Playwright browsers downloaded in CI via cache
+- **No runtime impact**: all changes are dev/CI only, no production code modified

--- a/openspec/changes/archive/2026-04-17-add-playwright-ci/specs/playwright-ci/spec.md
+++ b/openspec/changes/archive/2026-04-17-add-playwright-ci/specs/playwright-ci/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: CI workflow runs Playwright tests on every PR and push to main
+The system SHALL provide a GitHub Actions workflow (`playwright.yml`) that builds the app, starts a preview server, and runs the Playwright test suite on every pull request targeting `main` and every push to `main`.
+
+#### Scenario: Workflow triggers on pull request
+- **WHEN** a pull request is opened or updated against `main`
+- **THEN** the `playwright` workflow runs automatically
+
+#### Scenario: Workflow triggers on push to main
+- **WHEN** a commit is pushed to `main`
+- **THEN** the `playwright` workflow runs automatically
+
+#### Scenario: Tests pass on a clean build
+- **WHEN** the workflow runs and all tests pass
+- **THEN** the workflow job completes with a green status
+
+#### Scenario: Test report uploaded on failure
+- **WHEN** one or more Playwright tests fail
+- **THEN** the workflow uploads the Playwright HTML report as a workflow artefact named `playwright-report`
+
+---
+
+### Requirement: Map loads and renders on startup
+The app SHALL load and display a map when the page is opened.
+
+#### Scenario: Map canvas is visible
+- **WHEN** the page is loaded
+- **THEN** an OpenLayers map canvas element is visible in the viewport
+
+#### Scenario: Page title is set
+- **WHEN** the page is loaded
+- **THEN** the document title contains "Spielplatzkarte"
+
+---
+
+### Requirement: Playground selection opens info panel
+The app SHALL open the info panel when a playground feature is clicked on the map.
+
+#### Scenario: Info panel appears after playground click
+- **WHEN** a playground marker is clicked on the map
+- **THEN** the info panel becomes visible
+
+#### Scenario: URL hash is set on selection
+- **WHEN** a playground marker is clicked on the map
+- **THEN** the URL hash is updated to contain the playground's OSM ID
+
+---
+
+### Requirement: ESC key closes the info panel and clears the URL hash
+The app SHALL close the info panel and clear the URL hash when the ESC key is pressed while a playground is selected.
+
+#### Scenario: ESC closes panel
+- **WHEN** a playground is selected and the ESC key is pressed
+- **THEN** the info panel is no longer visible
+
+#### Scenario: ESC clears URL hash
+- **WHEN** a playground is selected and the ESC key is pressed
+- **THEN** the URL hash is empty
+
+---
+
+### Requirement: URL hash restores playground selection on page load
+The app SHALL re-select the playground identified by the URL hash when the page is loaded with a hash present.
+
+#### Scenario: Hash on load opens info panel
+- **WHEN** the page is loaded with a URL hash containing a valid playground OSM ID
+- **THEN** the info panel becomes visible with data for that playground
+
+---
+
+### Requirement: OSM field values are rendered as plain text, not HTML
+The app SHALL escape special HTML characters in OSM tag values so that crafted values cannot inject HTML or execute scripts.
+
+#### Scenario: HTML characters in playground name are escaped
+- **WHEN** a playground has a name containing `<`, `>`, or `&` characters
+- **THEN** those characters are displayed as visible text in the info panel, not interpreted as HTML
+
+#### Scenario: Script tag in description does not execute
+- **WHEN** a playground's description field contains a `<script>` tag value (intercepted via route mock)
+- **THEN** no script executes and the literal text is visible in the panel

--- a/openspec/changes/archive/2026-04-17-add-playwright-ci/tasks.md
+++ b/openspec/changes/archive/2026-04-17-add-playwright-ci/tasks.md
@@ -1,0 +1,39 @@
+## 1. Playwright Setup
+
+- [x] 1.1 Install `@playwright/test` as a dev dependency (`npm install --save-dev @playwright/test`)
+- [x] 1.2 Add `"test": "playwright test"` script to `package.json`
+- [x] 1.3 Create `playwright.config.js` with `webServer` pointing at `vite preview`, Chromium only, `reuseExistingServer: !process.env.CI`
+- [x] 1.4 Add `test-results/` and `playwright-report/` to `.gitignore`
+- [x] 1.5 Add `make test` target to `Makefile` that runs `npm test`
+
+## 2. Test Fixtures
+
+- [x] 2.1 Create `tests/fixtures/playground.json` — minimal Overpass API response containing one playground feature with a name containing `<script>` and HTML special characters, to be used as a route mock in XSS tests
+
+## 3. Test Suite
+
+- [x] 3.1 Create `tests/smoke.spec.js` — map canvas visible, page title contains "Spielplatzkarte"
+- [x] 3.2 Create `tests/selection.spec.js` — click playground → panel visible, URL hash set; ESC → panel hidden, hash cleared
+- [x] 3.3 Create `tests/hash-restore.spec.js` — load page with hash → panel opens for that playground (uses route mock to control data)
+- [x] 3.4 Create `tests/xss.spec.js` — intercept Overpass/PostgREST response with crafted field values, assert characters rendered as text not HTML
+
+## 4. GitHub Actions Workflow
+
+- [x] 4.1 Create `.github/workflows/e2e.yml` — triggers on push to `main` and PRs to `main`, `needs: build` job from `build.yml` is NOT reused (standalone build step for independence)
+- [x] 4.2 Pin all action SHAs and include version comments (`# vX.Y`)
+- [x] 4.3 Add `actions/cache` step for Playwright browsers keyed on `playwright-${{ hashFiles('package-lock.json') }}`
+- [x] 4.4 Add `Upload Playwright report` step using `actions/upload-artifact` that runs `if: failure()` and retains the report for 30 days
+- [x] 4.5 Sync `package-lock.json` after installing the new dev dependency
+
+## 5. Verification
+
+- [x] 5.1 Run `make test` locally and confirm all tests pass against `vite preview`
+- [x] 5.2 Confirm `playwright-report/` is not tracked by git
+
+### Review Findings
+
+- [x] [Review][Patch] XSS probe `exposeFunction` registered after navigation — probe can never fire [tests/xss.spec.js]
+- [x] [Review][Patch] Fixture name field lacks `<script>` tag — spec 2.1 requires "name containing `<script>` and HTML special characters" [tests/fixtures/playground.json]
+- [x] [Review][Defer] `hash-restore.spec.js` first test duplicates `selection.spec.js` first test — deferred, pre-existing test organisation choice
+- [x] [Review][Defer] `restoreFromHash` silently hangs if fixture returns empty FeatureCollection — deferred, pre-existing production code behaviour
+- [x] [Review][Defer] `webServer.timeout: 120_000` may be insufficient on cold CI runner with no build cache — deferred, speculative

--- a/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/design.md
+++ b/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`build.yml` uses `docker/metadata-action` to compute image tags. The `type=raw,value=latest` rule currently fires on any `main` push via `enable=${{ github.ref == 'refs/heads/main' }}`. Semver tags (`v*`) drive `type=semver` rules and do not set `latest` explicitly — but because `type=raw,value=latest` also enables on `main`, every commit merged to main overwrites `:latest`.
+
+Both the app image (`ghcr.io/<repo>`) and the importer image (`ghcr.io/<repo>-importer`) are affected identically and must be changed in the same way.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Publish `:rc` on every push to `main` (merged PR)
+- Reserve `:latest` exclusively for version-tag releases (`v*`)
+- Keep the short-SHA tag on all pushes for traceability
+- Change both app and importer image metadata blocks
+
+**Non-Goals:**
+- Adding new workflow jobs or restructuring the pipeline
+- Changing the importer or app `Dockerfile`
+- Introducing additional tag strategies (e.g. `:edge`, `:nightly`)
+
+## Decisions
+
+**Replace `value=latest` with `value=rc` on the `main` branch condition**
+
+Both `meta` and `meta-importer` steps have:
+```yaml
+tags: |
+  type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+  type=semver,pattern={{version}}
+  type=semver,pattern={{major}}.{{minor}}
+  type=sha,prefix=
+```
+
+Change `value=latest` → `value=rc` in both blocks. The `enable=` condition stays identical — `:rc` is pushed on main, `:latest` is no longer pushed on main.
+
+For version tags, `type=semver,pattern={{version}}` and `type=semver,pattern={{major}}.{{minor}}` already produce `:x.y.z` and `:x.y`. To also push `:latest` on a version tag, add a second `type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}` rule (or rely on the Docker Hub / GHCR default — but since the current workflow never set it on tags, this is out of scope and left as a follow-up).
+
+**Alternative considered:** a separate workflow triggered on `release` event — rejected because the existing `build.yml` already covers the tagging logic; adding a second workflow duplicates the Docker build steps.
+
+## Risks / Trade-offs
+
+- **[Risk] Operators pulling `:latest` for staging get stale images after this change** → Mitigation: document in README that `:rc` is the new pre-release tag; `:latest` will not update until the next version release.
+- **[Risk] `:latest` is never pushed** until the next `v*` tag — a new deployment has no `:latest` image temporarily → Acceptable: `:rc` fills this role.
+
+## Migration Plan
+
+1. Merge the `build.yml` change to `main` — the next push immediately starts publishing `:rc`.
+2. `:latest` retains its last-pushed digest until overwritten by the next `v*` tag.
+3. No rollback needed — the tag name change is additive from GHCR's perspective.

--- a/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/proposal.md
+++ b/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current `build.yml` workflow tags main-branch container builds as `:latest`, which collides with stable release semantics — operators pulling `:latest` expect a tested release, not unversioned work-in-progress. Publishing an `:rc` tag on every PR merge gives testers a clearly-labelled pre-release image without polluting the `:latest` channel.
+
+## What Changes
+
+- On push to `main` (i.e. every merged PR): publish both the app image and importer image tagged `:rc` instead of `:latest`
+- On version tag (`v*`): continue publishing `:latest` + semver tags as today — no change
+- The short-SHA tag continues to be published on both triggers for traceability
+- `:latest` is no longer pushed on main merges — it becomes exclusively tied to version tags
+
+## Capabilities
+
+### New Capabilities
+
+- `rc-container-tag`: Build and push `:rc`-tagged container images (app + importer) on every push to `main`
+
+### Modified Capabilities
+
+- (none — the existing `:latest` tagging logic changes, but it lives in `build.yml` configuration, not a spec)
+
+## Impact
+
+- `.github/workflows/build.yml`: modify the `type=raw` tag rule — replace `value=latest` with `value=rc` for the `main` branch condition
+- Downstream: anyone currently pulling `:latest` for staging/testing should switch to `:rc`; `:latest` will only update on releases

--- a/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/specs/rc-container-tag/spec.md
+++ b/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/specs/rc-container-tag/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: RC image published on main push
+The CI pipeline SHALL publish container images tagged `:rc` for both the app image and the importer image on every push to the `main` branch (i.e. every merged PR).
+
+#### Scenario: App image tagged rc on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** the app image `ghcr.io/<repo>` is pushed with the `:rc` tag
+
+#### Scenario: Importer image tagged rc on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** the importer image `ghcr.io/<repo>-importer` is pushed with the `:rc` tag
+
+#### Scenario: RC tag not published on version tag push
+- **WHEN** a `v*` tag is pushed
+- **THEN** neither the app nor the importer image is tagged `:rc`
+
+### Requirement: latest tag reserved for version releases
+The CI pipeline SHALL NOT publish the `:latest` tag on pushes to `main`. The `:latest` tag SHALL only be published when a version tag (`v*`) is pushed.
+
+#### Scenario: Latest not overwritten on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** neither image is pushed with the `:latest` tag
+
+#### Scenario: Short-SHA tag still published
+- **WHEN** a commit is pushed to `main`
+- **THEN** both images are still pushed with the short commit SHA tag for traceability

--- a/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/tasks.md
+++ b/openspec/changes/archive/2026-04-17-ci-rc-container-on-merge/tasks.md
@@ -1,0 +1,9 @@
+## 1. Update build.yml tag rules
+
+- [x] 1.1 In the `meta` step (app image), change `type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}` to `type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}`
+- [x] 1.2 In the `meta-importer` step (importer image), apply the same `value=latest` → `value=rc` change
+
+## 2. Verification
+
+- [x] 2.1 Confirm the workflow YAML is valid (no syntax errors) by inspecting the changed lines
+- [x] 2.2 Merge to `main` and verify that `ghcr.io/<repo>:rc` and `ghcr.io/<repo>-importer:rc` are published and `:latest` is not updated

--- a/openspec/changes/archive/2026-04-19-hub-ui-parity/design.md
+++ b/openspec/changes/archive/2026-04-19-hub-ui-parity/design.md
@@ -1,0 +1,166 @@
+## Context
+
+Spielplatzkarte ships a single Svelte app that renders one of two entry points based on `APP_MODE`:
+
+- `APP_MODE=standalone` → `StandaloneApp.svelte` — full UI for a single regional backend.
+- `APP_MODE=hub` → `HubApp.svelte` — a thin wrapper that mounts the map, the playground detail panel, and an `InstancePanel` listing registered backends.
+
+`HubApp` and `StandaloneApp` share `components/Map.svelte` but otherwise duplicate nothing — `HubApp` was designed as an aggregation-only view, assuming users wanting the full feature set would use a standalone instance.
+
+That assumption no longer holds: operators deploying federated topologies want the hub to be the primary UI, not a secondary overview. The spieli.eu deployment makes this concrete — the hub is the landing page, and the lack of search / filters / locate / deep-link puts the hub at a feature deficit relative to its data-nodes.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Every user-facing feature in standalone mode is available in hub mode.
+- Standalone mode behaviour is byte-equivalent to today after the refactor.
+- Hub behaviour is **data-driven** — no hardcoded geography, no assumption that the hub spans Germany or any other specific region.
+- Layout cost of the backend-list UI stays small: collapsed pill by default, only expands on user action.
+- The refactor is testable via the existing Playwright setup; no new test framework.
+
+**Non-Goals**
+
+- Server-side changes (DB, SQL, PostgREST, importer).
+- Per-backend filter configuration or per-backend contribution flows.
+- Nested federation (hubs that aggregate other hubs).
+- Any visual redesign of widgets that already exist in standalone.
+- Support for deep-link schemes other than the URL hash (query params, path segments).
+
+## Decisions
+
+### D1 — Extract a shared `AppShell` component
+
+`AppShell.svelte` owns: layout, responsive breakpoints, all widgets that are mode-independent, keyboard shortcuts, and the map mounting. Data-dependent concerns are injected as props. Both mode-specific apps compose `AppShell`.
+
+Alternatives considered:
+
+- *HubApp wraps StandaloneApp* — rejected: `StandaloneApp` would need so many injected props (playground source, data loader, extent source, nearest fetcher, contribution links, topleft slot) that it becomes the shell in all but name, with a misleading file location.
+- *Single `App.svelte` with `{#if appMode === 'hub'}` branches* — rejected: hub-only imports (registry, instance panel) leak into the standalone bundle; conditional branches sprinkle through layout code and make either mode harder to reason about in isolation.
+
+### D2 — Data providers injected via props
+
+`AppShell` exposes:
+
+| Prop | Type | Purpose |
+|---|---|---|
+| `playgroundSource` | `VectorSource` | The OL source to render. Hub shares one across backends; standalone owns its own. |
+| `searchExtent` | `Readable<[minLon, minLat, maxLon, maxLat]>` | Reactive bounds store for Nominatim. |
+| `nearestFetcher` | `(lat, lon) => Promise<Feature[]>` | Returns distance-sorted nearest playgrounds. |
+| `dataContribLinks` | `{ wikiUrl: string, chatUrl: string \| null }` | Content for the contribution modal. |
+| `defaultBackendUrl` | `string` | Fallback backend URL when a feature has no `_backendUrl`. |
+| `instancePanel` | Svelte snippet (optional) | Rendered bottom-left above the scale line. |
+
+This keeps `AppShell` agnostic about how data is produced.
+
+### D3 — InstancePanel as pill + drawer, bottom-left
+
+Pill content: globe icon, `<N> Regionen · <M> Spielplätze`, where N is the registered backend count and M is the sum of `featureCount` across backends.
+
+Position: bottom-left. The scale-line is positioned **below** the pill (both today the scale-line and the new pill want the same anchor; pill wins, scale-line adjusts downward).
+
+Interaction:
+
+- Click pill → drawer slides up, contains the existing per-backend detail list (name, version, status, count).
+- ESC, outside click, or second pill tap → drawer collapses.
+- `aria-expanded` on pill, focus trap while drawer is open.
+
+Loading and error states are reflected in the pill itself:
+
+- Registry still loading → pill shows a small spinner and "Lade Instanzen …".
+- Registry fetch failed → pill shows a warning icon and "Registry nicht erreichbar".
+- Zero backends reachable → pill shows "0 Regionen" (drawer lists each with its error).
+
+Alternatives considered:
+
+- *Top-right stacked panel* — rejected: collides with Filter + Edit controls; vertical real-estate cost is too high.
+- *Top-right pill with drawer* — rejected: still crowds top-right; bottom-left is underused.
+
+### D4 — URL hash scheme: `#<slug>/W<osm_id>`
+
+Parsed shapes:
+
+```
+#W<osm_id>             — legacy; standalone behaves as today, hub broadcasts
+#<slug>/W<osm_id>      — new; <slug> identifies a backend in registry.json
+```
+
+Hub behaviour:
+
+- With slug → resolve slug to a backend via the registry, wait for that backend's features to load, select the matching osm_id.
+- Without slug → search all loaded backends' features; pick the first match. Log a console warning if more than one backend has the same osm_id (rare, but possible across overlapping regions).
+
+Standalone behaviour:
+
+- With or without slug → select by osm_id from the single configured backend. Slug is accepted but ignored (so shared links paste cleanly into either mode).
+
+Writing: when a playground is selected in hub, write `#<slug>/W<osm_id>` to `location.hash` using the feature's `_backendUrl` resolved back to a slug via the registry. If the backend has no slug, write the legacy form.
+
+Alternatives considered:
+
+- *Query parameter `?backend=<slug>&osm=<id>`* — rejected: would require history API use; hash is already the idiom in this app.
+- *Encoding the URL of the backend directly into the hash* — rejected: long, leaks infra details, breaks if a backend moves.
+
+### D5 — Aggregated search extent and initial map fit
+
+The registry already calls `get_meta` per backend, which returns a `bbox`. The registry exposes an aggregated-bbox store that emits the union of all individual bboxes (recomputed when any backend's meta arrives).
+
+`AppShell` consumes this store for two purposes:
+
+1. Initial `view.fit(aggregatedBbox, { padding })` — hub-mode only.
+2. `searchExtent` prop passed to `SearchBar` for Nominatim bounds.
+
+Rationale: one data source, two consumers, same data. Keeps hub behaviour correct for arbitrary backend sets (Swiss cantons, a single city, global federation).
+
+### D6 — Multi-backend nearest fetcher
+
+`registry.js` exports `fetchNearestAcrossBackends(lat, lon)`:
+
+1. For each reachable backend, fire `get_nearest_playgrounds?lat=&lon=` in parallel.
+2. Apply a per-backend timeout (e.g. 3 s) via `AbortController`.
+3. Merge results; re-sort by `distance_m` ascending; dedupe by `osm_id` keeping the nearest match.
+4. Return up to a configurable limit (default: 10, same as standalone).
+
+A failing or timed-out backend contributes zero results but does not block the user interaction — consistent with existing behaviour when `apiBaseUrl` is unset in standalone.
+
+### D7 — DataContribution links in hub mode
+
+Hub passes:
+
+```js
+{
+  wikiUrl: 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground',
+  chatUrl: null,
+}
+```
+
+`DataContributionModal` hides the chat-link section when `chatUrl` is null. Standalone continues to pass per-region values from its `regionPlaygroundWikiUrl` / `regionChatUrl` config. No new config knobs for hub.
+
+### D8 — `slug` field in `registry.json` (optional)
+
+Registry entry (full form):
+
+```json
+{
+  "slug":    "bw",
+  "name":    "Baden-Württemberg",
+  "url":     "https://bw.example.org/api"
+}
+```
+
+Slug is **optional**. When absent:
+
+- Deep-links to a specific backend via slug aren't possible for this entry, but everything else works (broadcast-search, aggregation, etc.).
+- `InstancePanelDrawer` still renders the entry by `name`.
+
+Backwards compatibility: existing registry files with just `{name, url}` entries continue to work. Both top-level shapes (`{instances: [...]}` and bare array) remain supported.
+
+Slug format: lowercase ASCII, digits, hyphens — validated at load time; invalid slugs logged and treated as missing.
+
+## Risks
+
+- **AppShell extraction touches the bulk of the frontend.** Regression risk is low (it's a move, not a rewrite) but needs end-to-end smoke coverage. Mitigation: run the existing Playwright suite against both modes after each task.
+- **Multi-backend nearest can be slow.** If several backends are unhealthy, the user waits for timeouts. Mitigation: per-backend timeout + parallel fetches, render partial results as they arrive (stretch).
+- **Pill + mobile bottom-sheet may fight for z-index.** Bottom-left on mobile is near the bottom-sheet drag handle. Mitigation: on mobile, collapse the drawer when the bottom-sheet is expanded; keep the pill visible but small.
+- **Coordination with `document-federated-hub-deployment`.** That in-flight change also plans `docs/reference/registry-json.md`. This change creates it first; the other change's tasks that reference it should be updated to cross-link rather than create.
+- **Slug collisions between registries.** Two hubs could both use `slug: "bw"` for different backends. Acceptable — slugs are scoped per registry, deep-links are per-deployment.

--- a/openspec/changes/archive/2026-04-19-hub-ui-parity/proposal.md
+++ b/openspec/changes/archive/2026-04-19-hub-ui-parity/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Hub mode today renders a stripped-down UI: only the map, the playground detail panel, and an InstancePanel listing backends. Every other user-facing feature that ships in standalone mode is missing — search, filters (chips + panel), locate button, zoom controls, hover preview, nearby-playground suggestions, data-contribution modal, mobile bottom-sheet, responsive layout, initial region-fit, and URL-hash deep linking.
+
+Operators running a federated deployment therefore get a visibly degraded experience compared to a single regional instance, and in practice often have to deploy a separate standalone instance alongside the hub to offer the full feature set. That defeats the point of the Hub as a first-class aggregation UI.
+
+The gap is structural: `HubApp.svelte` and `StandaloneApp.svelte` are independent components with no shared shell, so every widget added to standalone has to be re-implemented (or skipped) in hub. This change fixes that by extracting a shared `AppShell`, leaving standalone's behaviour unchanged while giving hub every feature automatically.
+
+## What Changes
+
+- **Extract a shared `AppShell` component** from `StandaloneApp.svelte` containing the map, all widgets, responsive logic, and URL-hash plumbing. Data-dependent concerns are injected as props (playground source, search extent, nearest-fetcher, data-contribution links).
+- **Refactor `StandaloneApp`** into a thin wrapper that composes `AppShell` with its single-backend providers. No user-visible behaviour change.
+- **Refactor `HubApp`** to compose the same `AppShell` with registry-driven providers — union-bbox extent, multi-backend nearest fetcher, generic OSM-wiki contribution link, shared playground source.
+- **Redesign `InstancePanel`** as a bottom-left pill showing `<N> Regionen · <M> Spielplätze`. Clicking the pill expands a drawer listing each backend's details. The scale-line shifts below the pill so the two don't overlap.
+- **Extend URL-hash scheme** to `#<slug>/W<osm_id>`. The `slug` comes from `registry.json` (new optional field). Standalone ignores the slug; hub uses it to scope selection to a specific backend. Legacy `#W<osm_id>` still works — standalone behaves as today, hub broadcasts across backends.
+- **Extend `registry.js`** with two new stores: an aggregated-bbox store (union of backends' `get_meta.bbox`) and a `fetchNearestAcrossBackends(lat, lon)` helper that queries each backend in parallel with a per-backend timeout and merges results.
+- **Add `docs/reference/registry-json.md`** — documenting the registry schema including the new `slug` field.
+
+Out of scope:
+
+- Any server-side (DB, SQL, PostgREST, importer) changes.
+- Per-backend filter configuration (filters are client-side and already apply uniformly to all features).
+- Per-backend data-contribution links in hub mode.
+- Nested hubs (hub-of-hubs).
+- Theming or visual redesign of existing widgets beyond InstancePanel.
+
+## Capabilities
+
+### New Capabilities
+
+- `hub-ui-parity`: Hub-mode deployments present the same user-facing feature set as standalone deployments (map, search, filters, locate, zoom, hover, nearby, contribution modal, responsive layout), with additional UI for backend aggregation (instance pill + drawer, backend-slug deep links, multi-backend nearest search, union-bbox extent).
+
+### Modified Capabilities
+
+- (none — no existing capability's contract changes)
+
+## Impact
+
+- `app/src/components/AppShell.svelte` — **new**, extracted from `StandaloneApp`, owns layout + widgets + responsive logic.
+- `app/src/standalone/StandaloneApp.svelte` — becomes a thin wrapper around `AppShell`.
+- `app/src/hub/HubApp.svelte` — composes `AppShell` with registry-driven providers.
+- `app/src/hub/InstancePanel.svelte` — redesigned as a pill; new `InstancePanelDrawer.svelte` for the expanded state.
+- `app/src/hub/registry.js` — adds aggregated-bbox store and `fetchNearestAcrossBackends`; exposes `slug` on backend records.
+- `app/src/components/Map.svelte` — URL-hash parsing moves to a shared helper.
+- `app/src/lib/deeplink.js` — **new**, shared hash parser/writer supporting both `#W<osm_id>` and `#<slug>/W<osm_id>`.
+- `app/src/lib/api.js` — no change (the multi-backend wrapper lives in `registry.js`).
+- `public/registry.json` (example, if present) — sample entry gains a `slug` field.
+- `docs/reference/registry-json.md` — **new**, schema reference for the registry file.
+- `docs/reference/federation.md` — updated to mention the new hub UI and deep-link scheme.
+
+No changes to `compose.yml`, `.env.example`, any SQL, or any CI config.

--- a/openspec/changes/archive/2026-04-19-hub-ui-parity/specs/hub-ui-parity/spec.md
+++ b/openspec/changes/archive/2026-04-19-hub-ui-parity/specs/hub-ui-parity/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: Feature parity with standalone
+
+Hub-mode deployments SHALL render the same user-facing feature set as standalone-mode deployments: map, playground detail panel, search bar, filter chips, filter panel, locate button, zoom controls, hover preview, nearby-playground suggestions, data-contribution modal, and responsive mobile bottom-sheet.
+
+#### Scenario: Hub loads with reachable backends
+
+- **WHEN** a user opens a hub deployment and at least one backend is reachable
+- **THEN** every standalone-mode widget is rendered and interactive
+- **AND** no widget is hidden or disabled solely because `APP_MODE=hub`
+
+#### Scenario: Hub search uses aggregated extent
+
+- **WHEN** a user types a query in the search bar in hub mode
+- **THEN** Nominatim is called with `viewbox` equal to the union of all backends' `get_meta.bbox` values
+- **AND** if no backend has reported metadata yet, the search falls back to an unbounded query
+
+#### Scenario: Hub initial map fit
+
+- **WHEN** the hub loads and all backends have reported `get_meta`
+- **THEN** the map view is fit to the union of their bounding boxes with standard padding
+- **AND** if only one backend is registered the view is fit to that backend's bbox
+
+### Requirement: Backend instance visibility
+
+The hub SHALL display a collapsed pill in the bottom-left corner showing the count of registered regions and the summed playground count, expandable into a drawer that lists each backend's name, version, current playground count, and error state.
+
+#### Scenario: Pill shows aggregated counts
+
+- **WHEN** the registry has loaded and every backend has reported a feature count
+- **THEN** the pill shows `<N> Regionen · <M> Spielplätze` where N is the backend count and M is the sum across backends
+
+#### Scenario: Pill shows loading state
+
+- **WHEN** the registry is still being fetched
+- **THEN** the pill shows a spinner and a localised "loading instances" message
+
+#### Scenario: Pill shows registry error
+
+- **WHEN** the registry fetch fails
+- **THEN** the pill shows a warning icon and a localised "registry unreachable" message
+
+#### Scenario: Drawer opens and closes
+
+- **WHEN** the user clicks the pill
+- **THEN** a drawer slides up, listing every backend with name, version, count, and status
+- **AND** keyboard focus moves into the drawer
+- **AND** `aria-expanded=true` is set on the pill
+- **WHEN** the user presses ESC, clicks outside the drawer, or clicks the pill again
+- **THEN** the drawer collapses and focus returns to the pill
+
+#### Scenario: Scale-line does not overlap the pill
+
+- **WHEN** both the pill and the scale-line are visible in the bottom-left region
+- **THEN** the scale-line is rendered below the pill without visual overlap
+
+### Requirement: Deep-link with backend slug
+
+The URL hash SHALL support a `#<slug>/W<osm_id>` form where `<slug>` identifies a backend in `registry.json`. The legacy `#W<osm_id>` form SHALL continue to work.
+
+#### Scenario: Deep-link with slug in hub mode
+
+- **WHEN** a user visits `/#bw/W1234567` on a hub registry containing a backend with `slug: "bw"`
+- **THEN** the hub waits for that backend's features to load
+- **AND** selects the feature whose `osm_id` equals `1234567` on that backend
+
+#### Scenario: Deep-link without slug in hub mode
+
+- **WHEN** a user visits `/#W1234567` on a hub
+- **THEN** the hub searches every loaded backend's features for `osm_id = 1234567`
+- **AND** selects the first match found
+- **AND** logs a console warning if more than one backend contains that osm_id
+
+#### Scenario: Deep-link in standalone mode ignores slug
+
+- **WHEN** a user visits `/#anything/W1234567` on a standalone instance
+- **THEN** the instance selects `osm_id = 1234567` from its single configured backend
+- **AND** the slug is ignored with no warning or error
+
+#### Scenario: Selection updates the hash with slug
+
+- **WHEN** a user selects a playground in hub mode and the owning backend has a slug
+- **THEN** `location.hash` is set to `#<slug>/W<osm_id>`
+
+#### Scenario: Selection updates the hash without slug
+
+- **WHEN** a user selects a playground in hub mode and the owning backend has no slug
+- **THEN** `location.hash` is set to `#W<osm_id>` (legacy form)
+
+### Requirement: Multi-backend nearest-playground search
+
+In hub mode the nearby-playgrounds suggestion feature SHALL aggregate results from all registered backends, deduplicated by `osm_id` and sorted by distance ascending.
+
+#### Scenario: Nearby suggestions span backends
+
+- **WHEN** the user triggers the locate action and a position is obtained in hub mode
+- **THEN** each reachable backend's `get_nearest_playgrounds` is called in parallel
+- **AND** the merged results are shown, sorted by distance ascending
+- **AND** results with duplicate `osm_id` across backends keep only the nearest entry
+
+#### Scenario: Slow or failing backend does not block UI
+
+- **WHEN** one backend's `get_nearest_playgrounds` fails or times out
+- **THEN** results from the remaining backends are rendered without blocking user interaction
+- **AND** the timeout does not exceed the configured per-backend limit
+
+### Requirement: Generic data-contribution links in hub mode
+
+In hub mode the data-contribution modal SHALL link to the generic OSM wiki page for the `leisure=playground` tag and SHALL NOT show a regional chat link.
+
+#### Scenario: Contribution modal in hub
+
+- **WHEN** the user opens the data-contribution modal in hub mode
+- **THEN** the wiki link points to `https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground`
+- **AND** no chat link section is rendered
+
+#### Scenario: Contribution modal in standalone unchanged
+
+- **WHEN** the user opens the data-contribution modal in standalone mode
+- **THEN** the wiki link uses `regionPlaygroundWikiUrl` from configuration
+- **AND** the chat link appears if and only if `regionChatUrl` is configured
+
+### Requirement: Optional slug field in registry.json
+
+A `registry.json` entry MAY include a `slug` string field identifying the backend for deep-link purposes. The field SHALL be optional and SHALL NOT break existing registries that omit it.
+
+#### Scenario: Entry with slug
+
+- **WHEN** a registry entry contains `"slug": "bw"` alongside `name` and `url`
+- **THEN** the backend record exposes `slug: "bw"`
+- **AND** deep-links of the form `#bw/W<osm_id>` resolve to this backend
+
+#### Scenario: Entry without slug
+
+- **WHEN** a registry entry omits `slug`
+- **THEN** the backend record exposes `slug: null`
+- **AND** broadcast-search (hash without slug) still works for playgrounds on this backend
+
+#### Scenario: Invalid slug format
+
+- **WHEN** a registry entry contains a `slug` that does not match `[a-z0-9-]+`
+- **THEN** the slug is treated as missing
+- **AND** a console warning identifies the offending entry by URL

--- a/openspec/changes/archive/2026-04-19-hub-ui-parity/tasks.md
+++ b/openspec/changes/archive/2026-04-19-hub-ui-parity/tasks.md
@@ -1,0 +1,85 @@
+## 1. AppShell extraction
+
+- [ ] 1.1 Create `app/src/components/AppShell.svelte` — move the layout, widgets, responsive logic, and keyboard handling from `StandaloneApp.svelte` verbatim
+- [ ] 1.2 Add props: `playgroundSource`, `searchExtent` (store), `nearestFetcher`, `dataContribLinks`, `defaultBackendUrl`, `instancePanel` (optional snippet for bottom-left slot)
+- [ ] 1.3 Remove direct references to `apiBaseUrl`, `osmRelationId`, `fetchNearestPlaygrounds` — use injected equivalents
+- [ ] 1.4 Extract URL-hash parsing from `Map.svelte` into `app/src/lib/deeplink.js` — export `parseHash(h)` and `writeHash({ slug, osmId })`
+- [ ] 1.5 `AppShell` consumes `deeplink.js` and wires hash parsing through the selection store
+- [ ] 1.6 Confirm no hub-specific imports leak into `AppShell` (grep for `registry`, `InstancePanel`, etc.)
+
+## 2. Standalone refactor
+
+- [ ] 2.1 Refactor `app/src/standalone/StandaloneApp.svelte` to compose `AppShell`
+- [ ] 2.2 Owns the playground source; passes a `searchExtent` store computed from current map view (same logic as today)
+- [ ] 2.3 Passes `nearestFetcher = (lat, lon) => fetchNearestPlaygrounds(lat, lon, apiBaseUrl)`
+- [ ] 2.4 Passes `dataContribLinks = { wikiUrl: regionPlaygroundWikiUrl, chatUrl: regionChatUrl }`
+- [ ] 2.5 Retains existing initial data load (`loadStandaloneData`) and region-fit via Nominatim
+- [ ] 2.6 No `instancePanel` prop passed (bottom-left slot empty → scale-line sits where it does today)
+- [ ] 2.7 Manual smoke on dev server: search, filters (chips + panel), locate, nearby-playgrounds, hover preview, contribution modal, mobile bottom-sheet, zoom, deep-link `#W<osm_id>` — all pass
+
+## 3. registry.json schema extension
+
+- [ ] 3.1 Add `slug` field to registry entry schema (optional, lowercase ASCII + digits + hyphens)
+- [ ] 3.2 Update `registry.js` to surface `slug` on each backend status record; validate format and treat invalid values as absent with a console warning
+- [ ] 3.3 Update any example `registry.json` under `public/` or `docs/` to include a `slug` on each entry
+- [ ] 3.4 Support both `{ instances: [...] }` and bare array formats as today
+
+## 4. Registry-derived stores
+
+- [ ] 4.1 Add `aggregatedBbox` readable store to `registry.js`: updates as each backend's `get_meta` returns; emits the union of individual bboxes as `[minLon, minLat, maxLon, maxLat]`, or `null` until at least one backend has reported
+- [ ] 4.2 Add `fetchNearestAcrossBackends(lat, lon, limit = 10)` to `registry.js`: fires `get_nearest_playgrounds` against every reachable backend in parallel with a per-backend `AbortController` timeout (default 3 s), merges results, dedupes by `osm_id`, sorts by distance ascending, returns the top `limit`
+- [ ] 4.3 Expose both as named exports from `createRegistry` alongside the existing `backends` and `registryError` stores
+
+## 5. Hub refactor
+
+- [ ] 5.1 Refactor `app/src/hub/HubApp.svelte` to compose `AppShell`
+- [ ] 5.2 Wire `playgroundSource` from the existing shared `VectorSource`
+- [ ] 5.3 Wire `searchExtent` from the registry's `aggregatedBbox` store (reactive — updates as backends report)
+- [ ] 5.4 Wire `nearestFetcher` to `fetchNearestAcrossBackends`
+- [ ] 5.5 Wire `dataContribLinks` with the generic OSM wiki URL and `chatUrl: null`
+- [ ] 5.6 Pass the new `InstancePanel` pill as the `instancePanel` prop
+- [ ] 5.7 Hub owns initial `view.fit()`: subscribes to `aggregatedBbox` once and fits the map; falls back to a Germany-wide default until the first bbox arrives (matches current behaviour)
+
+## 6. InstancePanel redesign
+
+- [x] 6.1 Rewrite `app/src/hub/InstancePanel.svelte` as the collapsed pill — globe icon + `<N> Regionen · <M> Spielplätze`
+- [x] 6.2 Create `app/src/hub/InstancePanelDrawer.svelte` for the expanded state (move existing per-backend list rendering into it)
+- [x] 6.3 Position: bottom-left, `1rem` from edges; drawer slides up on click with a short animation
+- [x] 6.4 Scale-line shifts: update `custom-scale-line` CSS in `Map.svelte` to sit below the pill (sufficient `bottom:` offset)
+- [x] 6.5 Interaction: click pill toggles drawer; ESC or outside click collapses; `aria-expanded` on pill; focus trap while drawer open
+- [x] 6.6 Loading state: spinner in pill + "Lade Instanzen …" while `backends.length === 0`
+- [x] 6.7 Error state: warning icon + "Registry nicht erreichbar" when `registryError` is set
+- [x] 6.8 Mobile coordination: when the standalone-mode bottom-sheet is open, collapse the drawer automatically; pill stays visible but compact
+
+## 7. URL hash scheme
+
+- [x] 7.1 `parseHash` in `deeplink.js` matches both `#W<osm_id>` and `#<slug>/W<osm_id>`; returns `{ slug?: string, osmId: number } | null`
+- [x] 7.2 Standalone: ignores any slug — always selects by osm_id from the single configured backend
+- [x] 7.3 Hub with slug: resolves slug to backend via registry, waits for that backend's features to load, selects the matching osm_id
+- [x] 7.4 Hub without slug: searches all loaded backends' features for matching osm_id; picks first hit; console warning if more than one match
+- [x] 7.5 On selection in hub, `writeHash` emits `#<slug>/W<osm_id>` using the feature's `_backendUrl` resolved to slug; falls back to `#W<osm_id>` when the backend has no slug
+- [x] 7.6 Selection-clear writes empty hash (`#`) — same as today
+
+## 8. Tests
+
+- [x] 8.1 Playwright: hub mode smoke — asserts presence and basic function of search, filters, locate, zoom, hover preview, contribution modal, nearby-playground suggestions
+- [x] 8.2 Playwright: pill shows correct count after registry load; clicking expands drawer with backend list
+- [x] 8.3 Playwright: ESC collapses drawer; outside click collapses drawer
+- [x] 8.4 Playwright: deep-link `#<slug>/W<osm_id>` in hub selects correct playground on correct backend
+- [x] 8.5 Playwright: deep-link `#W<osm_id>` without slug in hub still selects (broadcast search)
+- [x] 8.6 Playwright: deep-link `#<anything>/W<osm_id>` in standalone selects osm_id regardless of slug
+- [x] 8.7 Playwright: standalone mode regression — same assertions as before this change still pass
+
+## 9. Documentation
+
+- [x] 9.1 Create `docs/reference/registry-json.md` — documents the schema (both top-level shapes), the `slug`/`name`/`url` fields, validation rules, and the two new registry-derived capabilities (aggregated bbox, multi-backend nearest)
+- [x] 9.2 Update `docs/reference/federation.md` with a brief note on the new hub UI (pill, drawer, deep-link scheme) and link to `registry-json.md`
+- [x] 9.3 Add an ASCII or screenshot of the hub layout (pill bottom-left, scale-line below it)
+- [x] 9.4 Update `mkdocs.yml` nav to include `registry-json.md`
+
+## 10. Final validation
+
+- [ ] 10.1 Local two-data-node + hub smoke: spin up two standalone instances, run hub pointing at both via `registry.json` with slugs; verify every item in section 8 manually
+- [ ] 10.2 Verify zero-regression in a single-node deployment (Fulda-like): compare behaviour against `main` for all standalone interactions
+- [ ] 10.3 Bundle size spot-check: hub bundle gains some code, standalone loses some; net should be roughly neutral. Record sizes before/after for the PR description
+- [ ] 10.4 Update CHANGELOG or release notes if the project uses them (currently no — skip)

--- a/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/design.md
+++ b/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`install.sh` is a single-file bash script that walks operators through an interactive setup, downloads `compose.prod.yml` + `db/init.sql`, writes `.env`, and optionally starts the stack. Currently it always installs the complete stack (db + PostgREST + app). `compose.prod.yml` already has a rough split between data services (`db`, `postgrest`, `importer`) and the UI (`app`), but no profiles are defined.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let operators choose exactly which tier to deploy without manually editing compose files.
+- Skip irrelevant questions per mode (e.g. no PBF/region questions for UI-only).
+- Keep `data-node-ui` fully backward-compatible with the current flow.
+- Pass the correct `--profile` flag to all `docker compose` calls automatically.
+
+**Non-Goals:**
+- Multi-host networking setup — operators configure `API_BASE_URL` manually when a remote data node exists.
+- Any changes to the Svelte app or PostgREST config beyond what `.env` already controls.
+- GUI or web-based installer.
+
+## Decisions
+
+### D1 — Docker Compose profiles as the mechanism
+
+Profiles let operators (and the installer) activate only the relevant services without maintaining multiple compose files. Each service is tagged with the profile(s) in which it participates:
+
+| Service    | data-node | ui | data-node-ui |
+|------------|:---------:|:--:|:------------:|
+| db         | ✓         |    | ✓            |
+| importer   | ✓         |    | ✓            |
+| postgrest  | ✓         |    | ✓            |
+| app        |           | ✓  | ✓            |
+
+Alternative considered: separate compose files per mode. Rejected — more files to maintain and download, and the installer would need to know which file to fetch.
+
+### D2 — Mode stored in `DEPLOY_MODE` env var
+
+Writing `DEPLOY_MODE` to `.env` means the operator can re-run `docker compose --profile $DEPLOY_MODE up -d` without remembering what they chose at install time. The installer reads this var when re-running to detect an existing mode.
+
+### D3 — Question branching via a simple `case` block
+
+After the mode is selected, a `case "$DEPLOY_MODE" in` block guards each question section:
+
+- `data-node`: region/PBF, infra (threads, no app-port)
+- `ui`: remote API URL, UI links, map display, app-port
+- `data-node-ui`: all questions (current behaviour)
+
+This keeps the script linear and easy to read.
+
+### D4 — `API_BASE_URL` for UI mode
+
+When mode is `ui`, the installer asks for the base URL of the remote PostgREST endpoint (e.g. `https://data.example.com/api`). This is written to `.env` and passed into the `app` container as `API_BASE_URL`.
+
+### D5 — No port question for data-node mode
+
+A data-only node doesn't expose the app. `APP_PORT` is omitted from `.env` for `data-node`, avoiding confusion.
+
+## Risks / Trade-offs
+
+- **Profile typo confusion** → The script uses a fixed `select` menu (not free text) so the value is always one of the three valid strings.
+- **Existing installs without `DEPLOY_MODE`** → The installer detects missing `DEPLOY_MODE` in an existing `.env` and treats it as `data-node-ui`, preserving backward compatibility.
+- **Remote API URL not validated** → We don't test connectivity to the remote API at install time. A bad URL fails silently until the user opens the app. Mitigation: print a reminder to verify connectivity after start.
+
+## Migration Plan
+
+1. Update `compose.prod.yml` to add profiles (backward-compatible: services without profiles still start when no `--profile` is given, so existing deployments are unaffected until they re-run the installer).
+2. Update `install.sh` with mode selection and branched questions.
+3. No database migration needed.
+4. Rollback: revert both files; existing `.env` files without `DEPLOY_MODE` continue to work.
+
+## Open Questions
+
+- Should the installer support upgrading an existing install to a different mode (e.g. data-node → data-node-ui)? → Out of scope for now; operators can edit `.env` and re-run `docker compose --profile <mode> up -d`.

--- a/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/proposal.md
+++ b/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The installer currently deploys the full stack (database + PostgREST + UI) without giving operators a choice. Some deployments benefit from separating the data backend from the frontend — for example, running a shared data node that multiple lightweight UI nodes connect to.
+
+## What Changes
+
+- The installer gains a deployment mode selection step (before any other configuration).
+- Three modes are supported: **data-node** (DB + PostgREST only), **ui** (app only, connects to a remote API), **data-node-ui** (current behaviour: full stack).
+- Questions irrelevant to the selected mode are skipped (e.g. no region/PBF questions for a UI-only node; no app-port/UI-link questions for a data-only node).
+- For **ui** mode the installer asks for the remote API base URL instead of region data.
+- The generated `.env` includes a `DEPLOY_MODE` variable reflecting the choice.
+- `compose.prod.yml` gains Docker Compose profiles (`data-node`, `ui`, `data-node-ui`) so the right services are started based on the chosen mode.
+
+## Capabilities
+
+### New Capabilities
+
+- `deployment-mode-selection`: Interactive selection of deployment mode (`data-node` | `ui` | `data-node-ui`) at install time, with conditional question flow and profile-scoped compose services.
+
+### Modified Capabilities
+
+- (none — existing installer flow is extended, not changed in behaviour for the `data-node-ui` path)
+
+## Impact
+
+- `install.sh` — new mode selection prompt, branched question sections, profile flag passed to all `docker compose` calls.
+- `compose.prod.yml` — services tagged with profiles matching the three modes.
+- `.env` — new `DEPLOY_MODE` variable written by installer.

--- a/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/specs/deployment-mode-selection/spec.md
+++ b/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/specs/deployment-mode-selection/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Mode selection prompt
+The installer SHALL present a numbered menu asking the operator to choose a deployment mode before any other configuration questions. Valid choices are `data-node`, `ui`, and `data-node-ui`.
+
+#### Scenario: Operator selects data-node
+- **WHEN** operator enters `1` (data-node) at the mode prompt
+- **THEN** `DEPLOY_MODE=data-node` is set and only region, PBF, importer-threads questions are asked
+
+#### Scenario: Operator selects ui
+- **WHEN** operator enters `2` (ui) at the mode prompt
+- **THEN** `DEPLOY_MODE=ui` is set and only remote API URL, UI links, map display, and app-port questions are asked
+
+#### Scenario: Operator selects data-node-ui
+- **WHEN** operator enters `3` (data-node-ui) at the mode prompt
+- **THEN** `DEPLOY_MODE=data-node-ui` is set and all existing questions are asked (current behaviour preserved)
+
+#### Scenario: Operator enters invalid choice
+- **WHEN** operator enters a value other than 1, 2, or 3
+- **THEN** the installer prints an error and re-displays the menu until a valid choice is made
+
+### Requirement: Remote API URL for UI mode
+When mode is `ui`, the installer SHALL ask for the base URL of the remote PostgREST API endpoint and write it as `API_BASE_URL` in `.env`.
+
+#### Scenario: UI mode API URL collected
+- **WHEN** `DEPLOY_MODE=ui` and operator enters a URL (e.g. `https://data.example.com/api`)
+- **THEN** `.env` contains `API_BASE_URL=https://data.example.com/api`
+
+#### Scenario: UI mode API URL has no default
+- **WHEN** `DEPLOY_MODE=ui` and operator leaves API URL blank
+- **THEN** installer treats it as a required field and asks again
+
+### Requirement: DEPLOY_MODE written to .env
+The installer SHALL write `DEPLOY_MODE=<value>` to `.env` so that operators can re-run `docker compose` with the correct profile without remembering their original choice.
+
+#### Scenario: .env contains DEPLOY_MODE after install
+- **WHEN** installer completes successfully for any mode
+- **THEN** `.env` contains `DEPLOY_MODE=<chosen-mode>`
+
+### Requirement: Docker Compose profile passed to all commands
+Every `docker compose` call in the installer (pull, up, run importer) SHALL include `--profile $DEPLOY_MODE` so only the services for the selected mode are started.
+
+#### Scenario: data-node mode starts only data services
+- **WHEN** `DEPLOY_MODE=data-node` and operator confirms start
+- **THEN** `docker compose --profile data-node up -d` is executed (db, postgrest started; app not started)
+
+#### Scenario: ui mode starts only app service
+- **WHEN** `DEPLOY_MODE=ui` and operator confirms start
+- **THEN** `docker compose --profile ui up -d` is executed (app started; db, postgrest not started)
+
+#### Scenario: data-node-ui mode starts all services
+- **WHEN** `DEPLOY_MODE=data-node-ui` and operator confirms start
+- **THEN** `docker compose --profile data-node-ui up -d` is executed (all services started)
+
+### Requirement: compose.prod.yml profiles for all services
+Every service in `compose.prod.yml` SHALL declare the `profiles` list matching the modes in which it participates.
+
+#### Scenario: db and postgrest carry data-node and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `db` and `postgrest` services list profiles `[data-node, data-node-ui]`
+
+#### Scenario: importer carries data-node and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `importer` service lists profiles `[data-node, data-node-ui]`
+
+#### Scenario: app carries ui and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `app` service lists profiles `[ui, data-node-ui]`
+
+### Requirement: Importer step skipped for UI mode
+The installer SHALL skip the OSM import prompt when `DEPLOY_MODE=ui` because there is no local database.
+
+#### Scenario: No import prompt in UI mode
+- **WHEN** `DEPLOY_MODE=ui`
+- **THEN** the "Run OSM import now?" confirmation is not shown
+
+### Requirement: Done message shows relevant URLs
+The final summary SHALL show only the services relevant to the selected mode.
+
+#### Scenario: data-node done message
+- **WHEN** `DEPLOY_MODE=data-node`
+- **THEN** done message shows no app URL (app is not running)
+
+#### Scenario: ui done message
+- **WHEN** `DEPLOY_MODE=ui`
+- **THEN** done message shows the app URL and omits database/importer hints

--- a/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/tasks.md
+++ b/openspec/changes/archive/2026-04-19-install-deployment-mode-selection/tasks.md
@@ -1,0 +1,49 @@
+## 1. compose.prod.yml — Add profiles
+
+- [x] 1.1 Add `profiles: [data-node, data-node-ui]` to the `db` service
+- [x] 1.2 Add `profiles: [data-node, data-node-ui]` to the `postgrest` service
+- [x] 1.3 Add `profiles: [data-node, data-node-ui]` to the `importer` service (currently has `profiles: [import]` — replace)
+- [x] 1.4 Add `profiles: [ui, data-node-ui]` to the `app` service
+- [x] 1.5 Verify `docker compose --profile data-node config` shows only db/postgrest/importer
+- [x] 1.6 Verify `docker compose --profile ui config` shows only app
+- [x] 1.7 Verify `docker compose --profile data-node-ui config` shows all services
+
+## 2. install.sh — Mode selection
+
+- [x] 2.1 Add a `choose_mode` function that presents a numbered menu (1=data-node, 2=ui, 3=data-node-ui) and loops until a valid choice is entered
+- [x] 2.2 Call `choose_mode` immediately after the deployment-directory prompt, store result in `DEPLOY_MODE`
+- [x] 2.3 Detect existing `.env` without `DEPLOY_MODE` and default to `data-node-ui` for backward compat
+
+## 3. install.sh — Branched question sections
+
+- [x] 3.1 Wrap the Region section (OSM_RELATION_ID, PBF_URL) in `[[ "$DEPLOY_MODE" != "ui" ]]`
+- [x] 3.2 Add a new UI-mode-only section that asks for `API_BASE_URL` (required, no default)
+- [x] 3.3 Wrap the "Optional: UI links" section so it only shows for `ui` and `data-node-ui`
+- [x] 3.4 Wrap the "Optional: map display" section so it only shows for `ui` and `data-node-ui`
+- [x] 3.5 For the infra section: skip `APP_PORT` when `DEPLOY_MODE=data-node`; skip `OSM2PGSQL_THREADS` when `DEPLOY_MODE=ui`
+
+## 4. install.sh — .env generation
+
+- [x] 4.1 Add `DEPLOY_MODE=${DEPLOY_MODE}` to the written `.env` (under the header comment)
+- [x] 4.2 Write `API_BASE_URL` to `.env` for `ui` mode; omit for other modes
+- [x] 4.3 Omit `APP_PORT` from `.env` for `data-node` mode
+- [x] 4.4 Omit `OSM2PGSQL_THREADS` from `.env` for `ui` mode
+
+## 5. install.sh — Docker Compose calls
+
+- [x] 5.1 Add `--profile "$DEPLOY_MODE"` to the `docker compose pull` call
+- [x] 5.2 Add `--profile "$DEPLOY_MODE"` to the `docker compose up -d` call
+- [x] 5.3 Add `--profile "$DEPLOY_MODE"` to the `docker compose run --rm importer` call
+- [x] 5.4 Skip the "Run OSM import now?" block entirely when `DEPLOY_MODE=ui`
+
+## 6. install.sh — Done message
+
+- [x] 6.1 Show app URL in the done message only when mode is `ui` or `data-node-ui`
+- [x] 6.2 Show importer hint only when mode is `data-node` or `data-node-ui`
+- [x] 6.3 Update the "Useful commands" section to include `--profile $DEPLOY_MODE` in example commands
+
+## 7. Manual smoke test
+
+- [ ] 7.1 Run installer in `data-node-ui` mode end-to-end and verify existing behaviour is unchanged
+- [ ] 7.2 Run installer in `data-node` mode and verify only db/postgrest start, no app URL shown
+- [ ] 7.3 Run installer in `ui` mode and verify only app starts, no import prompt, API URL written to `.env`

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/design.md
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/design.md
@@ -1,0 +1,86 @@
+## Context
+
+README.md is 607 lines mixing audience-specific content: a project pitch for evaluators, deploy instructions for operators, a git tutorial for contributors, and how-to guides for content editors. The packyard project in the same GitHub org already demonstrates the exact pattern to follow: MkDocs + Material theme, deployed to GitHub Pages via GitHub Actions. The goal is to replicate that setup here with content appropriate for Spielplatzkarte.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract deep content (troubleshooting, how-tos, full config reference, contributing workflow, glossary) into a browseable, searchable docs site
+- Slim README to ~150 lines that serve as an effective project landing page
+- Fully automated deployment: every push to `main` rebuilds the site
+- Local preview with a single `make` command
+
+**Non-Goals:**
+- Versioned docs (Mike) — content is operational, not API-contract; single `latest` is sufficient
+- Translating docs into languages other than English
+- Migrating the i18n how-to until i18n is re-integrated in the Svelte rewrite
+- Any changes to the Svelte app, Docker stack, or CI pipeline beyond the new docs workflow
+
+## Decisions
+
+### D1 — MkDocs + Material (not VitePress or Docusaurus)
+
+Same choice as packyard. The project already has a Python toolchain dependency (osm2pgsql docs use Python). Material theme is best-in-class for MkDocs. VitePress would be natural given the JS stack but adds Node tooling complexity to a docs workflow that should be independent of the app build. Docusaurus is heavier than needed.
+
+### D2 — Deploy on push to `main`, not on release
+
+Docs are operational (how to deploy, configure, troubleshoot). They should stay current with `main` rather than lagging until a release is cut. No Mike versioning needed. Workflow trigger: `push: branches: [main]`, paths: `['docs/**', 'mkdocs.yml']` plus a manual `workflow_dispatch`.
+
+### D3 — `docs/` directory structure
+
+```
+docs/
+├── index.md                          # landing page
+├── getting-started/
+│   └── quick-start.md                # installer walkthrough (from README)
+├── ops/
+│   ├── manual-deploy.md              # from-source deploy (from README)
+│   ├── configuration.md              # full env var table (from README)
+│   └── troubleshooting.md            # Q&As (from README)
+├── contributing/
+│   └── add-device.md                 # how-to add playground device (from README)
+└── reference/
+    ├── architecture.md               # diagram + explanation
+    ├── tech-stack.md                 # full tech stack table
+    ├── federation.md                 # federation section (from README)
+    └── glossary.md                   # OSM-specific terms only
+```
+
+The i18n how-to is intentionally excluded until i18n is active.
+
+### D4 — CONTRIBUTING.md at repo root
+
+GitHub surfaces `CONTRIBUTING.md` automatically in the "new issue" and "new PR" flows. The full git workflow from the README Contributing section moves here. The README Contributing section becomes two sentences with a link.
+
+### D5 — Glossary scope
+
+Only OSM/domain-specific terms are kept: OSM relation ID, PBF file, osm2pgsql, PostgREST, Overpass Turbo. Standard tools (Docker, nginx, PostgreSQL, Vite, etc.) are dropped — they are widely known and a sentence in a README won't substitute for their own documentation.
+
+### D6 — README target structure
+
+```
+# Spielplatzkarte
+  1-liner + origin
+
+## Architecture         (diagram — keep)
+## Tech stack           (table — keep, brief)
+## Deploy               (quick install only; link to docs for manual)
+## Configuration        (top 5 vars + link to full reference in docs)
+## Local development    (make install / make up / make dev — 3 lines)
+## Contributing         (2 sentences + link to CONTRIBUTING.md and docs)
+## Federation           (keep as-is)
+## External services    (table — keep)
+## License
+```
+
+The manual ToC is removed — GitHub renders heading anchors automatically.
+
+## Risks / Trade-offs
+
+- **`gh-pages` branch creation** → GitHub Pages must be enabled in repo settings after first deploy; the workflow will create the branch automatically on first run but Pages must be switched on manually.
+- **README content removal is irreversible in perception** → Some operators may have bookmarked specific README sections. Mitigation: all moved content gets a docs URL that is stable going forward.
+- **Python dependency for docs** → Operators building from source now need Python to preview docs locally. Mitigation: `make docs-serve` is clearly scoped; it's not required to run the app.
+
+## Open Questions
+
+(none — all decisions made during explore session)

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/proposal.md
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The README is 607 lines serving four different audiences (evaluators, operators, contributors, content editors) and mixing quick-start material with deep how-tos, troubleshooting Q&As, and a glossary — making it hard to scan and maintain. A dedicated docs site extracts that depth into a properly navigable, searchable reference while slimming the README to an effective project landing page.
+
+## What Changes
+
+- `docs/` directory added with MkDocs + Material theme source (markdown pages, `requirements.txt`)
+- `mkdocs.yml` added at repo root with navigation, Material theme config, and GitHub repo integration
+- `Makefile` gains `docs-install`, `docs-serve`, `docs-build`, `docs-clean` targets
+- `.github/workflows/docs.yml` added — deploys to GitHub Pages on every push to `main`
+- `CONTRIBUTING.md` added at repo root with the full contributing workflow (extracted from README)
+- `README.md` slimmed from 607 lines to ~150: keeps header, architecture diagram, tech stack table, quick install, abbreviated config, 3-line local dev, federation, external services, license
+- Docs content extracted from README into structured pages under `docs/`
+
+## Capabilities
+
+### New Capabilities
+
+- `mkdocs-site`: MkDocs Material docs site with GitHub Pages deployment, covering ops, contributing, and reference content extracted from README
+- `slim-readme`: README restructured as a concise project landing page (~150 lines), with deep content moved to docs
+
+### Modified Capabilities
+
+(none — no existing spec-level behaviour changes)
+
+## Impact
+
+- `README.md` — significant reduction in content; links added pointing to docs site
+- `CONTRIBUTING.md` — new file (extracted from README Contributing section)
+- `Makefile` — new `docs-*` targets added
+- `mkdocs.yml` — new file at repo root
+- `docs/` — new directory with all markdown source and `requirements.txt`
+- `.github/workflows/docs.yml` — new CI workflow
+- GitHub repository settings — GitHub Pages must be enabled (source: `gh-pages` branch)

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/specs/mkdocs-site/spec.md
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/specs/mkdocs-site/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: MkDocs site builds locally
+The repository SHALL include a `docs/` directory, `mkdocs.yml`, and `docs/requirements.txt` sufficient to build and serve the documentation site locally using `make docs-serve`.
+
+#### Scenario: Local preview
+- **WHEN** a developer runs `make docs-install` then `make docs-serve`
+- **THEN** a live-reload server starts at `http://localhost:8000` showing the full docs site
+
+#### Scenario: Clean build
+- **WHEN** a developer runs `make docs-build`
+- **THEN** a static site is generated in `site/` with no errors in strict mode
+
+### Requirement: Makefile docs targets
+The Makefile SHALL include four targets: `docs-install`, `docs-serve`, `docs-build`, `docs-clean`.
+
+#### Scenario: Install target creates virtualenv
+- **WHEN** `make docs-install` is run
+- **THEN** a `.venv` directory is created and all packages from `docs/requirements.txt` are installed into it
+
+#### Scenario: Clean target removes artifacts
+- **WHEN** `make docs-clean` is run
+- **THEN** the `site/` directory and `.venv` are removed
+
+### Requirement: GitHub Pages deployment on main push
+A GitHub Actions workflow SHALL deploy the docs site to GitHub Pages on every push to `main` that touches `docs/**` or `mkdocs.yml`, and on manual dispatch.
+
+#### Scenario: Automatic deploy on docs change
+- **WHEN** a commit touching `docs/` or `mkdocs.yml` is pushed to `main`
+- **THEN** the workflow runs, builds the site, and pushes it to the `gh-pages` branch
+
+#### Scenario: Manual deploy trigger
+- **WHEN** the workflow is triggered via `workflow_dispatch`
+- **THEN** the site is built and deployed regardless of which files changed
+
+### Requirement: Material theme with search and edit links
+The docs site SHALL use the MkDocs Material theme with full-text search enabled and an edit button on every page linking to the source file on GitHub.
+
+#### Scenario: Search returns relevant results
+- **WHEN** a visitor types "PBF" in the search box
+- **THEN** the glossary entry for PBF file appears in results
+
+#### Scenario: Edit link points to correct file
+- **WHEN** a visitor clicks the edit button on any docs page
+- **THEN** they are taken to the corresponding `.md` file in the `docs/` directory on GitHub
+
+### Requirement: Navigation covers all extracted content
+The docs site SHALL include pages for: quick start, manual deploy, configuration reference, troubleshooting, add-device how-to, architecture reference, tech stack, federation, and glossary.
+
+#### Scenario: All nav items resolve
+- **WHEN** every navigation item in `mkdocs.yml` is followed
+- **THEN** it renders a page with content (no 404s, no empty pages)
+
+### Requirement: Glossary contains only OSM-specific terms
+`docs/reference/glossary.md` SHALL define exactly the following terms and no others: OSM relation ID, PBF file, osm2pgsql, PostgREST, Overpass Turbo.
+
+#### Scenario: Generic tool terms absent
+- **WHEN** the glossary page is rendered
+- **THEN** it does not contain entries for Docker, nginx, PostgreSQL, Vite, Node.js, Svelte, Tailwind, or OpenLayers
+
+#### Scenario: OSM terms present
+- **WHEN** the glossary page is rendered
+- **THEN** it contains definitions for OSM relation ID, PBF file, osm2pgsql, PostgREST, and Overpass Turbo

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/specs/slim-readme/spec.md
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/specs/slim-readme/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: README is a concise landing page
+`README.md` SHALL be reduced to approximately 150 lines and contain only: project one-liner, origin attribution, architecture diagram, tech stack table, quick install snippet, abbreviated configuration (top vars + link to full docs), local development (3 make commands), contributing one-liner with links, federation section, external services table, and license.
+
+#### Scenario: README line count
+- **WHEN** the updated README is rendered
+- **THEN** it is no longer than 200 lines
+
+#### Scenario: README contains no ToC
+- **WHEN** the README is rendered on GitHub
+- **THEN** there is no manually-maintained table of contents section (GitHub renders heading anchors automatically)
+
+#### Scenario: Deep content links to docs
+- **WHEN** a reader encounters the configuration, troubleshooting, or contributing sections
+- **THEN** each section contains a link pointing to the corresponding docs site page
+
+### Requirement: Glossary reference removed from README
+The Glossary section SHALL be removed from `README.md` entirely, replaced by a single sentence linking to `docs/reference/glossary.md`.
+
+#### Scenario: No glossary table in README
+- **WHEN** `README.md` is rendered
+- **THEN** it contains no table with tool/term definitions
+
+#### Scenario: Glossary linked
+- **WHEN** `README.md` is rendered
+- **THEN** it contains at least one link to the docs glossary page
+
+### Requirement: CONTRIBUTING.md at repo root
+A `CONTRIBUTING.md` file SHALL exist at the repository root containing the full contributing workflow (issue → branch → change → commit → PR), branch naming convention, and commit message format.
+
+#### Scenario: GitHub surfaces CONTRIBUTING.md
+- **WHEN** a user opens a new issue or PR on GitHub
+- **THEN** GitHub displays a link to `CONTRIBUTING.md`
+
+#### Scenario: README Contributing section is brief
+- **WHEN** `README.md` is rendered
+- **THEN** the Contributing section is no longer than 5 lines and links to `CONTRIBUTING.md`
+
+### Requirement: Deploy commands updated
+All `docker compose` command examples in `README.md` SHALL include the `--profile` flag consistent with the deployment mode changes introduced in PR #118.
+
+#### Scenario: No bare docker compose commands
+- **WHEN** `README.md` is scanned for `docker compose` invocations
+- **THEN** every invocation that starts services includes `--profile <mode>`

--- a/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/tasks.md
+++ b/openspec/changes/archive/2026-04-19-setup-mkdocs-docs-site/tasks.md
@@ -1,0 +1,63 @@
+## 1. MkDocs scaffolding
+
+- [x] 1.1 Create `docs/requirements.txt` with `mkdocs`, `mkdocs-material`, and `mike` pinned to versions matching packyard
+- [x] 1.2 Create `mkdocs.yml` at repo root: site name, repo URL, edit URI, Material theme, nav skeleton, markdown extensions (admonition, superfences, tabbed, toc)
+- [x] 1.3 Add `docs-install`, `docs-serve`, `docs-build`, `docs-clean` targets to `Makefile`
+- [x] 1.4 Add `site/` and `.venv` to `.gitignore`
+- [x] 1.5 Verify `make docs-install && make docs-build` runs without errors
+
+## 2. GitHub Actions workflow
+
+- [x] 2.1 Create `.github/workflows/docs.yml` triggering on push to `main` (paths: `docs/**`, `mkdocs.yml`) and `workflow_dispatch`
+- [x] 2.2 Workflow steps: checkout (fetch-depth 0), setup Python, `make docs-install`, `mkdocs gh-deploy --force`
+- [x] 2.3 Add required permissions: `contents: write`
+
+## 3. Docs content — Getting Started
+
+- [x] 3.1 Create `docs/index.md`: brief project description, architecture diagram (copy from README), links to main sections
+- [x] 3.2 Create `docs/getting-started/quick-start.md`: full quick install walkthrough extracted from README (installer steps, post-install commands updated with `--profile` flags)
+
+## 4. Docs content — Operations
+
+- [x] 4.1 Create `docs/ops/manual-deploy.md`: manual from-source deploy steps extracted from README (steps 1–5), commands updated with `--profile` flags
+- [x] 4.2 Create `docs/ops/configuration.md`: full env var reference table extracted from README, all variables with defaults, modes, descriptions
+- [x] 4.3 Create `docs/ops/troubleshooting.md`: all 5 Q&A entries extracted from README troubleshooting section
+
+## 5. Docs content — Contributing
+
+- [x] 5.1 Create `docs/contributing/add-device.md`: full "How-to: Add a playground device" extracted from README (5 steps)
+- [x] 5.2 Create `CONTRIBUTING.md` at repo root: issue → branch → change → commit → PR workflow, branch naming, commit message format (extracted from README Contributing section)
+
+## 6. Docs content — Reference
+
+- [x] 6.1 Create `docs/reference/architecture.md`: data flow diagram, production vs dev explanation (from README)
+- [x] 6.2 Create `docs/reference/tech-stack.md`: full tech stack table (from README)
+- [x] 6.3 Create `docs/reference/federation.md`: federation section content (from README)
+- [x] 6.4 Create `docs/reference/glossary.md`: OSM relation ID, PBF file, osm2pgsql, PostgREST, Overpass Turbo — definitions only, no generic tool entries
+
+## 7. Wire up mkdocs.yml navigation
+
+- [x] 7.1 Fill in complete `nav:` section in `mkdocs.yml` mapping all pages created in tasks 3–6
+- [x] 7.2 Verify `make docs-build` renders all pages without 404s or warnings
+
+## 8. Slim README.md
+
+- [x] 8.1 Remove the manual table of contents
+- [x] 8.2 Remove the Glossary section; replace with one sentence linking to `docs/reference/glossary.md`
+- [x] 8.3 Remove the "Manual deploy (from source)" subsection; replace with one line linking to `docs/ops/manual-deploy.md`
+- [x] 8.4 Trim the Configuration reference to the top ~5 most-used variables plus a link to the full table in docs
+- [x] 8.5 Remove the "How-to: Add a playground device" section; replace with one line linking to `docs/contributing/add-device.md`
+- [x] 8.6 Remove the "How-to: Edit UI strings / add a language" section entirely (dead code; will be restored when i18n is re-integrated)
+- [x] 8.7 Remove the "Troubleshooting" section; replace with one line linking to `docs/ops/troubleshooting.md`
+- [x] 8.8 Replace the Contributing section body with 2 sentences + links to `CONTRIBUTING.md` and docs
+- [x] 8.9 Remove the "Internationalisation" section (duplicate of removed how-to; dead code)
+- [x] 8.10 Update all `docker compose` command examples to include `--profile data-node-ui` (or appropriate mode)
+- [x] 8.11 Verify README is ≤ 200 lines
+
+## 9. Enable GitHub Pages
+
+- [ ] 9.1 Push branch, confirm workflow runs and `gh-pages` branch is created
+- [ ] 9.2 Enable GitHub Pages in repository settings (source: `gh-pages` branch, root `/`)
+- [ ] 9.3 Confirm docs site is accessible at `https://mfuhrmann.github.io/spielplatzkarte/`
+- [ ] 9.4 Add docs URL to `mkdocs.yml` `site_url` field
+- [ ] 9.5 Add docs URL link to README (e.g. in the header or Contributing section)

--- a/openspec/changes/document-federated-hub-deployment/design.md
+++ b/openspec/changes/document-federated-hub-deployment/design.md
@@ -1,0 +1,84 @@
+## Context
+
+After v0.2.0 shipped, the federation code is production-ready (hub mode, registry, deep-links) and two of the three doc deliverables originally scoped in this change are already in-repo:
+
+- `docs/reference/federation.md` — conceptual reference (shipped via PR #183)
+- `docs/reference/registry-json.md` — schema reference (shipped via PR #183)
+
+The third and largest deliverable — a step-by-step walkthrough for standing up a Hub + N × data-node topology — is still missing, as are five smaller doc/config additions (`configuration.md` row, `architecture.md` matrix, `.env.example` Hub block, `federation.md` cross-link, MkDocs nav entry).
+
+The operator persona is **"someone standing up their first federated deployment"** — not "someone who already has two standalone instances and wants to federate them". This changes the doc's centre of gravity from "Hub wiring" toward "infrastructure bootstrap, then Hub wiring".
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single page an operator can read top-to-bottom and end up with a working Hub + 2 data-nodes.
+- Copy-pasteable commands against the repo's existing `compose.yml` profiles (`data-node`, `ui`).
+- Five small companion edits that close the "how did I discover this variable / this combination exists" gaps.
+
+**Non-Goals:**
+- TLS / reverse-proxy choice (Caddy vs nginx vs Traefik) — operator's decision, out of scope.
+- DNS and certificate bootstrap — generic infrastructure, not federation-specific.
+- Multi-hub / nested federation (a hub federating another hub).
+- Authn/authz across backends — every `/api/` is public today; a separate change.
+- Backup, monitoring, log aggregation — not federation-specific.
+- Non-Docker deployment paths (bare-metal systemd, k8s, swarm).
+- Documentation of the already-shipped `federation.md` / `registry-json.md` (they stand).
+
+## Decisions
+
+### D1 — Audience is "first-time federation operator"
+
+The walkthrough is written as if the reader owns three fresh Linux hosts and nothing else. Every command appears in full; no "you know where this goes" gaps. Readers who already have running standalone instances can skim §1 (data-node setup) and land at §2 (write the registry).
+
+### D2 — 150-line copy-paste recipe over a 500-line guide
+
+A sharp persona tolerates an opinionated recipe. Offering variations ("if you use k8s…", "if you already have a reverse proxy…") triples the page length and serves the *second* federation deployment, not the first. Variations belong in follow-up pages or linked third-party material.
+
+### D3 — Topology assumption: Hub + ≥ 1 data-node (no UI on backends)
+
+The walkthrough assumes `DEPLOY_MODE=ui` + `APP_MODE=hub` on the Hub and `DEPLOY_MODE=data-node` on each backend. Technically the registry accepts any URL exposing `/api/rpc/get_meta`, including `data-node-ui` instances — but documenting that possibility in the walkthrough forces the reader to resolve ambiguity they don't have context for. The `registry-json.md` reference page already notes the broader truth; the walkthrough picks the canonical path.
+
+### D4 — Opinionated infrastructure choices baked in
+
+- **Docker Compose directly** (no swarm, no k8s, no Nomad).
+- **Single VPS per node** (three hosts for two backends + one hub). Co-location is possible but complicates the CORS story needlessly for a first read.
+- **Public DNS hostnames** (not IP-only). TLS termination assumed but not prescribed.
+- **Repo's compose profiles verbatim** — `--profile data-node` and `--profile ui`.
+
+These are stated up front in §0 so an operator on a different stack knows within 10 seconds that this page isn't for them.
+
+### D5 — Matrix shape in `architecture.md`: 2×2, not 3×2
+
+A 3×2 matrix with an entire `data-node` row reading "N/A — no UI" is noise. Collapse to a 2×2:
+
+|              | `standalone` | `hub` |
+|--------------|--------------|-------|
+| `ui`         | Regional map | Federated map |
+| `data-node-ui` | Single-region | Hub + local backend¹ |
+
+¹ Legal but not recommended — the hub UI reads from the registry, so the local data-node is only reached if it appears in the registry. Run hub and data-nodes as separate deployments.
+
+`data-node` doesn't appear because it has no UI to configure an `APP_MODE` against.
+
+### D6 — Doc file placement
+
+| File | Role | Why here |
+|---|---|---|
+| `docs/ops/federated-deployment.md` | Walkthrough (new) | Action, not concept → `ops/` |
+| `docs/reference/federation.md` | Conceptual reference (shipped, +See also) | Already the conceptual home |
+| `docs/reference/registry-json.md` | Schema reference (shipped, no change) | Schema lives in `reference/` |
+| `docs/reference/architecture.md` | + Mode matrix + caption | Matrix is architecture, not ops |
+| `docs/ops/configuration.md` | + `REGISTRY_URL` row, amend `APP_MODE` row | Env-var table already lives here |
+| `.env.example` | + Commented Hub block + pointer comment | Discoverable by operators grepping `.env` |
+| `mkdocs.yml` | + Walkthrough nav entry under Operations | MkDocs nav must include it |
+
+## Risks / Trade-offs
+
+- **Walkthrough rots if compose profile names change.** Mitigation: link specific profile flags to `compose.yml` in-repo via the GitHub `edit_uri` so readers notice drift; CI `mkdocs build --strict` catches broken internal links but won't catch stale shell commands.
+- **Opinionated recipe alienates non-Docker operators.** Accepted — a federation walkthrough for every deployment style is a book, not a page. Non-Docker operators have the `federation.md` + `registry-json.md` references and can translate.
+- **Matrix footnote on `data-node-ui × hub`.** Readers may read the footnote as "you can't do this" when the reality is "you can, but it's weird." The footnote wording matters.
+
+## Open Questions
+
+(none — decisions made during explore session)

--- a/openspec/changes/document-federated-hub-deployment/proposal.md
+++ b/openspec/changes/document-federated-hub-deployment/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+A federated topology — one UI running in Hub mode aggregating two or more data-nodes that have no UI of their own — is supported by the code (federation endpoints exist on every data node, the app has `APP_MODE=hub` and a `registry.json` loader), but is not documented as an end-to-end path. The pieces are scattered:
+
+- `docs/reference/federation.md` says the Hub uses `APP_MODE=hub` and reads `registry.json`, but shows no example file, no format spec, and no `DEPLOY_MODE` guidance for the backends.
+- `REGISTRY_URL` is honoured by `oci/app/docker-entrypoint.sh` and `app/src/lib/config.js`, but is absent from `docs/ops/configuration.md` and from `.env.example`.
+- `docs/ops/manual-deploy.md` is single-node only and never mentions multi-node deployments.
+- `docs/reference/architecture.md` lists the three `DEPLOY_MODE` profiles but never shows how they combine with the orthogonal `APP_MODE` axis (`standalone` vs `hub`).
+
+An operator who wants "one UI that aggregates two regional data backends" today has to read the source to figure out the `registry.json` schema, guess that `REGISTRY_URL` exists as an env var, and manually wire `DEPLOY_MODE=ui` + `APP_MODE=hub` together by hand-editing `.env`.
+
+## What Changes
+
+- Add `docs/ops/federated-deployment.md` — a step-by-step walkthrough for the Hub-UI + N × data-node topology, including a copy-pasteable `registry.json` example and a topology diagram.
+- Add a `REGISTRY_URL` row to the variable table in `docs/ops/configuration.md` (mode column: `ui` with `APP_MODE=hub`).
+- Add a commented Hub block to `.env.example` showing `APP_MODE=hub` and `REGISTRY_URL`.
+- Add a `docs/reference/registry-json.md` reference page documenting the `registry.json` schema, the two accepted top-level shapes (`{instances:[...]}` and bare array), and the fields the Hub reads from each entry.
+- Extend `docs/reference/architecture.md` with a 2-axis matrix (`DEPLOY_MODE` × `APP_MODE`) making the legal combinations explicit.
+- Link the new walkthrough from `docs/reference/federation.md` and from the MkDocs nav in `mkdocs.yml`.
+
+Out of scope (possible follow-up proposals):
+- Extending `install.sh` to offer Hub as a first-class selection. (Would require a secondary prompt after `DEPLOY_MODE=ui` for `APP_MODE` + `REGISTRY_URL`.)
+- Restructuring the deployment docs around the 2-axis model rather than just adding a matrix.
+
+## Capabilities
+
+### New Capabilities
+
+- `federated-hub-deployment-docs`: Documentation required to stand up a federated deployment (one Hub UI + ≥ 1 data-node backend) without reading source code.
+
+### Modified Capabilities
+
+- (none — this change only adds docs and example-config lines; runtime behaviour is untouched.)
+
+## Impact
+
+- `docs/ops/federated-deployment.md` — new file.
+- `docs/reference/registry-json.md` — new file.
+- `docs/ops/configuration.md` — new row in the variables table.
+- `docs/reference/architecture.md` — new section (deploy-mode × app-mode matrix).
+- `docs/reference/federation.md` — link added pointing to the walkthrough.
+- `.env.example` — new commented Hub block.
+- `mkdocs.yml` — nav entries for the two new pages.
+- No code changes. No existing doc pages are restructured.

--- a/openspec/changes/document-federated-hub-deployment/specs/federated-hub-deployment-docs/spec.md
+++ b/openspec/changes/document-federated-hub-deployment/specs/federated-hub-deployment-docs/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Federated deployment walkthrough exists
+The documentation SHALL contain an end-to-end walkthrough page for standing up a federated deployment consisting of one Hub UI (`DEPLOY_MODE=ui`, `APP_MODE=hub`) plus one or more data-nodes (`DEPLOY_MODE=data-node`) without any UI of their own.
+
+#### Scenario: Walkthrough page is reachable from the MkDocs site
+- **WHEN** the MkDocs site is built
+- **THEN** a page titled "Federated deployment" (or equivalent) is present under the Ops section of the navigation and is built without warnings in `--strict` mode
+
+#### Scenario: Walkthrough describes every node's `.env`
+- **WHEN** a reader follows the walkthrough
+- **THEN** the `.env` content for each data-node and for the Hub UI is shown explicitly, with mode-specific variables called out (e.g. `APP_MODE=hub` and `REGISTRY_URL` on the Hub; `OSM_RELATION_ID`, `PBF_URL` on each data-node)
+
+#### Scenario: Walkthrough provides a copy-pasteable registry example
+- **WHEN** a reader reaches the Hub configuration step
+- **THEN** a complete `registry.json` example with at least two backend entries is shown inline, ready to copy
+
+#### Scenario: Walkthrough shows the docker compose invocations
+- **WHEN** a reader reaches the "start the stack" step for each node
+- **THEN** the exact `docker compose --profile <mode> up -d` command (and for data-nodes, the importer invocation) is shown
+
+### Requirement: registry.json schema is documented
+The documentation SHALL contain a reference page describing the accepted `registry.json` shapes and per-entry fields, with the page linked from the federation reference page.
+
+#### Scenario: Both accepted top-level shapes are documented
+- **WHEN** a reader consults the registry-json reference page
+- **THEN** both `{instances: [...]}` and bare-array shapes are documented as valid, matching the behaviour in `app/src/hub/registry.js`
+
+#### Scenario: Per-entry fields match implementation
+- **WHEN** a reader consults the registry-json reference page
+- **THEN** the required (`url`) and optional (`name`) fields are listed, and fields that are populated at runtime from `/api/rpc/get_meta` (`version`, `region`) are clearly marked as *not* user-settable in the file
+
+### Requirement: REGISTRY_URL listed in the configuration reference
+The configuration-variables table in `docs/ops/configuration.md` SHALL include a row for `REGISTRY_URL`, consistent with its use by `oci/app/docker-entrypoint.sh` and `app/src/lib/config.js`.
+
+#### Scenario: Variable is listed with mode scope
+- **WHEN** a reader consults the configuration variables table
+- **THEN** `REGISTRY_URL` appears with its mode scope (`ui` when `APP_MODE=hub`) and a one-line description linking to the walkthrough or registry-json reference
+
+### Requirement: Hub block exists in `.env.example`
+The `.env.example` file SHALL contain a commented-out Hub section showing `APP_MODE=hub` and `REGISTRY_URL`, with a comment pointing operators to the walkthrough.
+
+#### Scenario: Hub block is present and commented
+- **WHEN** `.env.example` is inspected
+- **THEN** a section starting with a Hub heading contains at minimum `# APP_MODE=hub` and `# REGISTRY_URL=…`, both commented, plus a one-line pointer to the walkthrough page
+
+### Requirement: Deploy-mode × app-mode matrix in architecture doc
+The architecture reference SHALL include a matrix showing legal combinations of `DEPLOY_MODE` (`data-node`, `ui`, `data-node-ui`) and `APP_MODE` (`standalone`, `hub`), so readers understand the two axes are orthogonal.
+
+#### Scenario: Matrix marks the Hub-UI cell
+- **WHEN** a reader consults the architecture reference
+- **THEN** the matrix clearly identifies the `ui + hub` cell as the federated Hub topology and points to the walkthrough
+
+#### Scenario: Matrix marks the impossible cell
+- **WHEN** a reader consults the matrix
+- **THEN** the `data-node + hub` cell is marked N/A (no UI to run in hub mode), so the combination is not attempted

--- a/openspec/changes/document-federated-hub-deployment/tasks.md
+++ b/openspec/changes/document-federated-hub-deployment/tasks.md
@@ -1,0 +1,49 @@
+## 1. Walkthrough page — `docs/ops/federated-deployment.md`
+
+- [ ] 1.1 Add an intro paragraph defining the topology: one Hub UI + ≥ 1 data-node, no UI on the backends
+- [ ] 1.2 Include an ASCII topology diagram showing browser → Hub UI → N × data-node
+- [ ] 1.3 Document the per-node `.env` for each data-node (`DEPLOY_MODE=data-node`, `OSM_RELATION_ID`, `PBF_URL`, `POSTGRES_PASSWORD`)
+- [ ] 1.4 Document the Hub UI's `.env` (`DEPLOY_MODE=ui`, `APP_MODE=hub`, `REGISTRY_URL`, `HUB_POLL_INTERVAL`, `APP_PORT`) — note that `API_BASE_URL` is *not* set on a Hub
+- [ ] 1.5 Show a copy-pasteable `registry.json` example covering two backends in the `{instances: [...]}` shape
+- [ ] 1.6 Document where `registry.json` is served from (same origin as the Hub UI) and the CORS requirement on data nodes
+- [ ] 1.7 Show the exact `docker compose --profile ui up -d` invocation for the Hub and `--profile data-node up -d` + `run --rm importer` for each backend
+- [ ] 1.8 Add a "Verification" section: operator visits the Hub, opens DevTools, sees features loaded from each backend URL
+
+## 2. Registry schema reference — `docs/reference/registry-json.md`
+
+- [ ] 2.1 Document the two accepted top-level shapes: `{instances: [...]}` and bare array (source of truth: `app/src/hub/registry.js:93`)
+- [ ] 2.2 Document per-entry fields read by the Hub: `url` (required), `name` (optional, falls back to meta or url)
+- [ ] 2.3 Note which fields come from `/api/rpc/get_meta` at runtime (`version`, `region`) so readers don't try to set them in `registry.json`
+- [ ] 2.4 Include a minimal and a full example side-by-side
+
+## 3. Configuration reference — `docs/ops/configuration.md`
+
+- [ ] 3.1 Add a `REGISTRY_URL` row: default unset, mode `ui` (hub), description + link to the registry-json reference page
+- [ ] 3.2 Clarify the existing `APP_MODE` row so it's visible that `hub` requires `REGISTRY_URL`
+
+## 4. Architecture reference — `docs/reference/architecture.md`
+
+- [ ] 4.1 Under "Deployment modes", add a second subsection showing the `DEPLOY_MODE` × `APP_MODE` matrix
+- [ ] 4.2 Mark the legal-and-useful cells; mark `data-node × hub` as N/A (no UI to run in hub mode)
+- [ ] 4.3 Include a one-line caption pointing readers at `docs/ops/federated-deployment.md` for the hub topology
+
+## 5. Federation page cross-link — `docs/reference/federation.md`
+
+- [ ] 5.1 Add a "See also" link to `docs/ops/federated-deployment.md` as the stand-up walkthrough
+- [ ] 5.2 Add a "See also" link to `docs/reference/registry-json.md` for the schema
+
+## 6. `.env.example` — Hub block
+
+- [ ] 6.1 Add a commented "Hub mode" section with `APP_MODE=hub` and `REGISTRY_URL=` (both commented out)
+- [ ] 6.2 Add a one-line comment pointing at `docs/ops/federated-deployment.md`
+
+## 7. MkDocs nav — `mkdocs.yml`
+
+- [ ] 7.1 Add `docs/ops/federated-deployment.md` under the Ops section of the nav
+- [ ] 7.2 Add `docs/reference/registry-json.md` under the Reference section of the nav
+
+## 8. Validation
+
+- [ ] 8.1 Run `mkdocs build --strict` and confirm no broken links / nav warnings
+- [ ] 8.2 Run `openspec validate document-federated-hub-deployment --strict` and confirm it passes
+- [ ] 8.3 Read the walkthrough top-to-bottom as if standing up a real cluster — sanity-check that every command is correct against `compose.prod.yml` and `install.sh`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/deployment-mode-selection/spec.md
+++ b/openspec/specs/deployment-mode-selection/spec.md
@@ -1,0 +1,90 @@
+# deployment-mode-selection Specification
+
+## Purpose
+TBD - created by archiving change install-deployment-mode-selection. Update Purpose after archive.
+## Requirements
+### Requirement: Mode selection prompt
+The installer SHALL present a numbered menu asking the operator to choose a deployment mode before any other configuration questions. Valid choices are `data-node`, `ui`, and `data-node-ui`.
+
+#### Scenario: Operator selects data-node
+- **WHEN** operator enters `1` (data-node) at the mode prompt
+- **THEN** `DEPLOY_MODE=data-node` is set and only region, PBF, importer-threads questions are asked
+
+#### Scenario: Operator selects ui
+- **WHEN** operator enters `2` (ui) at the mode prompt
+- **THEN** `DEPLOY_MODE=ui` is set and only remote API URL, UI links, map display, and app-port questions are asked
+
+#### Scenario: Operator selects data-node-ui
+- **WHEN** operator enters `3` (data-node-ui) at the mode prompt
+- **THEN** `DEPLOY_MODE=data-node-ui` is set and all existing questions are asked (current behaviour preserved)
+
+#### Scenario: Operator enters invalid choice
+- **WHEN** operator enters a value other than 1, 2, or 3
+- **THEN** the installer prints an error and re-displays the menu until a valid choice is made
+
+### Requirement: Remote API URL for UI mode
+When mode is `ui`, the installer SHALL ask for the base URL of the remote PostgREST API endpoint and write it as `API_BASE_URL` in `.env`.
+
+#### Scenario: UI mode API URL collected
+- **WHEN** `DEPLOY_MODE=ui` and operator enters a URL (e.g. `https://data.example.com/api`)
+- **THEN** `.env` contains `API_BASE_URL=https://data.example.com/api`
+
+#### Scenario: UI mode API URL has no default
+- **WHEN** `DEPLOY_MODE=ui` and operator leaves API URL blank
+- **THEN** installer treats it as a required field and asks again
+
+### Requirement: DEPLOY_MODE written to .env
+The installer SHALL write `DEPLOY_MODE=<value>` to `.env` so that operators can re-run `docker compose` with the correct profile without remembering their original choice.
+
+#### Scenario: .env contains DEPLOY_MODE after install
+- **WHEN** installer completes successfully for any mode
+- **THEN** `.env` contains `DEPLOY_MODE=<chosen-mode>`
+
+### Requirement: Docker Compose profile passed to all commands
+Every `docker compose` call in the installer (pull, up, run importer) SHALL include `--profile $DEPLOY_MODE` so only the services for the selected mode are started.
+
+#### Scenario: data-node mode starts only data services
+- **WHEN** `DEPLOY_MODE=data-node` and operator confirms start
+- **THEN** `docker compose --profile data-node up -d` is executed (db, postgrest started; app not started)
+
+#### Scenario: ui mode starts only app service
+- **WHEN** `DEPLOY_MODE=ui` and operator confirms start
+- **THEN** `docker compose --profile ui up -d` is executed (app started; db, postgrest not started)
+
+#### Scenario: data-node-ui mode starts all services
+- **WHEN** `DEPLOY_MODE=data-node-ui` and operator confirms start
+- **THEN** `docker compose --profile data-node-ui up -d` is executed (all services started)
+
+### Requirement: compose.prod.yml profiles for all services
+Every service in `compose.prod.yml` SHALL declare the `profiles` list matching the modes in which it participates.
+
+#### Scenario: db and postgrest carry data-node and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `db` and `postgrest` services list profiles `[data-node, data-node-ui]`
+
+#### Scenario: importer carries data-node and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `importer` service lists profiles `[data-node, data-node-ui]`
+
+#### Scenario: app carries ui and data-node-ui profiles
+- **WHEN** compose file is parsed
+- **THEN** `app` service lists profiles `[ui, data-node-ui]`
+
+### Requirement: Importer step skipped for UI mode
+The installer SHALL skip the OSM import prompt when `DEPLOY_MODE=ui` because there is no local database.
+
+#### Scenario: No import prompt in UI mode
+- **WHEN** `DEPLOY_MODE=ui`
+- **THEN** the "Run OSM import now?" confirmation is not shown
+
+### Requirement: Done message shows relevant URLs
+The final summary SHALL show only the services relevant to the selected mode.
+
+#### Scenario: data-node done message
+- **WHEN** `DEPLOY_MODE=data-node`
+- **THEN** done message shows no app URL (app is not running)
+
+#### Scenario: ui done message
+- **WHEN** `DEPLOY_MODE=ui`
+- **THEN** done message shows the app URL and omits database/importer hints
+

--- a/openspec/specs/hub-ui-parity/spec.md
+++ b/openspec/specs/hub-ui-parity/spec.md
@@ -1,0 +1,148 @@
+# hub-ui-parity Specification
+
+## Purpose
+TBD - created by archiving change hub-ui-parity. Update Purpose after archive.
+## Requirements
+### Requirement: Feature parity with standalone
+
+Hub-mode deployments SHALL render the same user-facing feature set as standalone-mode deployments: map, playground detail panel, search bar, filter chips, filter panel, locate button, zoom controls, hover preview, nearby-playground suggestions, data-contribution modal, and responsive mobile bottom-sheet.
+
+#### Scenario: Hub loads with reachable backends
+
+- **WHEN** a user opens a hub deployment and at least one backend is reachable
+- **THEN** every standalone-mode widget is rendered and interactive
+- **AND** no widget is hidden or disabled solely because `APP_MODE=hub`
+
+#### Scenario: Hub search uses aggregated extent
+
+- **WHEN** a user types a query in the search bar in hub mode
+- **THEN** Nominatim is called with `viewbox` equal to the union of all backends' `get_meta.bbox` values
+- **AND** if no backend has reported metadata yet, the search falls back to an unbounded query
+
+#### Scenario: Hub initial map fit
+
+- **WHEN** the hub loads and all backends have reported `get_meta`
+- **THEN** the map view is fit to the union of their bounding boxes with standard padding
+- **AND** if only one backend is registered the view is fit to that backend's bbox
+
+### Requirement: Backend instance visibility
+
+The hub SHALL display a collapsed pill in the bottom-left corner showing the count of registered regions and the summed playground count, expandable into a drawer that lists each backend's name, version, current playground count, and error state.
+
+#### Scenario: Pill shows aggregated counts
+
+- **WHEN** the registry has loaded and every backend has reported a feature count
+- **THEN** the pill shows `<N> Regionen · <M> Spielplätze` where N is the backend count and M is the sum across backends
+
+#### Scenario: Pill shows loading state
+
+- **WHEN** the registry is still being fetched
+- **THEN** the pill shows a spinner and a localised "loading instances" message
+
+#### Scenario: Pill shows registry error
+
+- **WHEN** the registry fetch fails
+- **THEN** the pill shows a warning icon and a localised "registry unreachable" message
+
+#### Scenario: Drawer opens and closes
+
+- **WHEN** the user clicks the pill
+- **THEN** a drawer slides up, listing every backend with name, version, count, and status
+- **AND** keyboard focus moves into the drawer
+- **AND** `aria-expanded=true` is set on the pill
+- **WHEN** the user presses ESC, clicks outside the drawer, or clicks the pill again
+- **THEN** the drawer collapses and focus returns to the pill
+
+#### Scenario: Scale-line does not overlap the pill
+
+- **WHEN** both the pill and the scale-line are visible in the bottom-left region
+- **THEN** the scale-line is rendered below the pill without visual overlap
+
+### Requirement: Deep-link with backend slug
+
+The URL hash SHALL support a `#<slug>/W<osm_id>` form where `<slug>` identifies a backend in `registry.json`. The legacy `#W<osm_id>` form SHALL continue to work.
+
+#### Scenario: Deep-link with slug in hub mode
+
+- **WHEN** a user visits `/#bw/W1234567` on a hub registry containing a backend with `slug: "bw"`
+- **THEN** the hub waits for that backend's features to load
+- **AND** selects the feature whose `osm_id` equals `1234567` on that backend
+
+#### Scenario: Deep-link without slug in hub mode
+
+- **WHEN** a user visits `/#W1234567` on a hub
+- **THEN** the hub searches every loaded backend's features for `osm_id = 1234567`
+- **AND** selects the first match found
+- **AND** logs a console warning if more than one backend contains that osm_id
+
+#### Scenario: Deep-link in standalone mode ignores slug
+
+- **WHEN** a user visits `/#anything/W1234567` on a standalone instance
+- **THEN** the instance selects `osm_id = 1234567` from its single configured backend
+- **AND** the slug is ignored with no warning or error
+
+#### Scenario: Selection updates the hash with slug
+
+- **WHEN** a user selects a playground in hub mode and the owning backend has a slug
+- **THEN** `location.hash` is set to `#<slug>/W<osm_id>`
+
+#### Scenario: Selection updates the hash without slug
+
+- **WHEN** a user selects a playground in hub mode and the owning backend has no slug
+- **THEN** `location.hash` is set to `#W<osm_id>` (legacy form)
+
+### Requirement: Multi-backend nearest-playground search
+
+In hub mode the nearby-playgrounds suggestion feature SHALL aggregate results from all registered backends, deduplicated by `osm_id` and sorted by distance ascending.
+
+#### Scenario: Nearby suggestions span backends
+
+- **WHEN** the user triggers the locate action and a position is obtained in hub mode
+- **THEN** each reachable backend's `get_nearest_playgrounds` is called in parallel
+- **AND** the merged results are shown, sorted by distance ascending
+- **AND** results with duplicate `osm_id` across backends keep only the nearest entry
+
+#### Scenario: Slow or failing backend does not block UI
+
+- **WHEN** one backend's `get_nearest_playgrounds` fails or times out
+- **THEN** results from the remaining backends are rendered without blocking user interaction
+- **AND** the timeout does not exceed the configured per-backend limit
+
+### Requirement: Generic data-contribution links in hub mode
+
+In hub mode the data-contribution modal SHALL link to the generic OSM wiki page for the `leisure=playground` tag and SHALL NOT show a regional chat link.
+
+#### Scenario: Contribution modal in hub
+
+- **WHEN** the user opens the data-contribution modal in hub mode
+- **THEN** the wiki link points to `https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground`
+- **AND** no chat link section is rendered
+
+#### Scenario: Contribution modal in standalone unchanged
+
+- **WHEN** the user opens the data-contribution modal in standalone mode
+- **THEN** the wiki link uses `regionPlaygroundWikiUrl` from configuration
+- **AND** the chat link appears if and only if `regionChatUrl` is configured
+
+### Requirement: Optional slug field in registry.json
+
+A `registry.json` entry MAY include a `slug` string field identifying the backend for deep-link purposes. The field SHALL be optional and SHALL NOT break existing registries that omit it.
+
+#### Scenario: Entry with slug
+
+- **WHEN** a registry entry contains `"slug": "bw"` alongside `name` and `url`
+- **THEN** the backend record exposes `slug: "bw"`
+- **AND** deep-links of the form `#bw/W<osm_id>` resolve to this backend
+
+#### Scenario: Entry without slug
+
+- **WHEN** a registry entry omits `slug`
+- **THEN** the backend record exposes `slug: null`
+- **AND** broadcast-search (hash without slug) still works for playgrounds on this backend
+
+#### Scenario: Invalid slug format
+
+- **WHEN** a registry entry contains a `slug` that does not match `[a-z0-9-]+`
+- **THEN** the slug is treated as missing
+- **AND** a console warning identifies the offending entry by URL
+

--- a/openspec/specs/mkdocs-site/spec.md
+++ b/openspec/specs/mkdocs-site/spec.md
@@ -1,0 +1,67 @@
+# mkdocs-site Specification
+
+## Purpose
+TBD - created by archiving change setup-mkdocs-docs-site. Update Purpose after archive.
+## Requirements
+### Requirement: MkDocs site builds locally
+The repository SHALL include a `docs/` directory, `mkdocs.yml`, and `docs/requirements.txt` sufficient to build and serve the documentation site locally using `make docs-serve`.
+
+#### Scenario: Local preview
+- **WHEN** a developer runs `make docs-install` then `make docs-serve`
+- **THEN** a live-reload server starts at `http://localhost:8000` showing the full docs site
+
+#### Scenario: Clean build
+- **WHEN** a developer runs `make docs-build`
+- **THEN** a static site is generated in `site/` with no errors in strict mode
+
+### Requirement: Makefile docs targets
+The Makefile SHALL include four targets: `docs-install`, `docs-serve`, `docs-build`, `docs-clean`.
+
+#### Scenario: Install target creates virtualenv
+- **WHEN** `make docs-install` is run
+- **THEN** a `.venv` directory is created and all packages from `docs/requirements.txt` are installed into it
+
+#### Scenario: Clean target removes artifacts
+- **WHEN** `make docs-clean` is run
+- **THEN** the `site/` directory and `.venv` are removed
+
+### Requirement: GitHub Pages deployment on main push
+A GitHub Actions workflow SHALL deploy the docs site to GitHub Pages on every push to `main` that touches `docs/**` or `mkdocs.yml`, and on manual dispatch.
+
+#### Scenario: Automatic deploy on docs change
+- **WHEN** a commit touching `docs/` or `mkdocs.yml` is pushed to `main`
+- **THEN** the workflow runs, builds the site, and pushes it to the `gh-pages` branch
+
+#### Scenario: Manual deploy trigger
+- **WHEN** the workflow is triggered via `workflow_dispatch`
+- **THEN** the site is built and deployed regardless of which files changed
+
+### Requirement: Material theme with search and edit links
+The docs site SHALL use the MkDocs Material theme with full-text search enabled and an edit button on every page linking to the source file on GitHub.
+
+#### Scenario: Search returns relevant results
+- **WHEN** a visitor types "PBF" in the search box
+- **THEN** the glossary entry for PBF file appears in results
+
+#### Scenario: Edit link points to correct file
+- **WHEN** a visitor clicks the edit button on any docs page
+- **THEN** they are taken to the corresponding `.md` file in the `docs/` directory on GitHub
+
+### Requirement: Navigation covers all extracted content
+The docs site SHALL include pages for: quick start, manual deploy, configuration reference, troubleshooting, add-device how-to, architecture reference, tech stack, federation, and glossary.
+
+#### Scenario: All nav items resolve
+- **WHEN** every navigation item in `mkdocs.yml` is followed
+- **THEN** it renders a page with content (no 404s, no empty pages)
+
+### Requirement: Glossary contains only OSM-specific terms
+`docs/reference/glossary.md` SHALL define exactly the following terms and no others: OSM relation ID, PBF file, osm2pgsql, PostgREST, Overpass Turbo.
+
+#### Scenario: Generic tool terms absent
+- **WHEN** the glossary page is rendered
+- **THEN** it does not contain entries for Docker, nginx, PostgreSQL, Vite, Node.js, Svelte, Tailwind, or OpenLayers
+
+#### Scenario: OSM terms present
+- **WHEN** the glossary page is rendered
+- **THEN** it contains definitions for OSM relation ID, PBF file, osm2pgsql, PostgREST, and Overpass Turbo
+

--- a/openspec/specs/playwright-ci/spec.md
+++ b/openspec/specs/playwright-ci/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# playwright-ci Specification
+
+## Purpose
+
+Provide an automated browser-test safety net so regressions in the playground detail panel, map interactions, and security fixes (XSS escaping, contact links) cannot silently ship. Runs on every pull request and every push to `main`, with an HTML report uploaded on failure.
+
+## Requirements
 
 ### Requirement: CI workflow runs Playwright tests on every PR and push to main
 The system SHALL provide a GitHub Actions workflow (`playwright.yml`) that builds the app, starts a preview server, and runs the Playwright test suite on every pull request targeting `main` and every push to `main`.

--- a/openspec/specs/playwright-ci/spec.md
+++ b/openspec/specs/playwright-ci/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: CI workflow runs Playwright tests on every PR and push to main
+The system SHALL provide a GitHub Actions workflow (`playwright.yml`) that builds the app, starts a preview server, and runs the Playwright test suite on every pull request targeting `main` and every push to `main`.
+
+#### Scenario: Workflow triggers on pull request
+- **WHEN** a pull request is opened or updated against `main`
+- **THEN** the `playwright` workflow runs automatically
+
+#### Scenario: Workflow triggers on push to main
+- **WHEN** a commit is pushed to `main`
+- **THEN** the `playwright` workflow runs automatically
+
+#### Scenario: Tests pass on a clean build
+- **WHEN** the workflow runs and all tests pass
+- **THEN** the workflow job completes with a green status
+
+#### Scenario: Test report uploaded on failure
+- **WHEN** one or more Playwright tests fail
+- **THEN** the workflow uploads the Playwright HTML report as a workflow artefact named `playwright-report`
+
+---
+
+### Requirement: Map loads and renders on startup
+The app SHALL load and display a map when the page is opened.
+
+#### Scenario: Map canvas is visible
+- **WHEN** the page is loaded
+- **THEN** an OpenLayers map canvas element is visible in the viewport
+
+#### Scenario: Page title is set
+- **WHEN** the page is loaded
+- **THEN** the document title contains "Spielplatzkarte"
+
+---
+
+### Requirement: Playground selection opens info panel
+The app SHALL open the info panel when a playground feature is clicked on the map.
+
+#### Scenario: Info panel appears after playground click
+- **WHEN** a playground marker is clicked on the map
+- **THEN** the info panel becomes visible
+
+#### Scenario: URL hash is set on selection
+- **WHEN** a playground marker is clicked on the map
+- **THEN** the URL hash is updated to contain the playground's OSM ID
+
+---
+
+### Requirement: ESC key closes the info panel and clears the URL hash
+The app SHALL close the info panel and clear the URL hash when the ESC key is pressed while a playground is selected.
+
+#### Scenario: ESC closes panel
+- **WHEN** a playground is selected and the ESC key is pressed
+- **THEN** the info panel is no longer visible
+
+#### Scenario: ESC clears URL hash
+- **WHEN** a playground is selected and the ESC key is pressed
+- **THEN** the URL hash is empty
+
+---
+
+### Requirement: URL hash restores playground selection on page load
+The app SHALL re-select the playground identified by the URL hash when the page is loaded with a hash present.
+
+#### Scenario: Hash on load opens info panel
+- **WHEN** the page is loaded with a URL hash containing a valid playground OSM ID
+- **THEN** the info panel becomes visible with data for that playground
+
+---
+
+### Requirement: OSM field values are rendered as plain text, not HTML
+The app SHALL escape special HTML characters in OSM tag values so that crafted values cannot inject HTML or execute scripts.
+
+#### Scenario: HTML characters in playground name are escaped
+- **WHEN** a playground has a name containing `<`, `>`, or `&` characters
+- **THEN** those characters are displayed as visible text in the info panel, not interpreted as HTML
+
+#### Scenario: Script tag in description does not execute
+- **WHEN** a playground's description field contains a `<script>` tag value (intercepted via route mock)
+- **THEN** no script executes and the literal text is visible in the panel

--- a/openspec/specs/rc-container-tag/spec.md
+++ b/openspec/specs/rc-container-tag/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# rc-container-tag Specification
+
+## Purpose
+
+Separate pre-release container images from stable releases: every merge to `main` publishes an `:rc`-tagged image for testers, while `:latest` remains exclusively tied to version tags so operators pulling `:latest` always get a tested release.
+
+## Requirements
 
 ### Requirement: RC image published on main push
 The CI pipeline SHALL publish container images tagged `:rc` for both the app image and the importer image on every push to the `main` branch (i.e. every merged PR).

--- a/openspec/specs/rc-container-tag/spec.md
+++ b/openspec/specs/rc-container-tag/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: RC image published on main push
+The CI pipeline SHALL publish container images tagged `:rc` for both the app image and the importer image on every push to the `main` branch (i.e. every merged PR).
+
+#### Scenario: App image tagged rc on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** the app image `ghcr.io/<repo>` is pushed with the `:rc` tag
+
+#### Scenario: Importer image tagged rc on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** the importer image `ghcr.io/<repo>-importer` is pushed with the `:rc` tag
+
+#### Scenario: RC tag not published on version tag push
+- **WHEN** a `v*` tag is pushed
+- **THEN** neither the app nor the importer image is tagged `:rc`
+
+### Requirement: latest tag reserved for version releases
+The CI pipeline SHALL NOT publish the `:latest` tag on pushes to `main`. The `:latest` tag SHALL only be published when a version tag (`v*`) is pushed.
+
+#### Scenario: Latest not overwritten on main push
+- **WHEN** a commit is pushed to `main`
+- **THEN** neither image is pushed with the `:latest` tag
+
+#### Scenario: Short-SHA tag still published
+- **WHEN** a commit is pushed to `main`
+- **THEN** both images are still pushed with the short commit SHA tag for traceability

--- a/openspec/specs/scheduled-importer/spec.md
+++ b/openspec/specs/scheduled-importer/spec.md
@@ -1,0 +1,29 @@
+### Requirement: Service unit runs the importer via Docker Compose
+The system SHALL provide a `deploy/spielplatzkarte-import.service` systemd service unit that executes `docker compose run --rm importer` in the project directory, loading credentials from the `.env` file via `EnvironmentFile=`.
+
+#### Scenario: Service unit executes the importer container
+- **WHEN** the service unit is started (manually or by the timer)
+- **THEN** `docker compose run --rm importer` is invoked in the configured `WorkingDirectory`
+- **THEN** the importer container runs to completion and is removed afterwards
+
+#### Scenario: Service unit picks up environment from .env
+- **WHEN** the service unit starts
+- **THEN** environment variables from `.env` (e.g. `OSM_RELATION_ID`, `PBF_URL`) are available to the Docker Compose invocation
+
+### Requirement: Timer unit triggers the importer weekly
+The system SHALL provide a `deploy/spielplatzkarte-import.timer` systemd timer unit that activates the service unit once a week with `Persistent=true`.
+
+#### Scenario: Timer fires on the weekly schedule
+- **WHEN** the configured weekly calendar expression elapses
+- **THEN** `spielplatzkarte-import.service` is started automatically
+
+#### Scenario: Missed run is caught on next boot
+- **WHEN** the system was offline during a scheduled run
+- **THEN** `spielplatzkarte-import.service` is started once on the next boot due to `Persistent=true`
+
+### Requirement: Unit files are documented for installation
+The project documentation SHALL describe how to copy, configure, and enable the unit files so operators can set up automated imports without prior systemd expertise.
+
+#### Scenario: Operator follows the documented install steps
+- **WHEN** an operator follows the documented procedure (copy units, edit `WorkingDirectory` and `User=`, `systemctl enable --now`)
+- **THEN** the timer is active and the importer runs automatically each week

--- a/openspec/specs/scheduled-importer/spec.md
+++ b/openspec/specs/scheduled-importer/spec.md
@@ -1,3 +1,11 @@
+# scheduled-importer Specification
+
+## Purpose
+
+Give operators a drop-in systemd service + timer pair so OSM data refreshes weekly without custom cron jobs or manual intervention. The service runs `docker compose run --rm importer` against the project's existing `.env`; the timer fires weekly with `Persistent=true` to catch missed runs on next boot.
+
+## Requirements
+
 ### Requirement: Service unit runs the importer via Docker Compose
 The system SHALL provide a `deploy/spielplatzkarte-import.service` systemd service unit that executes `docker compose run --rm importer` in the project directory, loading credentials from the `.env` file via `EnvironmentFile=`.
 

--- a/openspec/specs/slim-readme/spec.md
+++ b/openspec/specs/slim-readme/spec.md
@@ -1,0 +1,49 @@
+# slim-readme Specification
+
+## Purpose
+TBD - created by archiving change setup-mkdocs-docs-site. Update Purpose after archive.
+## Requirements
+### Requirement: README is a concise landing page
+`README.md` SHALL be reduced to approximately 150 lines and contain only: project one-liner, origin attribution, architecture diagram, tech stack table, quick install snippet, abbreviated configuration (top vars + link to full docs), local development (3 make commands), contributing one-liner with links, federation section, external services table, and license.
+
+#### Scenario: README line count
+- **WHEN** the updated README is rendered
+- **THEN** it is no longer than 200 lines
+
+#### Scenario: README contains no ToC
+- **WHEN** the README is rendered on GitHub
+- **THEN** there is no manually-maintained table of contents section (GitHub renders heading anchors automatically)
+
+#### Scenario: Deep content links to docs
+- **WHEN** a reader encounters the configuration, troubleshooting, or contributing sections
+- **THEN** each section contains a link pointing to the corresponding docs site page
+
+### Requirement: Glossary reference removed from README
+The Glossary section SHALL be removed from `README.md` entirely, replaced by a single sentence linking to `docs/reference/glossary.md`.
+
+#### Scenario: No glossary table in README
+- **WHEN** `README.md` is rendered
+- **THEN** it contains no table with tool/term definitions
+
+#### Scenario: Glossary linked
+- **WHEN** `README.md` is rendered
+- **THEN** it contains at least one link to the docs glossary page
+
+### Requirement: CONTRIBUTING.md at repo root
+A `CONTRIBUTING.md` file SHALL exist at the repository root containing the full contributing workflow (issue → branch → change → commit → PR), branch naming convention, and commit message format.
+
+#### Scenario: GitHub surfaces CONTRIBUTING.md
+- **WHEN** a user opens a new issue or PR on GitHub
+- **THEN** GitHub displays a link to `CONTRIBUTING.md`
+
+#### Scenario: README Contributing section is brief
+- **WHEN** `README.md` is rendered
+- **THEN** the Contributing section is no longer than 5 lines and links to `CONTRIBUTING.md`
+
+### Requirement: Deploy commands updated
+All `docker compose` command examples in `README.md` SHALL include the `--profile` flag consistent with the deployment mode changes introduced in PR #118.
+
+#### Scenario: No bare docker compose commands
+- **WHEN** `README.md` is scanned for `docker compose` invocations
+- **THEN** every invocation that starts services includes `--profile <mode>`
+


### PR DESCRIPTION
## Summary

- Revise ADR-0001 with a 2026-04-20 revision block (the "real friction" trigger it anticipated has fired).
- Remove the wholesale `openspec/` line from `.gitignore`.
- Baseline commit of the whole `openspec/` tree: specs, archive, two in-flight federation proposals, two new drafts for Europe-scale playground delivery.

## Why now

During a collaborative `/opsx:explore` session, @ronnytrommer drafted two multi-file change proposals (`add-tiered-playground-delivery`, `add-federated-playground-clustering`) that each span four files. The original ADR prescribed issue-paste handoff (pattern from #190) — which does not scale to multi-file proposals. Round-tripping edits between issue comments and local `openspec/changes/` diverges almost immediately.

## What the revision changes

Original decision: track `specs/` + `changes/archive/`; exclude active `changes/<name>/`.
Revised decision: track everything. Branch discipline carries the "private WIP vs ready to share" boundary.

## Coordination (please read before merging)

Per the coordination step added to ADR-0001 under this revision, local `openspec/` trees differ between @mfuhrmann and @ronnytrommer. This PR is opened as **draft** so @mfuhrmann can:

1. Review the diff for `openspec/changes/add-federation-health-exposition/` and `openspec/changes/document-federated-hub-deployment/` — these are his in-flight proposals as they exist in @ronnytrommer's local tree.
2. If his authoritative local versions differ, push the correct versions onto this branch before marking ready for review.
3. On merge, both contributors should hard-reset their local `openspec/` to the committed tree and cherry-pick any diverged local commits back on top.

## Files touched

- `docs/adr/0001-openspec-sharing-policy.md` — revision block appended, status updated to "Revised"
- `.gitignore` — removed `openspec/` line
- `openspec/**` — 56 baseline files (7 specs, 6 archived changes, 4 active proposals)

## Test plan

- [ ] @mfuhrmann reviews and reconciles the two in-flight federation proposals
- [ ] `openspec validate --all` passes on this branch
- [ ] `.gitignore` change reviewed for any unintended consequences
- [ ] Both contributors confirm they can cleanly reset to the merged baseline

Refs #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)