### PR TITLE
docs(hub): add end-to-end federated deployment walkthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,10 +43,23 @@ MAP_MIN_ZOOM=10
 # the app's own origin in that case.
 # PARENT_ORIGIN=https://hub.example.com
 
-# ── Optional: infrastructure ─────────────────────────────────────────────────────
+# ── Optional: Hub mode (federated deployment) ───────────────────────────────────
+# A Hub aggregates multiple regional data-nodes onto one map. See:
+#   docs/ops/federated-deployment.md
+# These apply ONLY on the Hub container (DEPLOY_MODE=ui). Leave them commented
+# on standalone or data-node hosts.
 
 # App mode: 'standalone' (default) or 'hub' (federation map with registry.json)
 # APP_MODE=hub
+
+# URL of the registry JSON listing backend APIs. Default is same-origin /registry.json;
+# bind-mount your own file at /usr/share/nginx/html/registry.json in the app container.
+# REGISTRY_URL=/registry.json
+
+# Seconds between Hub re-polls of each backend's playground data.
+# HUB_POLL_INTERVAL=300
+
+# ── Optional: infrastructure ─────────────────────────────────────────────────────
 
 # Port the app is exposed on the host
 APP_PORT=8080

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -82,6 +82,8 @@ services:
       MAP_MIN_ZOOM:               ${MAP_MIN_ZOOM:-10}
       POI_RADIUS_M:               ${POI_RADIUS_M:-5000}
       API_BASE_URL:               ${API_BASE_URL:-/api}
+      REGISTRY_URL:               ${REGISTRY_URL:-/registry.json}
+      HUB_POLL_INTERVAL:          ${HUB_POLL_INTERVAL:-300}
     restart: on-failure
 
 volumes:

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -7,11 +7,11 @@ All variables are set in `.env` (copy from `.env.example`). The installer genera
 | Variable | Default | Mode | Description |
 |---|---|---|---|
 | `DEPLOY_MODE` | — | — | Deployment mode: `data-node`, `ui`, or `data-node-ui`. Written by the installer. |
-| `APP_MODE` | `standalone` | both | App mode: `standalone` (regional map) or `hub` (aggregation map) |
+| `APP_MODE` | `standalone` | both | App mode: `standalone` (regional map) or `hub` (aggregation map). `hub` requires `REGISTRY_URL` and must be paired with `DEPLOY_MODE=ui`. See [Federated Deployment](federated-deployment.md). |
 | `OSM_RELATION_ID` | `62700` | data-node, data-node-ui | OSM relation ID of the region to display |
 | `OSM_RELATION_ID2` | `454881` | dev only | OSM relation ID for the second local backend (`db2`); used by `make import2` / `make seed-load2` |
 | `PBF_URL` | Hessen extract | data-node, data-node-ui | Geofabrik `.osm.pbf` download URL |
-| `REGISTRY_URL` | `/registry.json` | hub | URL of the registry JSON listing backends (hub mode only) |
+| `REGISTRY_URL` | `/registry.json` | hub | URL of the registry JSON listing backends. Default is same-origin; bind-mount or bake in a custom file. See [Federated Deployment](federated-deployment.md) and [`registry.json` reference](../reference/registry-json.md). |
 | `API_BASE_URL` | `/api` | ui, data-node-ui | Base URL of the PostgREST API. Set to the remote URL for `ui` mode (e.g. `https://data.example.com/api`). |
 | `REGION_PLAYGROUND_WIKI_URL` | Generic OSM wiki | ui, data-node-ui | Wiki page linked in the "Contribute" modal |
 | `REGION_CHAT_URL` | *(hidden)* | ui, data-node-ui | Community chat link; leave empty to hide the button |
@@ -27,7 +27,7 @@ All variables are set in `.env` (copy from `.env.example`). The installer genera
 | `OSM_PREFILTER_MIN_MB` | `20` | data-node, data-node-ui | Source PBF files smaller than this many MB skip the osmium pre-filter step. |
 | `GEOSERVER_URL` | *(disabled)* | data-node, data-node-ui | Base URL of a GeoServer instance for the shadow WMS layer; leave empty to disable |
 | `GEOSERVER_WORKSPACE` | `spieli` | data-node, data-node-ui | GeoServer workspace name — only used when `GEOSERVER_URL` is set |
-| `HUB_POLL_INTERVAL` | `300` | hub | Seconds between Hub re-fetches of playground data from all registered instances |
+| `HUB_POLL_INTERVAL` | `300` | hub | Seconds between Hub re-fetches of playground data from all registered instances. Bare integer, no unit suffix. See [Federated Deployment](federated-deployment.md). |
 
 ## Applying changes
 

