### PR TITLE
fix(nearby): cap hub results at 25 km to suppress distant backends

### DIFF
--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -14,6 +14,9 @@ const geojsonFormat = new GeoJSON();
 // backend contributes zero results but never stalls the user interaction.
 const NEAREST_TIMEOUT_MS = 3000;
 const NEAREST_DEFAULT_LIMIT = 10;
+// Discard results from backends that are farther away than this — prevents
+// a distant backend from polluting the list with its own "nearby" playgrounds.
+const NEAREST_MAX_DISTANCE_M = 25_000;
 
 /**
  * Backend status shape:
@@ -183,6 +186,7 @@ export function createRegistry(vectorSource) {
     }
     return [...byOsmId.values()]
       .sort((a, b) => a.distance_m - b.distance_m)
+      .filter(item => item.distance_m <= NEAREST_MAX_DISTANCE_M)
       .slice(0, limit);
   }
 


### PR DESCRIPTION
## Summary

- In hub mode, `fetchNearestAcrossBackends` merges results from all registered backends in parallel. A backend that is 300+ km from the user's location contributes its own nearest playgrounds, polluting the list alongside truly local results.
- Applies a 25 km cap in `registry.js` after merging and before slicing — the right place since that's where multi-backend results are combined.
- This cap was originally in `NearbyPlaygrounds.svelte` (PR #243), removed in PR #244 due to empty-list issues when the API wasn't deployed. PR #245 fixed the API availability, so the cap is now safe to restore — placed correctly in the fetcher layer.

## Test plan

- [ ] Press locate in hub mode with ≥2 backends registered — only playgrounds within 25 km should appear
- [ ] Verify playgrounds 300+ km away no longer show up in the list
- [ ] Confirm local playgrounds (<25 km) still appear correctly

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)