### PR TITLE
fix(nearby): hide suggestions more than 25 km away

### DIFF
--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -24,6 +24,8 @@
    */
   export let defaultBackendUrl = '';
 
+  const MAX_DISTANCE_M = 25_000;
+
   let items = [];
   let loading = true;
 
@@ -65,12 +67,13 @@
     loading = true;
     items = [];
     try {
-      items = fetcher
+      const results = fetcher
         ? await fetcher(lt, lg)
         : nearestFromSource(lt, lg);
+      items = results.filter(item => item.distance_m <= MAX_DISTANCE_M);
     } catch (err) {
       console.error('Nearest playgrounds fetch failed:', err);
-      items = nearestFromSource(lt, lg);
+      items = nearestFromSource(lt, lg).filter(item => item.distance_m <= MAX_DISTANCE_M);
     } finally {
       loading = false;
     }


### PR DESCRIPTION
Closes #199

## Summary

- `NearbyPlaygrounds` now filters out any result with `distance_m > 25 000` before rendering
- Applies to both the PostgREST fetcher path and the client-side vector source fallback
- When no playgrounds are within 25 km the existing "no nearby playgrounds" empty state is shown instead of misleading results from a distant region

## Root cause

The DB function correctly scopes results to each backend's region via `ST_Within`, but there was no maximum distance cap anywhere in the stack. In Hub mode with multiple backends, `fetchNearestAcrossBackends` merges and sorts all results by distance — returning playgrounds 300 km away if the user's location is far from every registered region.

## Test plan

- [ ] Locate / search from within a region — nearby suggestions appear as before
- [ ] Locate / search from far away (different city/region) — panel shows empty state instead of distant results

🤖 Generated with [Claude Code](https://claude.com/claude-code)