--- a/docs/ops/federated-deployment.md
+++ b/docs/ops/federated-deployment.md
@@ -1,0 +1,186 @@
+# Federated Deployment (Hub + data-nodes)
+
+A **federated** deployment consists of one **Hub UI** (no local database) aggregating two or more regional **data-nodes** into a single map. Users browse at the Hub's URL; their browser talks directly to each data-node's PostgREST `/api/`, merging the results client-side.
+
+This walkthrough stands up the topology end-to-end. For a single-region deployment, see [Manual Deploy](manual-deploy.md) instead.
+
+## Topology
+
+```
+                ┌──────────────────────────────────────────────┐
+                │                                              │
+                │    Hub UI (DEPLOY_MODE=ui, APP_MODE=hub)     │
+  Browser ────► │    • serves the app bundle                   │
+                │    • serves registry.json                    │
+                │    • NO database, NO /api                    │
+                │                                              │
+                └──────────┬─────────────────┬─────────────────┘
+                           │                 │
+                           │ CORS            │ CORS
+                           ▼                 ▼
+      ┌───────────────────────────┐ ┌───────────────────────────┐
+      │ Data-node A               │ │ Data-node B               │
+      │ DEPLOY_MODE=data-node-ui  │ │ DEPLOY_MODE=data-node-ui  │
+      │ • PostGIS + PostgREST     │ │ • PostGIS + PostgREST     │
+      │ • nginx serves /api/+CORS │ │ • nginx serves /api/+CORS │
+      └───────────────────────────┘ └───────────────────────────┘
+```
+
+Each data-node runs the full `data-node-ui` profile so the shipped nginx config serves `/api/` with the CORS headers the Hub's browser clients need. The Hub is the same frontend image flipped to `APP_MODE=hub` with a `registry.json` listing the data-node API URLs, and no database of its own.
+
+!!! note "Pure `DEPLOY_MODE=data-node` (advanced)"
+    The `data-node` profile (invoked with `--profile data-node`) ships db + PostgREST only — no HTTP server, no port publish, no CORS handling. You can use it if you run your own reverse proxy in front of the PostgREST container and add the right `Access-Control-Allow-*` headers to `/api/` responses. For the happy path, prefer `data-node-ui` — it's what this walkthrough assumes. In `data-node-ui` mode only `/api/` needs to be reachable from the Hub's origin; front the `APP_PORT` with a reverse proxy that blocks paths other than `/api/` if you don't want the secondary standalone UI publicly reachable.
+
+## Prerequisites
+
+- One host (or cluster) per node — the Hub and each data-node can run on the same machine or on separate ones. Each must reach the others over HTTP/HTTPS.
+- Docker with the Compose plugin on every host.
+- One OSM relation ID and one Geofabrik PBF URL per data-node ([how to find them](manual-deploy.md#step-1-find-your-regions-osm-relation-id)).
+- HTTPS-terminating reverse proxy in front of each data-node in production — the browser must be able to fetch the data-node's `/api/` over HTTPS when the Hub itself is served over HTTPS.
+- When co-locating nodes on one host, give each its own `APP_PORT` (e.g. `8080`, `8081`, `8082`) and its own `COMPOSE_PROJECT_NAME` (e.g. `spieli-fulda`, `spieli-neuhof`, `spieli-hub`) so port bindings and Docker resource names don't collide.
+
+## Step 1 — Stand up each data-node
+
+Repeat on every data-node host. For this walkthrough the two backends are "Fulda" and "Neuhof".
+
+### Data-node `.env`
+
+Replace `<strong-random-password>` with an actual generated secret (`openssl rand -base64 24` is fine) — the angle brackets are a placeholder, not a literal value.
+
+```env
+DEPLOY_MODE=data-node-ui
+OSM_RELATION_ID=454863
+PBF_URL=https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf
+POSTGRES_PASSWORD=<strong-random-password>
+```
+
+No `APP_MODE`, no `REGISTRY_URL` — the frontend on a data-node runs in its default standalone mode purely so nginx can serve `/api/` with CORS. `API_BASE_URL` stays at its default `/api`.
+
+### Start the backend and import
+
+```bash
+docker compose -f compose.prod.yml --profile data-node-ui up -d
+docker compose -f compose.prod.yml --profile data-node-ui run --rm importer
+```
+
+The first command starts `db`, `postgrest`, and the `app` container (which hosts nginx in front of PostgREST). The second runs the importer once — see [Manual Deploy § Step 4](manual-deploy.md#step-4-start-the-stack-and-import-data) for what the import does and how long it takes.
+
+### Expose `/api/` to the Hub
+
+Because the Hub's browser clients hit `/api/` cross-origin, each data-node must be reachable at a stable URL (e.g. `https://fulda.example.com/api`) and respond with CORS headers. The shipped nginx config in `data-node-ui` mode adds `Access-Control-Allow-Origin: *` and the right methods on `/api/` automatically — no extra configuration needed. In production, front `APP_PORT` with an HTTPS-terminating reverse proxy.
+
+Verify from a machine that is **not** the data-node itself:
+
+```bash
+curl -i https://fulda.example.com/api/rpc/get_meta
+# expect 200 OK, JSON body with { relation_id, name, playground_count, bbox }
+# response should also include: Access-Control-Allow-Origin: *
+```
+
+## Step 2 — Prepare `registry.json`
+
+The Hub discovers its data-nodes by fetching a `registry.json` from its own origin. Create the file you'll deploy with the Hub:
+
+```json
+{
+  "instances": [
+    {
+      "slug": "fulda",
+      "url":  "https://fulda.example.com/api",
+      "name": "Fulda"
+    },
+    {
+      "slug": "neuhof",
+      "url":  "https://neuhof.example.com/api",
+      "name": "Neuhof"
+    }
+  ]
+}
+```
+
+**Field rules** — see the [`registry.json` reference](../reference/registry-json.md) for the full schema. The short version:
+
+| Field | Required | Notes |
+|---|---|---|
+| `url`  | yes | Absolute URL of the data-node's PostgREST base — no trailing slash |
+| `name` | recommended | Human-readable label shown in the instance drawer. Falls back to the `url` if omitted, which gives ugly labels — always set it in practice |
+| `slug` | no  | Stable lowercase-ASCII identifier used in shareable deep-links |
+
+Do **not** add `version` or `region` fields — the Hub populates those at runtime from each backend's `/api/rpc/get_meta` response. Anything you put in `registry.json` for those keys is ignored.
+
+The file is served from the **Hub's own origin** under `/registry.json` (the default value of `REGISTRY_URL`). It is *not* fetched from one of the data-nodes. CORS is not needed for the registry file itself, only for the data-node APIs it points at (handled in Step 1).
+
+## Step 3 — Stand up the Hub
+
+### Hub `.env`
+
+```env
+DEPLOY_MODE=ui
+APP_MODE=hub
+REGISTRY_URL=/registry.json
+HUB_POLL_INTERVAL=300
+APP_PORT=8080
+```
+
+Notes:
+
+- `REGISTRY_URL=/registry.json` is the default and means "same origin as the Hub". Set a different value only if you host the registry elsewhere. The value is sanitized by the container entrypoint — only `A-Z a-z 0-9 : / . + _ % ~ -` survive, so query strings (`?v=2`) and fragments (`#anchor`) are silently dropped. Use a clean path.
+- `HUB_POLL_INTERVAL` is seconds as a bare integer (e.g. `300`, not `300s`). Default 300 re-fetches playground data from every data-node every 5 minutes.
+- **`API_BASE_URL` is deliberately absent** on a Hub. The Hub speaks to multiple data-nodes over CORS and reads their URLs from `registry.json`; a single `API_BASE_URL` would be meaningless.
+- `OSM_RELATION_ID`, `PBF_URL`, `POSTGRES_PASSWORD` are **not** set on the Hub — it has no database.
+
+### Replace the bundled `registry.json` (required)
+
+The Hub's shipped image bundles a development `registry.json` pointing at local `/api` and `/api2`. Those paths have no upstream in the `ui` profile, so a Hub started without this step will load with every backend marked red. Pick one of the following — **neither is optional**:
+
+**Option A — bind-mount (recommended, no rebuild)**
+
+Drop your file alongside `compose.prod.yml` as `registry.json`, then create `compose.override.yml` next to it:
+
+```yaml
+services:
+  app:
+    volumes:
+      - ./registry.json:/usr/share/nginx/html/registry.json:ro
+```
+
+Compose **does not** auto-merge `compose.override.yml` when you pass `-f compose.prod.yml` explicitly. With Option A you must list both files on every invocation (see the Start command below); Option B doesn't need the override file at all.
+
+**Option B — custom image**
+
+Build your own image from source with your `registry.json` placed at `app/public/registry.json` before `make docker-build`. No override file needed in this case.
+
+### Start the Hub
+
+With Option A (bind-mount):
+
+```bash
+docker compose -f compose.prod.yml -f compose.override.yml --profile ui up -d
+```
+
+With Option B (custom image — just the one file):
+
+```bash
+docker compose -f compose.prod.yml --profile ui up -d
+```
+
+The Hub has no importer, no database, no `run --rm importer` step.
+
+## Step 4 — Verify
+
+1. Open the Hub URL in a browser (e.g. `https://hub.example.com`).
+2. You should see the map render, fit to the union of all configured regions, with the instance pill in the bottom-left showing the aggregated region + playground counts (localized German: e.g. `2 Regionen · <count> Spielplätze` with a globe icon).
+3. Open DevTools → Network and reload. You should see:
+   - One `GET /registry.json` from the Hub's origin.
+   - One `GET /rpc/get_meta` and one `GET /rpc/get_playgrounds` per data-node, cross-origin, returning 200.
+4. Click the instance pill — the drawer lists both backends with their playground count. (A version badge renders only when a backend's `get_meta` exposes a `version` field, which the SQL function doesn't today, so the badge slot stays empty in current releases.)
+5. Click a playground in each region — the selection panel opens with that region's data.
+
+If any data-node request fails in DevTools, the instance drawer marks that backend red with the error message. Check the data-node's CORS headers (Step 1 verification) and that its URL in `registry.json` is reachable from the browser, not only from the Hub host.
+
+## See also
+
+- [`registry.json` reference](../reference/registry-json.md) — full schema, slug rules, derived behaviours.
+- [Federation](../reference/federation.md) — conceptual overview of Hub mode and federation endpoints.
+- [Configuration](configuration.md) — full variables table including `REGISTRY_URL` and `HUB_POLL_INTERVAL`.
+- [Architecture](../reference/architecture.md) — the `DEPLOY_MODE` × `APP_MODE` matrix that makes the legal combinations explicit.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -58,6 +58,18 @@ The compose file supports three profiles, selected at install time via `DEPLOY_M
 | `ui` | app (nginx) | Frontend connecting to a remote data node |
 | `data-node-ui` | All of the above | Self-contained single-region deployment |
 
+### `DEPLOY_MODE` × `APP_MODE` — legal combinations
+
+`DEPLOY_MODE` picks which containers run. `APP_MODE` picks how the frontend behaves. They are orthogonal: one chooses *where* the code runs, the other chooses *what* the code does.
+
+|                           | `APP_MODE=standalone`                                                                                 | `APP_MODE=hub`                                                                                                  |
+|---------------------------|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `DEPLOY_MODE=data-node`   | N/A — no frontend, `APP_MODE` is ignored                                                              | N/A — no frontend to run in hub mode                                                                            |
+| `DEPLOY_MODE=ui`          | Remote-frontend for one region (`API_BASE_URL` points at a remote `/api/` — that backend must enable [CORS](../ops/federated-deployment.md#expose-api-to-the-hub)) | **Federated Hub** — aggregates multiple data-nodes                                                          |
+| `DEPLOY_MODE=data-node-ui`| Default single-region deployment                                                                      | Hub co-located with a local data-node — replace the bundled `registry.json` (see walkthrough), or the Hub will point at dev paths |
+
+For the federated Hub topology (`DEPLOY_MODE=ui` + `APP_MODE=hub`), see [Federated Deployment](../ops/federated-deployment.md).
+
 ## Key source directories
 
 | Path | Role |

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -91,3 +91,8 @@ The Hub renders the same layout as a standalone regional map, with two additions
 - **Deep-link scheme**: see the [deep-link behaviour table](registry-json.md#deep-link-behaviour) in the registry reference.
 
 The scale-line sits just below the pill in the same bottom-left corner. All other controls (search, filters, locate, zoom, contribute) are shared with standalone mode and behave identically.
+
+## See also
+
+- [Federated Deployment](../ops/federated-deployment.md) — step-by-step walkthrough for standing up one Hub + N data-nodes.
+- [`registry.json` reference](registry-json.md) — registry schema, slug rules, derived aggregate behaviours.

--- a/docs/reference/registry-json.md
+++ b/docs/reference/registry-json.md
@@ -4,7 +4,7 @@ The Hub reads a `registry.json` file at startup and on a short poll interval (`H
 
 ## Location
 
-- **Served from**: the nginx container under `/registry.json` (path configurable via `HUB_REGISTRY_URL`).
+- **Served from**: the nginx container under `/registry.json` (path configurable via `REGISTRY_URL`).
 - **Source file**: `app/public/registry.json` in the repo. In production, replace or bind-mount with your own registry.
 - **Served as**: `application/json`. CORS is not needed for the registry file itself — the Hub fetches it from its own origin. The *backends* the registry points at are typically cross-origin and must enable CORS on `/api/` (covered in [Federation endpoints](federation.md#federation-endpoints)).
 
@@ -47,8 +47,11 @@ Both forms are supported indefinitely. New registries should prefer the object f
 | Field | Required | Description |
 |---|---|---|
 | `url`  | yes | Base URL of the backend's PostgREST `/api` (no trailing slash). The Hub appends `/rpc/get_playgrounds`, `/rpc/get_meta`, and `/rpc/get_nearest_playgrounds`. |
-| `name` | yes | Human-readable label. Shown in the instance drawer and — until `get_meta` returns — used as the backend's displayed region name. Falls back to `url` if omitted. |
+| `name` | recommended | Human-readable label. Shown in the instance drawer and — until `get_meta` returns — used as the backend's displayed region name. Technically falls back to `url` if omitted, which gives ugly labels — always set it. |
 | `slug` | no  | Short stable identifier used in deep-links (`#<slug>/W<osm_id>`). If present, features from this backend round-trip their slug back into the URL hash on selection. See [validation rules](#slug-validation) below. |
+
+!!! note "Runtime-populated fields"
+    The Hub does **not** read `version` or `region` from `registry.json` entries — adding those keys to the file has no effect. Both are derived at runtime from each backend's `/api/rpc/get_meta` response: `region` from the OSM relation name, `version` from a `version` key the response *would* carry. The current `get_meta` SQL function (`importer/api.sql`) does not return `version`, so `version` stays `null` and the instance drawer's version badge remains empty until a future release wires one through.
 
 ### Slug validation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - Quick Start: getting-started/quick-start.md
   - Operations:
       - Manual Deploy: ops/manual-deploy.md
+      - Federated Deployment: ops/federated-deployment.md
       - Configuration: ops/configuration.md
       - Troubleshooting: ops/troubleshooting.md
   - Contributing:

--- a/openspec/changes/document-federated-hub-deployment/tasks.md
+++ b/openspec/changes/document-federated-hub-deployment/tasks.md
@@ -1,49 +1,107 @@
 ## 1. Walkthrough page — `docs/ops/federated-deployment.md`
 
-- [ ] 1.1 Add an intro paragraph defining the topology: one Hub UI + ≥ 1 data-node, no UI on the backends
-- [ ] 1.2 Include an ASCII topology diagram showing browser → Hub UI → N × data-node
-- [ ] 1.3 Document the per-node `.env` for each data-node (`DEPLOY_MODE=data-node`, `OSM_RELATION_ID`, `PBF_URL`, `POSTGRES_PASSWORD`)
-- [ ] 1.4 Document the Hub UI's `.env` (`DEPLOY_MODE=ui`, `APP_MODE=hub`, `REGISTRY_URL`, `HUB_POLL_INTERVAL`, `APP_PORT`) — note that `API_BASE_URL` is *not* set on a Hub
-- [ ] 1.5 Show a copy-pasteable `registry.json` example covering two backends in the `{instances: [...]}` shape
-- [ ] 1.6 Document where `registry.json` is served from (same origin as the Hub UI) and the CORS requirement on data nodes
-- [ ] 1.7 Show the exact `docker compose --profile ui up -d` invocation for the Hub and `--profile data-node up -d` + `run --rm importer` for each backend
-- [ ] 1.8 Add a "Verification" section: operator visits the Hub, opens DevTools, sees features loaded from each backend URL
+- [x] 1.1 Add an intro paragraph defining the topology: one Hub UI + ≥ 1 data-node, no UI on the backends
+- [x] 1.2 Include an ASCII topology diagram showing browser → Hub UI → N × data-node
+- [x] 1.3 Document the per-node `.env` for each data-node (`DEPLOY_MODE=data-node`, `OSM_RELATION_ID`, `PBF_URL`, `POSTGRES_PASSWORD`)
+- [x] 1.4 Document the Hub UI's `.env` (`DEPLOY_MODE=ui`, `APP_MODE=hub`, `REGISTRY_URL`, `HUB_POLL_INTERVAL`, `APP_PORT`) — note that `API_BASE_URL` is *not* set on a Hub
+- [x] 1.5 Show a copy-pasteable `registry.json` example covering two backends in the `{instances: [...]}` shape
+- [x] 1.6 Document where `registry.json` is served from (same origin as the Hub UI) and the CORS requirement on data nodes
+- [x] 1.7 Show the exact `docker compose --profile ui up -d` invocation for the Hub and `--profile data-node up -d` + `run --rm importer` for each backend
+- [x] 1.8 Add a "Verification" section: operator visits the Hub, opens DevTools, sees features loaded from each backend URL
 
 ## 2. Registry schema reference — `docs/reference/registry-json.md`
 
-- [ ] 2.1 Document the two accepted top-level shapes: `{instances: [...]}` and bare array (source of truth: `app/src/hub/registry.js:93`)
-- [ ] 2.2 Document per-entry fields read by the Hub: `url` (required), `name` (optional, falls back to meta or url)
-- [ ] 2.3 Note which fields come from `/api/rpc/get_meta` at runtime (`version`, `region`) so readers don't try to set them in `registry.json`
-- [ ] 2.4 Include a minimal and a full example side-by-side
+- [x] 2.1 Document the two accepted top-level shapes: `{instances: [...]}` and bare array (source of truth: `app/src/hub/registry.js:93`)
+- [x] 2.2 Document per-entry fields read by the Hub: `url` (required), `name` (optional, falls back to meta or url)
+- [x] 2.3 Note which fields come from `/api/rpc/get_meta` at runtime (`version`, `region`) so readers don't try to set them in `registry.json`
+- [x] 2.4 Include a minimal and a full example side-by-side
 
 ## 3. Configuration reference — `docs/ops/configuration.md`
 
-- [ ] 3.1 Add a `REGISTRY_URL` row: default unset, mode `ui` (hub), description + link to the registry-json reference page
-- [ ] 3.2 Clarify the existing `APP_MODE` row so it's visible that `hub` requires `REGISTRY_URL`
+- [x] 3.1 Add a `REGISTRY_URL` row: default unset, mode `ui` (hub), description + link to the registry-json reference page
+- [x] 3.2 Clarify the existing `APP_MODE` row so it's visible that `hub` requires `REGISTRY_URL`
 
 ## 4. Architecture reference — `docs/reference/architecture.md`
 
-- [ ] 4.1 Under "Deployment modes", add a second subsection showing the `DEPLOY_MODE` × `APP_MODE` matrix
-- [ ] 4.2 Mark the legal-and-useful cells; mark `data-node × hub` as N/A (no UI to run in hub mode)
-- [ ] 4.3 Include a one-line caption pointing readers at `docs/ops/federated-deployment.md` for the hub topology
+- [x] 4.1 Under "Deployment modes", add a second subsection showing the `DEPLOY_MODE` × `APP_MODE` matrix
+- [x] 4.2 Mark the legal-and-useful cells; mark `data-node × hub` as N/A (no UI to run in hub mode)
+- [x] 4.3 Include a one-line caption pointing readers at `docs/ops/federated-deployment.md` for the hub topology
 
 ## 5. Federation page cross-link — `docs/reference/federation.md`
 
-- [ ] 5.1 Add a "See also" link to `docs/ops/federated-deployment.md` as the stand-up walkthrough
-- [ ] 5.2 Add a "See also" link to `docs/reference/registry-json.md` for the schema
+- [x] 5.1 Add a "See also" link to `docs/ops/federated-deployment.md` as the stand-up walkthrough
+- [x] 5.2 Add a "See also" link to `docs/reference/registry-json.md` for the schema
 
 ## 6. `.env.example` — Hub block
 
-- [ ] 6.1 Add a commented "Hub mode" section with `APP_MODE=hub` and `REGISTRY_URL=` (both commented out)
-- [ ] 6.2 Add a one-line comment pointing at `docs/ops/federated-deployment.md`
+- [x] 6.1 Add a commented "Hub mode" section with `APP_MODE=hub` and `REGISTRY_URL=` (both commented out)
+- [x] 6.2 Add a one-line comment pointing at `docs/ops/federated-deployment.md`
 
 ## 7. MkDocs nav — `mkdocs.yml`
 
-- [ ] 7.1 Add `docs/ops/federated-deployment.md` under the Ops section of the nav
-- [ ] 7.2 Add `docs/reference/registry-json.md` under the Reference section of the nav
+- [x] 7.1 Add `docs/ops/federated-deployment.md` under the Ops section of the nav
+- [x] 7.2 Add `docs/reference/registry-json.md` under the Reference section of the nav
 
 ## 8. Validation
 
-- [ ] 8.1 Run `mkdocs build --strict` and confirm no broken links / nav warnings
-- [ ] 8.2 Run `openspec validate document-federated-hub-deployment --strict` and confirm it passes
-- [ ] 8.3 Read the walkthrough top-to-bottom as if standing up a real cluster — sanity-check that every command is correct against `compose.prod.yml` and `install.sh`
+- [x] 8.1 Run `mkdocs build --strict` and confirm no broken links / nav warnings
+- [x] 8.2 Run `openspec validate document-federated-hub-deployment --strict` and confirm it passes
+- [x] 8.3 Read the walkthrough top-to-bottom as if standing up a real cluster — sanity-check that every command is correct against `compose.prod.yml` and `install.sh`
+
+## 9. Review Findings (bmad-code-review, 2026-04-24)
+
+### Critical
+- [x] [Review][Patch] `compose.override.yml` auto-merge claim is wrong when `-f compose.prod.yml` is used. Compose v2 only auto-merges `compose.override.yml` when no `-f` is passed. Fix: Option A must use `docker compose -f compose.prod.yml -f compose.override.yml --profile ui up -d`, and the explanatory text must drop "Compose merges both automatically". [docs/ops/federated-deployment.md Step 3 "Option A"]
+
+### High
+- [x] [Review][Patch] Walkthrough's CORS guidance assumes nginx from `data-node-ui`, but Step 1 deploys `data-node` profile which has no HTTP server and no port publish for `postgrest`. Operator following the happy path has no reachable `/api`. Fix: either tell operators to add their own reverse proxy + port publish (with snippet), or recommend `DEPLOY_MODE=data-node-ui` for external data-nodes even if the UI is not used. [docs/ops/federated-deployment.md Step 1 "Enable public access"]
+- [x] [Review][Patch] Default `REGISTRY_URL=/registry.json` serves the dev fixture (`/api`, `/api2`) baked into the image. On a `DEPLOY_MODE=ui` Hub, those paths have no upstream — Hub loads with all-red backends. The walkthrough presents bind-mount (Option A) and custom image (Option B) as "options" but at least one is mandatory. Fix: mark Step 3 "Make registry.json available" as required, not optional polish. [docs/ops/federated-deployment.md Step 3]
+- [x] [Review][Patch] Compose override YAML example in Option A is missing the `services:` root key — a literal copy-paste produces invalid YAML. Fix: wrap under `services:`. [docs/ops/federated-deployment.md Step 3 "Option A" code block]
+
+### Medium
+- [x] [Review][Patch] `REGISTRY_URL` and `HUB_POLL_INTERVAL` rows in `docs/ops/configuration.md` don't link to the walkthrough or registry reference (spec Req 3 Scenario asks for a link). Fix: append `See [Federated Deployment](federated-deployment.md).` to both descriptions. [docs/ops/configuration.md:14, :30]
+- [x] [Review][Patch] `docs/reference/registry-json.md` doesn't mark `version` and `region` as runtime-populated from `get_meta` and therefore not user-settable in the file (task 2.3 unsatisfied). Also the `name` field is listed as required but `app/src/hub/registry.js:114` falls back to `url` — clarify "required for readable display, falls back to url". [docs/reference/registry-json.md entry fields table]
+- [x] [Review][Patch] Walkthrough's `get_meta` curl comment lists a `version` field that `importer/api.sql:591-601` does not return. Fix to `{ relation_id, name, playground_count, bbox }`. [docs/ops/federated-deployment.md Step 1 verification block]
+- [x] [Review][Patch] `REGISTRY_URL` documented as a URL, but `oci/app/docker-entrypoint.sh:14` strips `?`, `=`, `&` via sanitizer — query strings and fragments are silently dropped. Fix: add a one-line note to the walkthrough's `REGISTRY_URL` description. [docs/ops/federated-deployment.md Step 3 Hub `.env` notes]
+- [x] [Review][Patch] Architecture matrix's `data-node-ui + hub` cell ("Hub co-located with a local data-node (dev / single-host)") doesn't warn that the default registry targets dev paths (`/api`, `/api2`) and must be replaced. Fix: add a short caveat to the cell or the caption. [docs/reference/architecture.md matrix]
+
+### Low
+- [x] [Review][Patch] `.env.example` Hub banner says "Uncomment these and set DEPLOY_MODE=ui when running a Hub container" but the data-node block tacitly relies on default. Tighten wording so operators don't uncomment Hub vars on data-nodes. [.env.example Hub-mode block top comment]
+- [x] [Review][Patch] Verification step 4.2 shows `🌐 2 Regionen · N Spielplätze` with literal `N` inside backticks — readers will wonder if they should see the letter. Replace with `<count>` placeholder and note localized German text is expected. [docs/ops/federated-deployment.md Step 4 item 2]
+- [x] [Review][Patch] Architecture matrix `ui + standalone` cell ("Remote-frontend for one region") gives no pointer to Step 1's CORS requirements, which also apply here. Minor: add a one-line note. [docs/reference/architecture.md matrix]
+- [x] [Review][Patch] `HUB_POLL_INTERVAL` documented only as "seconds between ...". Noting the value is a bare integer (not `300s`) would pre-empt a common footgun. [docs/ops/federated-deployment.md Step 3 notes]
+- [x] [Review][Patch] Data-node `.env` example uses `POSTGRES_PASSWORD=<strong-random-password>` with angle-bracket placeholder — a literal paste with brackets would be accepted by PostgreSQL but be an embarrassing password. Nudge the operator with "(replace the placeholder)". [docs/ops/federated-deployment.md Step 1 data-node .env]
+
+## 10. Review Findings — Pass 2 (bmad-code-review, 2026-04-24)
+
+Re-review of pass 1's 14 patches. Both hard spec misses from pass 1 confirmed resolved. 7 small residual issues + 1 cosmetic task-hygiene item.
+
+- [x] [Review][Patch] Step 4 item 4 promises a "version badge" the drawer won't render — `InstancePanelDrawer.svelte:71` guards on `{#if b.version}` but `get_meta` never returns `version`. Regression from the pass-1 curl fix. Fix: drop "version badge" from the verification list, or caveat that it's always empty today. [docs/ops/federated-deployment.md Step 4 item 4] (Medium)
+- [x] [Review][Patch] "You must list both files on every invocation" paragraph is scoped to Option A but written unscoped — Option B readers may think they also need the override. Fix: scope the sentence explicitly. [docs/ops/federated-deployment.md Step 3 "Replace the bundled registry.json"] (Low)
+- [x] [Review][Patch] "Pure `DEPLOY_MODE=data-node` (advanced)" tip box doesn't say which `--profile` to use. Fix: add `--profile data-node` to the guidance. [docs/ops/federated-deployment.md Topology section tip] (Low)
+- [x] [Review][Patch] Runtime-populated caveat in `registry-json.md` overstates behaviour — `registry.js` never reads `entry.version`/`entry.region`, so there's nothing to "overwrite", and `get_meta` doesn't return `version` so it's always null (not "app package version"). Fix: rewrite to say the Hub ignores these keys in the file, and `version` stays null until the importer or backend surfaces one. [docs/reference/registry-json.md runtime-populated admonition] (Low-Medium)
+- [x] [Review][Patch] Port conflict when two data-nodes share a host — both default `APP_PORT=8080`. Fix: add a one-line note to Prerequisites or the data-node `.env` block recommending distinct `APP_PORT` + `COMPOSE_PROJECT_NAME` for co-located backends. [docs/ops/federated-deployment.md Prerequisites / Step 1] (Medium)
+- [x] [Review][Patch] `!!! tip` admonition for the pure data-node path carries a warning-level caveat (no HTTP server, secondary UI may leak). Change to `!!! note` or `!!! warning` for correct visual severity. [docs/ops/federated-deployment.md Topology section] (Low)
+- [x] [Review][Patch] Architecture matrix `ui × standalone` cell mentions "that backend must enable CORS" with no pointer. Fix: link the phrase to the walkthrough's Step 1 CORS discussion. [docs/reference/architecture.md matrix] (Low)
+- [x] [Review][Patch] Implementation tasks 1.1–7.1 remain unticked despite being done; only 8.1/8.2 and the review patches are ticked. Cosmetic but tidier for archive. [openspec/changes/.../tasks.md] (Nit)
+
+### Dismissed (pass 2)
+- Mode column "hub" for `REGISTRY_URL` / `HUB_POLL_INTERVAL` despite unconditional compose wiring — the Mode column describes where the var has effect, not where it's wired. Convention is consistent.
+- `name` field naming consistency between walkthrough mini-table and reference — both say "recommended"; already consistent.
+- `.env.example` Hub banner could be misread — current wording "These apply ONLY on the Hub container (DEPLOY_MODE=ui)" is clear enough.
+- Password placeholder nudge position — verified correct (before the code block).
+- Proposal "no UI of their own" vs walkthrough recommending `data-node-ui` — acknowledged documented trade-off; proposal intent is preserved operationally.
+- `registry-json.md` admission that `get_meta` doesn't return `version` — consistent with Step 1 curl comment.
+
+### Dismissed (noise / false positive / already handled)
+- Rename `HUB_REGISTRY_URL` → `REGISTRY_URL` half-done: only one occurrence existed, already fixed this branch.
+- OSM_RELATION_ID=454863 vs canonical: `454863` IS correct for Fulda Stadt (`docs/reference/federation.md:34`).
+- `--profile data-node/ui` labels don't exist: verified present in `compose.prod.yml` profiles blocks.
+- Registry URL trailing-slash concern: matches `app/src/hub/registry.js` concatenation behaviour.
+- "hub requires REGISTRY_URL" overreach: default `/registry.json` works with bind-mount, acceptable phrasing.
+- `See also` link-style inconsistency: nit not worth the churn.
+- Auditor: `REGISTRY_URL` row missing from configuration.md — the row pre-exists at line 14; only the link is missing (captured above as Medium).
+- Auditor: mkdocs Reference nav missing registry-json entry — already present pre-existing (`mkdocs.yml:44`).
+- Auditor: compose.prod.yml scope violation — user explicitly approved bundling the fix earlier this session.
+- Auditor: `HUB_POLL_INTERVAL` scope creep in task 1.4 — same user-approved judgment.
+- Empty `HUB_POLL_INTERVAL` env producing invalid JS: the Edge Hunter self-corrected; `${VAR:-default}` handles both unset and empty.


### PR DESCRIPTION
## Summary

- Adds `docs/ops/federated-deployment.md` — end-to-end walkthrough for one Hub UI + N data-nodes with copy-pasteable `.env`, `registry.json`, and `docker compose` commands. Covers both bind-mount and custom-image paths and includes a DevTools-based verification step.
- Adds a `DEPLOY_MODE × APP_MODE` matrix to `docs/reference/architecture.md`, surfaces the `REGISTRY_URL` / `HUB_POLL_INTERVAL` variables in the configuration reference and `.env.example`, and fixes a `HUB_REGISTRY_URL` → `REGISTRY_URL` typo in the registry reference.
- `compose.prod.yml` now forwards `REGISTRY_URL` and `HUB_POLL_INTERVAL` to the `app` container so the walkthrough's hub `.env` takes effect in production (previously only `compose.yml` dev did this).

Implements OpenSpec change [`document-federated-hub-deployment`](https://github.com/mfuhrmann/spieli/tree/main/openspec/changes/document-federated-hub-deployment). Two rounds of adversarial code review (14 + 8 patches) recorded in `tasks.md` §9 / §10.

## Test plan

- [ ] `mkdocs build --strict` builds cleanly (verified locally)
- [ ] `openspec validate document-federated-hub-deployment --strict` passes (verified locally)
- [ ] Follow the walkthrough verbatim on a clean host with two regions and confirm the Hub renders both backends with playground counts
- [ ] Confirm non-hub deployments on `compose.prod.yml` are unaffected (REGISTRY_URL/HUB_POLL_INTERVAL defaults are no-ops on `APP_MODE=standalone`)
- [ ] Spot-check every Markdown link resolves inside the rendered MkDocs site

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)