### PR TITLE
fix(ui): prevent long playground names from being clipped in hover preview

### DIFF
--- a/app/src/components/HoverPreview.svelte
+++ b/app/src/components/HoverPreview.svelte
@@ -38,10 +38,10 @@
     style={style}
   >
     <div class="relative -translate-x-1/2 -translate-y-full -mt-3">
-      <div class="hover-card rounded-lg shadow-lg border p-3 min-w-[180px] max-w-[240px]">
+      <div class="hover-card rounded-lg shadow-lg border p-3 min-w-[180px] max-w-[280px]">
 
         <!-- Title -->
-        <h4 class="font-semibold text-sm leading-tight mb-1.5 line-clamp-2" style="color: #1f2937;">
+        <h4 class="font-semibold text-sm leading-tight mb-1.5 line-clamp-2" style="color: #1f2937; hyphens: auto;" lang="de">
           {title}
         </h4>
 


### PR DESCRIPTION
Fixes #216

## Summary
- Widens the hover card from `max-w-[240px]` to `max-w-[280px]` so most German compound words (e.g. "Haderwaldsiedlung") fit on one line without breaking
- Adds `hyphens: auto` with `lang="de"` on the title as a graceful fallback for names that still exceed the card width — browser hyphenates at proper German syllable boundaries instead of clipping

## Test plan
- [ ] Hover over a playground with a long single-word name — full name should be visible
- [ ] Hover over a playground with a short name — card should still be compact
- [ ] Hover over a playground near the top edge of the viewport — positioning unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)