### PR TITLE
fix: cancel pending hover debounce when pointer leaves playground

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -170,6 +170,7 @@
           debouncedHover(playHit, evt.pixel);
         } else if (!playHit && lastHoverFeature) {
           lastHoverFeature = null;
+          debouncedHover.cancel();
           if (onclearhover) onclearhover();
         }
       }


### PR DESCRIPTION
## Summary
- Adds `debouncedHover.cancel()` in the `!playHit` branch of the `pointermove` handler in `Map.svelte`
- Previously, moving the cursor quickly from playground A → playground B → empty area would cause the popup to re-appear at B's position: `onclearhover()` fired, hiding the popup, but the 100 ms debounce for B still triggered afterward and re-set `hoverFeature`
- The `pointerleave` handler already cancelled the debounce correctly; this brings the inline clear path in line with it

## Test plan
- [ ] Hover over a playground — HoverPreview appears
- [ ] Slowly move cursor off the playground — popup disappears immediately, stays gone
- [ ] Quickly move cursor from playground A → playground B → empty area — popup disappears and does **not** reappear
- [ ] Quickly move cursor from playground A → playground B (staying there) — popup appears for B after ~100 ms

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)