### PR TITLE
fix(importer): validate cached PBF with osmium fileinfo before use

### DIFF
--- a/importer/import.sh
+++ b/importer/import.sh
@@ -44,11 +44,17 @@ done
 echo "[importer] PostgreSQL is ready."
 
 # --------------------------------------------------------------------------- #
-# Download PBF (skipped if already cached under the same filename)
+# Download PBF (skipped if already cached and intact)
 # --------------------------------------------------------------------------- #
 if [ -f "$PBF_FILE" ]; then
-    echo "[importer] Using cached $PBF_FILE ($(du -sh "$PBF_FILE" | cut -f1)) — delete volume to force re-download"
-else
+    if ! osmium fileinfo "$PBF_FILE" > /dev/null 2>&1; then
+        echo "[importer] Cached $PBF_FILE is corrupt or incomplete — re-downloading..."
+        rm -f "$PBF_FILE"
+    else
+        echo "[importer] Using cached $PBF_FILE ($(du -sh "$PBF_FILE" | cut -f1))"
+    fi
+fi
+if [ ! -f "$PBF_FILE" ]; then
     echo "[importer] Downloading $PBF_URL ..."
     wget --progress=dot:giga -O "$PBF_FILE" "$PBF_URL"
     echo "[importer] Download complete: $(du -sh "$PBF_FILE" | cut -f1)"


### PR DESCRIPTION
## Summary

- Validates the cached `.osm.pbf` with `osmium fileinfo` on every import startup before trusting it
- Deletes and re-downloads automatically if the file is corrupt or truncated
- Fixes the `PBF error: unexpected EOF` failure that occurs after an interrupted download

## Test plan

- [ ] Start an import with a healthy cached PBF — should print "Using cached …" and proceed normally
- [ ] Truncate the cached file (`truncate -s 10M /data/…pbf`) and re-run — should print "corrupt or incomplete — re-downloading…" and fetch a fresh copy
- [ ] First-time run (no cache) — download path unchanged

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)