### PR TITLE
fix(nearby): remove distance cap; fall back to vector source when API returns empty

### DIFF
--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -24,8 +24,6 @@
    */
   export let defaultBackendUrl = '';
 
-  const MAX_DISTANCE_M = 25_000;
-
   let items = [];
   let loading = true;
 
@@ -70,10 +68,10 @@
       const results = fetcher
         ? await fetcher(lt, lg)
         : nearestFromSource(lt, lg);
-      items = results.filter(item => item.distance_m <= MAX_DISTANCE_M);
+      items = results.length > 0 ? results : nearestFromSource(lt, lg);
     } catch (err) {
       console.error('Nearest playgrounds fetch failed:', err);
-      items = nearestFromSource(lt, lg).filter(item => item.distance_m <= MAX_DISTANCE_M);
+      items = nearestFromSource(lt, lg);
     } finally {
       loading = false;
     }


### PR DESCRIPTION
## Summary

- Removes the `MAX_DISTANCE_M = 25_000` client-side filter that silently hid all results when the user was >25 km from the nearest playground in the loaded dataset. The distance is already shown per row, so the user can judge relevance themselves.
- Adds a fallback to `nearestFromSource` when the API fetcher returns an empty array (not only when it throws), so hub users see suggestions from loaded vector features even when backends are unreachable or `get_nearest_playgrounds` is not yet deployed.

## Test plan

- [ ] Press locate → nearby panel appears with closest playgrounds and distances shown
- [ ] Test from a location far from the covered region (>25 km) → still shows results with correct distance
- [ ] Simulate API failure (disconnect network) → panel falls back to vector-source scan and shows results

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)