### PR TITLE
feat(ui): add completeness legend to map start page (#201)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -10,6 +10,7 @@
   import EquipmentTooltip from './EquipmentTooltip.svelte';
   import NearbyPlaygrounds from './NearbyPlaygrounds.svelte';
   import DataContributionModal from './DataContributionModal.svelte';
+  import CompletenessLegend from './CompletenessLegend.svelte';
   import { onDestroy, onMount } from 'svelte';
   import { Pencil, Plus, Minus } from 'lucide-svelte';
   import { _ } from 'svelte-i18n';
@@ -293,6 +294,12 @@
         {@render instancePanel()}
       </div>
     {/if}
+
+    {#if !$hasSelection}
+      <div class="legend-slot">
+        <CompletenessLegend />
+      </div>
+    {/if}
   {/if}
 
   {#if !isMobile && $hasSelection}
@@ -427,6 +434,20 @@
   @media (max-width: 1023px) {
     .instance-slot {
       left: 0.75rem;
+    }
+  }
+
+  /* Completeness legend — bottom-left, above scale line, behind bottom sheet on mobile */
+  .legend-slot {
+    position: absolute;
+    bottom: 4rem;
+    left: 1rem;
+    z-index: 100;
+  }
+
+  @media (max-width: 1023px) {
+    .legend-slot {
+      z-index: 30;
     }
   }
 

--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -443,6 +443,7 @@
     bottom: 4rem;
     left: 1rem;
     z-index: 100;
+    pointer-events: none;
   }
 
   @media (max-width: 1023px) {

--- a/app/src/components/CompletenessLegend.svelte
+++ b/app/src/components/CompletenessLegend.svelte
@@ -1,0 +1,98 @@
+<script>
+  import { _ } from 'svelte-i18n';
+</script>
+
+<aside class="legend">
+  <ul class="legend-list">
+    <li class="legend-item">
+      <span class="swatch swatch--complete"></span>
+      <span>{$_('completeness.complete')}</span>
+    </li>
+    <li class="legend-item">
+      <span class="swatch swatch--partial"></span>
+      <span>{$_('completeness.partial')}</span>
+    </li>
+    <li class="legend-item">
+      <span class="swatch swatch--missing"></span>
+      <span>{$_('completeness.missing')}</span>
+    </li>
+    <li class="legend-item legend-item--hatch">
+      <span class="swatch swatch--hatch"></span>
+      <span>{$_('completeness.restrictedHint')}</span>
+    </li>
+  </ul>
+</aside>
+
+<style>
+  .legend {
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(4px);
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    padding: 0.5rem 0.65rem;
+    font-size: 0.72rem;
+    color: #374151;
+    max-width: 200px;
+  }
+
+  .legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    line-height: 1.2;
+  }
+
+  .legend-item--hatch {
+    border-top: 1px solid #e5e7eb;
+    padding-top: 0.3rem;
+    margin-top: 0.05rem;
+    color: #6b7280;
+  }
+
+  .swatch {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 1.5px solid;
+  }
+
+  /* Match vectorStyles.js colours exactly */
+  .swatch--complete {
+    background-color: rgba(34, 139, 34, 0.22);
+    border-color: #155215;
+  }
+
+  .swatch--partial {
+    background-color: rgba(234, 179, 8, 0.22);
+    border-color: #92400e;
+  }
+
+  .swatch--missing {
+    background-color: rgba(239, 68, 68, 0.18);
+    border-color: #991b1b;
+  }
+
+  /* Diagonal hatch matching the canvas pattern in vectorStyles.js */
+  .swatch--hatch {
+    background:
+      repeating-linear-gradient(
+        -45deg,
+        rgba(34, 139, 34, 0.55) 0px,
+        rgba(34, 139, 34, 0.55) 1.5px,
+        rgba(34, 139, 34, 0.08) 1.5px,
+        rgba(34, 139, 34, 0.08) 5px
+      );
+    border-color: #155215;
+    border-style: dashed;
+  }
+</style>

--- a/locales/de.json
+++ b/locales/de.json
@@ -69,7 +69,8 @@
     "dotComplete": "Daten vollständig",
     "dotPartial": "Teilweise erfasst",
     "dotMissing": "Daten fehlen",
-    "badgeComplete": "Vollständig"
+    "badgeComplete": "Vollständig",
+    "restrictedHint": "schraffiert = nicht öffentlich"
   },
   "accordion": {
     "photos": "Bilder",

--- a/locales/en.json
+++ b/locales/en.json
@@ -69,7 +69,8 @@
     "dotComplete": "Data complete",
     "dotPartial": "Partially mapped",
     "dotMissing": "No data",
-    "badgeComplete": "Complete"
+    "badgeComplete": "Complete",
+    "restrictedHint": "hatched = not public"
   },
   "accordion": {
     "photos": "Photos",


### PR DESCRIPTION
Closes #201

## Summary

- Restores the colour-key panel from the legacy v0.1.x UI
- Three swatches (green/amber/red) matching the exact polygon fill/stroke colours from `vectorStyles.js`
- Hatched swatch with dashed border explaining restricted-access playgrounds
- Positioned bottom-left above the scale line (`bottom: 4rem`)
- Hidden when a playground is selected (side panel / bottom sheet take over)
- `z-30` on mobile so the bottom sheet naturally covers it when open
- New i18n key `completeness.restrictedHint` in both `de.json` and `en.json`

## Test plan

- [ ] Legend visible at bottom-left on page load (no playground selected)
- [ ] Legend disappears when a playground is clicked/tapped
- [ ] Legend reappears after deselecting
- [ ] On mobile: legend sits behind bottom sheet when swiped up
- [ ] Scale line not covered by the legend
- [ ] Swatch colours match the actual polygon colours on the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)