### PR TITLE
test(tiered): deflake deprecation-warning Playwright test

### DIFF
--- a/tests/tiered.spec.js
+++ b/tests/tiered.spec.js
@@ -50,19 +50,22 @@ test.describe('Tiered delivery', () => {
       route.fulfill({ status: 404, contentType: 'application/json', body: '{}' })
     );
 
-    const warnings = [];
+    const deprecationLogs = [];
     page.on('console', msg => {
-      if (msg.type() === 'warning') warnings.push(msg.text());
+      if (msg.type() === 'warning' && msg.text().includes('fetchPlaygrounds is deprecated')) {
+        deprecationLogs.push(msg.text());
+      }
     });
 
     await page.goto('/');
-    // Give the orchestrator's debounced moveend a chance to settle and
-    // the legacy fallback to log.
-    await page.waitForTimeout(800);
-
-    const deprecationLogs = warnings.filter(t =>
-      t.includes('fetchPlaygrounds is deprecated')
-    );
+    // Wait deterministically for the warning to surface — the orchestrator
+    // debounces moveend by 300 ms and the legacy fallback adds one fetch
+    // round-trip, but on a slow runner that can drift past a fixed
+    // sleep. Polling with a generous deadline avoids the flake.
+    await expect.poll(
+      () => deprecationLogs.length,
+      { timeout: 8000, message: 'expected the deprecation warning to fire after the cluster RPC 404s' },
+    ).toBeGreaterThanOrEqual(1);
     expect(deprecationLogs.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

The new `tests/tiered.spec.js::legacy fetchPlaygrounds emits a one-time deprecation warning` test was flaky on slower CI runners: `page.waitForTimeout(800)` wasn't always long enough for the orchestrator's 300 ms debounce + cluster-RPC 404 + legacy fetch round-trip to land before the assertion ran. The flake surfaced on PR #280's CI run (an archive PR with zero runtime changes), confirming the wait window was the only variable.

Replaces the fixed sleep with `expect.poll(...).toBeGreaterThanOrEqual(1)` keyed on the deprecation-log accumulator, deadline 8 s. Fast-fail in the happy path, tolerates slow runners. The "exactly once" assertion is preserved after the poll succeeds.

## Test plan

- [ ] CI Playwright passes (the flake should now resolve to a stable green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)