### PR TITLE
fix(api): union region polygon rows in get_nearest_playgrounds

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -629,7 +629,7 @@ AS $$
       ST_SetSRID(ST_MakePoint(lon, lat), 4326)::geography            AS geog_4326
   ),
   region AS (
-    SELECT way FROM planet_osm_polygon WHERE osm_id = -relation_id LIMIT 1
+    SELECT ST_Union(way) AS way FROM planet_osm_polygon WHERE osm_id = -relation_id
   ),
   nearest AS (
     SELECT


### PR DESCRIPTION
Closes #199

## Summary

- `get_nearest_playgrounds` used `LIMIT 1` when building the region CTE, which returned only one row of the region polygon — breaking regions stored as multiple rows in `planet_osm_polygon`
- Replaced with `ST_Union(way)` to correctly merge all rows for the relation before computing the nearest-playground distance filter

## Test plan

- [ ] Search for a location and trigger the "nearest playgrounds" suggestion panel
- [ ] Verify suggestions are within the correct region (not 300 km away)
- [ ] Works for regions stored as multiple polygon rows (e.g. Fulda Stadt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)