### PR TITLE
fix: remove unused .review-item CSS selectors from ReviewsPanel

### DIFF
--- a/app/src/components/ReviewsPanel.svelte
+++ b/app/src/components/ReviewsPanel.svelte
@@ -190,14 +190,6 @@
     color: #6b7280;
     margin-bottom: 8px;
   }
-  .review-item {
-    margin-bottom: 0.5rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid #f3f4f6;
-    font-size: 13px;
-  }
-  .review-item:last-of-type { border-bottom: none; }
-
   .star-btn {
     background: none; border: none; padding: 0;
     font-size: 22px; line-height: 1; cursor: pointer;


### PR DESCRIPTION
Fixes #239

## Summary
- Removes dead `.review-item` and `.review-item:last-of-type` CSS rules from `ReviewsPanel.svelte` — these selectors were never applied in the template (review entries use `.review-card`)
- Eliminates two `css_unused_selector` build warnings that appeared during `make docker-build`

## Test plan
- [ ] Run `make docker-build` — no `css_unused_selector` warnings for `ReviewsPanel.svelte`
- [ ] Open a playground with reviews — review display unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)