### PR TITLE
chore: release v0.2.5

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.2.5-rc",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -7,8 +7,9 @@
 #   docker compose -f compose.prod.yml --profile data-node-ui up -d
 #   docker compose -f compose.prod.yml --profile data-node run --rm importer
 #
-# Images are published to ghcr.io on every tagged release and on every push
-# to main (tagged :latest). Pin to a specific version for reproducible deploys.
+# Images are published to ghcr.io on every push to main (tagged :rc) and on
+# every tagged release (tagged :latest + semver). Pin to a semver tag for
+# reproducible deploys.
 
 services:
 
@@ -68,7 +69,7 @@ services:
 
   # ── Svelte app — serves the frontend and proxies /api/ to PostgREST ─────────
   app:
-    image: ghcr.io/mfuhrmann/spieli:rc
+    image: ghcr.io/mfuhrmann/spieli:latest
     profiles: [ui, data-node-ui]
     ports:
       - "${APP_PORT:-8080}:80"


### PR DESCRIPTION
## Summary

- Both images in `compose.prod.yml` pinned to `:latest` so `install.sh` always pulls the last stable release
- `app/package.json` bumped from `0.2.5-rc` → `0.2.5`
- After this merges: tag `v0.2.5` → CI publishes `:latest`, `:0.2.5`, `:0.2` for both images

## Why `:latest` instead of `:rc`

`:rc` tracks rolling `main` builds — users who install would get whatever is currently in development. `:latest` is only published on `v*` tag pushes, making `install.sh` a stable installer.

## Test plan

- [ ] Merge this PR
- [ ] `git tag v0.2.5 && git push origin v0.2.5` — CI builds `:latest` for both images
- [ ] Run `install.sh` fresh and confirm `docker compose pull` succeeds
- [ ] Bump `app/package.json` to `0.2.6-rc` in a follow-up commit

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)