### PR TITLE
feat(hub): federated playground clustering (P2 §1–§8)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-svelte": "^0.469.0",
         "ol": "10.8.0",
         "opening_hours": "^3.9.0",
+        "supercluster": "^8.0.1",
         "svelte": "^5.55.4",
         "svelte-i18n": "^4.0.1",
         "tailwind-merge": "^2.6.1",
@@ -1866,6 +1867,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2511,6 +2518,15 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
       "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
     },
     "node_modules/svelte": {
       "version": "5.55.4",

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "lucide-svelte": "^0.469.0",
     "ol": "10.8.0",
     "opening_hours": "^3.9.0",
+    "supercluster": "^8.0.1",
     "svelte": "^5.55.4",
     "svelte-i18n": "^4.0.1",
     "tailwind-merge": "^2.6.1",

--- a/app/public/config.js
+++ b/app/public/config.js
@@ -27,6 +27,10 @@ window.APP_CONFIG = {
 
   // --- Tiered playground delivery (standalone mode in P1) ---
   // Two tiers: cluster (zoom ≤ 13) and polygon (zoom > 13).
-  // Hub-side fan-out lands in add-federated-playground-clustering (P2).
   clusterMaxZoom: 13,
+
+  // --- Federated clustering (hub mode, P2) ---
+  // Zoom ≤ macroMaxZoom shows the country-level macro view (one ring per
+  // backend) and the orchestrator skips per-tier fetches entirely.
+  macroMaxZoom: 5,
 };

--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -37,6 +37,13 @@
   export let clusterSource = null;
 
   /**
+   * Macro-tier source (hub-only, zoom ≤ macroMaxZoom). Fed by `MacroView`
+   * from the registry's per-backend metadata; null in standalone mode.
+   * @type {import('ol/source/Vector.js').default | null}
+   */
+  export let macroSource = null;
+
+  /**
    * Readable store emitting the current map view in WGS84 as
    * `[minLon, minLat, maxLon, maxLat]` (or null). Consumed by SearchBar as
    * Nominatim `viewbox`.
@@ -135,31 +142,45 @@
       return;
     }
 
-    // §5.1 — when the polygon source is empty (cluster tier on first load),
-    // hydrate the single feature on demand from get_playground(osm_id).
-    // The source's 'change' event re-runs this handler and the standard
-    // match path then selects + fits.
+    // §5.1 — when the polygon source is empty (cluster/macro tier on first
+    // load), hydrate the single feature on demand from `get_playground`.
     //
-    // Only standalone, slug-less deeplinks need hydration:
-    //   - Hub mode: registry's per-backend broadcast loading populates the
-    //     source as each backend responds, then the match path above runs
-    //     on every 'change' until a hit. Hydrating here would race against
-    //     that and target the wrong backend URL.
-    //   - Standalone + slug: the slug is ignored (`resolveSlugToBackendUrl`
-    //     is null), the match path runs as broadcast across all features,
-    //     and once the orchestrator loads the polygon tier the match
-    //     succeeds. No hydration needed.
+    // Hydration cases:
+    //   - Standalone + slug-less hash → fetch from `defaultBackendUrl`.
+    //   - Hub + slug-prefixed hash    → fetch from the slug-resolved
+    //     backend URL (P2 §3 — registry no longer eager-loads polygons,
+    //     so this path is needed for slug-routed hub deeplinks too).
+    //   - Hub + slug-less hash (broadcast) → defer; no good way to pick a
+    //     backend without a hint. Resolves once the user pans/zooms into
+    //     polygon tier and the orchestrator loads features that match.
+    //   - Standalone + slug-prefixed → defer; standalone has no slug
+    //     resolver, so `resolveSlugToBackendUrl` is null and we wait for
+    //     the orchestrator's polygon-tier load to surface the feature.
     if (hydrating) return;
-    if (resolveSlugToBackendUrl) return; // hub mode — registry handles it
-    if (parsed.slug) return;             // standalone with slug — wait for source
+    let hydrateFromUrl = null;
+    if (parsed.slug && resolveSlugToBackendUrl) {
+      hydrateFromUrl = resolveSlugToBackendUrl(parsed.slug);
+      if (!hydrateFromUrl) return; // unknown slug — keep waiting (warned above)
+    } else if (!parsed.slug && !resolveSlugToBackendUrl) {
+      hydrateFromUrl = defaultBackendUrl;
+    } else {
+      return; // hub broadcast or standalone-with-slug — defer to source change
+    }
     hydrating = true;
     try {
-      const feature = await fetchPlaygroundByOsmId(parsed.osmId, defaultBackendUrl);
+      const feature = await fetchPlaygroundByOsmId(parsed.osmId, hydrateFromUrl);
       if (feature) {
         const olFeatures = geojsonFormat.readFeatures(
           { type: 'FeatureCollection', features: [feature] },
           { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' },
         );
+        // Stamp `_backendUrl` (and `_backendSlug` when present) so the
+        // standard match path's `f.get('_backendUrl') ?? defaultBackendUrl`
+        // routes selection to the right hub backend.
+        for (const f of olFeatures) {
+          f.set('_backendUrl', hydrateFromUrl);
+          if (parsed.slug) f.set('_backendSlug', parsed.slug);
+        }
         playgroundSource.addFeatures(olFeatures);
       } else {
         // 200 OK with no body — the backend confirms no playground exists
@@ -306,6 +327,7 @@
   <Map
     {playgroundSource}
     {clusterSource}
+    {macroSource}
     {defaultBackendUrl}
     onhover={handleHover}
     onclearhover={clearHover}

--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -87,6 +87,15 @@
    */
   export let resolveSlugToBackendUrl = null;
 
+  /**
+   * Hub-only "list every registered backend URL" accessor. Used by the
+   * slug-less deeplink path to broadcast `fetchPlaygroundByOsmId` across
+   * every backend; the first match wins, duplicates log a warning.
+   * Standalone passes `null`.
+   * @type {(() => string[]) | null}
+   */
+  export let getAllBackendUrls = null;
+
   // ── URL hash restore ──────────────────────────────────────────────────────
   //
   // Runs once on first load and again on every `change` event from the
@@ -150,13 +159,59 @@
     //   - Hub + slug-prefixed hash    → fetch from the slug-resolved
     //     backend URL (P2 §3 — registry no longer eager-loads polygons,
     //     so this path is needed for slug-routed hub deeplinks too).
-    //   - Hub + slug-less hash (broadcast) → defer; no good way to pick a
-    //     backend without a hint. Resolves once the user pans/zooms into
-    //     polygon tier and the orchestrator loads features that match.
+    //   - Hub + slug-less hash (broadcast) → fan out `get_playground`
+    //     across every registered backend; first match wins, duplicates
+    //     log a warning. Cost: N parallel requests per slug-less hub
+    //     deeplink load (bounded by registry size, ≤30 backends).
     //   - Standalone + slug-prefixed → defer; standalone has no slug
     //     resolver, so `resolveSlugToBackendUrl` is null and we wait for
     //     the orchestrator's polygon-tier load to surface the feature.
     if (hydrating) return;
+
+    // Hub + slug-less broadcast — handled separately because it's the
+    // only path that fans out across multiple backends in parallel.
+    if (!parsed.slug && resolveSlugToBackendUrl && getAllBackendUrls) {
+      const urls = getAllBackendUrls();
+      if (urls.length === 0) return; // backends still loading — retry on next change
+      hydrating = true;
+      try {
+        const settled = await Promise.all(urls.map(url =>
+          fetchPlaygroundByOsmId(parsed.osmId, url)
+            .then(feat => feat ? { feat, url } : null)
+            .catch(() => null),
+        ));
+        const matches = settled.filter(Boolean);
+        if (matches.length > 1) {
+          console.warn(`[deeplink] osm_id ${parsed.osmId} matched ${matches.length} backends — selecting the first`);
+        }
+        if (matches.length > 0) {
+          const { feat, url } = matches[0];
+          const olFeatures = geojsonFormat.readFeatures(
+            { type: 'FeatureCollection', features: [feat] },
+            { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' },
+          );
+          for (const f of olFeatures) f.set('_backendUrl', url);
+          playgroundSource.addFeatures(olFeatures);
+          // The standard match path inside `playgroundSource.on('change')`
+          // will pick up the freshly-added features and complete the
+          // selection + fit on the next tick.
+        } else if (!warnedHydrationFailed) {
+          warnedHydrationFailed = true;
+          console.warn(`[deeplink] no playground found for osm_id ${parsed.osmId} across ${urls.length} backend(s)`);
+          hashRestored = true;
+        }
+      } catch (err) {
+        if (!warnedHydrationFailed) {
+          warnedHydrationFailed = true;
+          console.warn('[deeplink] broadcast hydration failed (give up; reload to retry):', err);
+        }
+        hashRestored = true;
+      } finally {
+        hydrating = false;
+      }
+      return;
+    }
+
     let hydrateFromUrl = null;
     if (parsed.slug && resolveSlugToBackendUrl) {
       hydrateFromUrl = resolveSlugToBackendUrl(parsed.slug);
@@ -164,7 +219,7 @@
     } else if (!parsed.slug && !resolveSlugToBackendUrl) {
       hydrateFromUrl = defaultBackendUrl;
     } else {
-      return; // hub broadcast or standalone-with-slug — defer to source change
+      return; // standalone-with-slug — defer to source change
     }
     hydrating = true;
     try {

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -5,7 +5,7 @@
   import VectorSource from 'ol/source/Vector.js';
   import XYZ from 'ol/source/XYZ.js';
   import GeoJSON from 'ol/format/GeoJSON.js';
-  import { transform } from 'ol/proj';
+  import { transform, transformExtent } from 'ol/proj';
   import { ScaleLine, defaults as defaultControls } from 'ol/control.js';
   import { defaults as defaultInteractions } from 'ol/interaction/defaults';
 
@@ -17,6 +17,7 @@
     treeStyle,
     clusterTierStyleFn,
   } from '../lib/vectorStyles.js';
+  import { macroRingStyleFn } from '../hub/macroRingStyle.js';
   import { selection } from '../stores/selection.js';
   import { mapStore } from '../stores/map.js';
   import { playgroundSourceStore } from '../stores/playgroundSource.js';
@@ -30,6 +31,8 @@
   export let playgroundSource = null;
   /** @type {VectorSource | null} - cluster-tier source (zoom ≤ clusterMaxZoom) */
   export let clusterSource = null;
+  /** @type {VectorSource | null} - macro-tier source (hub-only, zoom ≤ macroMaxZoom) */
+  export let macroSource = null;
   /** Backend URL used for selection — standalone passes apiBaseUrl, hub passes per-feature URL */
   export let defaultBackendUrl = apiBaseUrl;
   
@@ -46,6 +49,7 @@
   let olMap = null;
   let playgroundLayer = null; // polygon tier (zoom > clusterMaxZoom) — exposed for filter reactivity
   let clusterLayer = null;    // cluster tier (zoom ≤ clusterMaxZoom) — §3
+  let macroLayer = null;      // macro tier (hub-only, zoom ≤ macroMaxZoom) — P2 §5
   let equipmentLayer = null;  // overlay: equipment points/polygons
   let treeLayer = null;       // overlay: tree dots
   let overlayUnsubscribe = null;
@@ -56,9 +60,10 @@
     // renders in degraded paths (e.g. tests that mount Map without a parent).
     const polygonSrc = playgroundSource ?? new VectorSource();
     const clusterSrc = clusterSource    ?? new VectorSource();
+    const macroSrc   = macroSource      ?? new VectorSource();
 
-    // Both tier layers start hidden; the activeTierStore subscription below
-    // reveals the right one once the orchestrator has chosen a tier.
+    // All three tier layers start hidden; the activeTierStore subscription
+    // below reveals exactly one once the orchestrator has chosen a tier.
     playgroundLayer = new VectorLayer({
       source: polygonSrc,
       zIndex: 10,
@@ -69,6 +74,14 @@
       source: clusterSrc,
       zIndex: 12,
       style: clusterTierStyleFn,
+      visible: false,
+    });
+    // Macro tier sits above the cluster layer (zIndex 14) so any future
+    // overlap during a tier transition keeps the macro rings on top.
+    macroLayer = new VectorLayer({
+      source: macroSrc,
+      zIndex: 14,
+      style: macroRingStyleFn,
       visible: false,
     });
 
@@ -89,7 +102,7 @@
 
     olMap = new Map({
       target: mapContainer,
-      layers: [basemap, playgroundLayer, clusterLayer],
+      layers: [basemap, playgroundLayer, clusterLayer, macroLayer],
       view,
       // Disable default zoom/rotate controls for cleaner UI like Google Maps
       controls: defaultControls({ 
@@ -141,6 +154,9 @@
     //  - Cluster tier (§4.5): zoom in ~2 levels toward the cluster centre;
     //    a single-child cluster (count === 1) at high zoom transitions
     //    naturally into the polygon tier.
+    //  - Macro tier (P2 §5): fit-to-bbox of the clicked backend; the
+    //    orchestrator's debounced moveend will land in cluster or polygon
+    //    tier and trigger a fan-out scoped to that backend.
     //  - Empty space: clear selection.
     olMap.on('click', (evt) => {
       const polygonHit = olMap.forEachFeatureAtPixel(evt.pixel, (f) => f, {
@@ -168,6 +184,19 @@
         });
         return;
       }
+      const macroHit = olMap.forEachFeatureAtPixel(evt.pixel, (f) => f, {
+        layerFilter: (l) => l === macroLayer,
+      });
+      if (macroHit) {
+        const bbox4326 = macroHit.get('_bbox');
+        if (Array.isArray(bbox4326) && bbox4326.length === 4) {
+          view.fit(transformExtent(bbox4326, 'EPSG:4326', 'EPSG:3857'), {
+            padding: [40, 40, 40, 420],
+            duration: 400,
+          });
+        }
+        return;
+      }
       selection.clear();
     });
 
@@ -192,8 +221,12 @@
       const clusterHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
         layerFilter: l => l === clusterLayer,
       });
+      // Macro tier rings: click → fit-to-bbox; same affordance as clusters.
+      const macroHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
+        layerFilter: l => l === macroLayer,
+      });
 
-      mapContainer.style.cursor = (overlayHit || playHit || clusterHit) ? 'pointer' : '';
+      mapContainer.style.cursor = (overlayHit || playHit || clusterHit || macroHit) ? 'pointer' : '';
 
       // Overlay hover takes priority
       if (overlayHit !== lastEquipHoverFeature) {
@@ -239,16 +272,18 @@
     playgroundSourceStore.set(polygonSrc);
 
     // Tier-driven layer visibility. `tier === null` means the orchestrator
-    // hasn't run yet — keep both layers hidden.
+    // hasn't run yet — keep all three tier layers hidden.
     tierUnsubscribe = activeTierStore.subscribe(tier => {
       if (!playgroundLayer) return;
       if (tier === null) {
         playgroundLayer.setVisible(false);
         clusterLayer.setVisible(false);
+        macroLayer.setVisible(false);
         return;
       }
       playgroundLayer.setVisible(tier === 'polygon');
       clusterLayer.setVisible(tier === 'cluster');
+      macroLayer.setVisible(tier === 'macro');
     });
   });
 

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -6,20 +6,32 @@
 
   import AppShell from '../components/AppShell.svelte';
   import InstancePanel from './InstancePanel.svelte';
+  import MacroView from './MacroView.svelte';
 
   import { createRegistry } from './registry.js';
+  import { attachHubOrchestrator } from './hubOrchestrator.js';
   import { mapStore } from '../stores/map.js';
+  import { clusterMaxZoom } from '../lib/config.js';
 
   // Generic OSM wiki link for the contribution modal (hub is region-agnostic).
   const HUB_WIKI_URL = 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
 
-  const sharedSource = new VectorSource();
+  // Three sources owned by the hub — the orchestrator populates cluster /
+  // polygon on every moveend; MacroView (P2 §5) populates macro from
+  // backend metadata (no fetch). Map.svelte toggles layer visibility from
+  // activeTierStore — same pattern as the standalone two-tier design,
+  // extended with the hub-only macro tier.
+  const polygonSource = new VectorSource();
+  const clusterSource = new VectorSource();
+  const macroSource   = new VectorSource();
+  let detachOrchestrator = null;
+
   const {
     backends,
     registryError,
     aggregatedBbox,
     fetchNearestAcrossBackends,
-  } = createRegistry(sharedSource);
+  } = createRegistry();
 
   const dataContribLinks = { wikiUrl: HUB_WIKI_URL, chatUrl: null };
 
@@ -40,9 +52,21 @@
 
   function tryFit(map, bbox) {
     if (fitDone || !map || !bbox) return;
+    // Single-backend hubs always clamp to clusterMaxZoom + 1 (spec §6.1):
+    // a single small city's bbox fitted with normal padding lands in the
+    // macro tier, where one giant ring covers a city the user already
+    // implied they wanted to look at. Clamping forces the initial paint
+    // into the cluster tier.
+    //
+    // Multi-backend hubs accept whatever the union dictates (spec §6.2)
+    // — a Germany+France union legitimately wants the macro continent
+    // overview now that §5 ships and macro rings render properly.
+    const backendCount = get(backends).length;
+    const fitOpts = { padding: [20, 20, 20, 380], duration: 0 };
+    if (backendCount <= 1) fitOpts.maxZoom = clusterMaxZoom + 1;
     map.getView().fit(
       transformExtent(bbox, 'EPSG:4326', 'EPSG:3857'),
-      { padding: [20, 20, 20, 380], duration: 0 }
+      fitOpts,
     );
     fitDone = true;
     detachMap?.();
@@ -55,16 +79,36 @@
     let latestBbox = null;
     detachMap = mapStore.subscribe(m => { latestMap = m; tryFit(latestMap, latestBbox); });
     detachBbox = aggregatedBbox.subscribe(b => { latestBbox = b; tryFit(latestMap, latestBbox); });
+
+    // Attach the hub orchestrator once the map is published. The orchestrator
+    // fans out per-tier RPCs across registered backends on every (debounced)
+    // moveend, populates clusterSource / polygonSource, and writes the
+    // active tier to activeTierStore for layer-visibility toggling.
+    const detachAttach = mapStore.subscribe(map => {
+      if (!map || detachOrchestrator) return;
+      detachOrchestrator = attachHubOrchestrator({
+        map,
+        backendsStore: backends,
+        clusterSource,
+        polygonSource,
+      });
+      detachAttach();
+    });
   });
 
   onDestroy(() => {
     detachMap?.();
     detachBbox?.();
+    detachOrchestrator?.();
   });
 </script>
 
+<MacroView {backends} source={macroSource} />
+
 <AppShell
-  playgroundSource={sharedSource}
+  playgroundSource={polygonSource}
+  {clusterSource}
+  {macroSource}
   searchExtent={aggregatedBbox}
   nearestFetcher={fetchNearestAcrossBackends}
   {resolveSlugToBackendUrl}

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -42,16 +42,33 @@
     return get(backends).find(b => b.slug === slug)?.url ?? null;
   }
 
-  // Initial region fit: once both the map and the first aggregated bbox are
-  // available, fit the view and then stop listening. Until that point the map
-  // stays on its default Germany-wide center from Map.svelte — the "safe"
-  // fallback from D5.
+  // Sync accessor for the slug-less broadcast deeplink path. AppShell fans
+  // `fetchPlaygroundByOsmId` across these URLs in parallel; first hit wins.
+  function getAllBackendUrls() {
+    return get(backends).map(b => b.url);
+  }
+
+  // Initial region fit: once the map is ready, every registered backend has
+  // finished its first `get_meta` (success or error), and `aggregatedBbox`
+  // has emitted its non-null union, fit the view and then stop listening.
+  // Until that point the map stays on its default Germany-wide center from
+  // Map.svelte — the "safe" fallback from D5.
+  //
+  // Why wait for *every* backend's first load: with two backends, the
+  // first one to settle drives `aggregatedBbox` to its own bbox alone.
+  // If we fit on that single-bbox emission, `backendCount === 1` and the
+  // single-backend clamp (`clusterMaxZoom + 1`) latches — even though
+  // the union with the second backend would justify the macro tier.
   let fitDone = false;
+  let latestMap = null;
+  let latestBbox = null;
+  let backendsSettled = false;
   let detachMap = null;
   let detachBbox = null;
+  let detachBackends = null;
 
-  function tryFit(map, bbox) {
-    if (fitDone || !map || !bbox) return;
+  function tryFit() {
+    if (fitDone || !latestMap || !latestBbox || !backendsSettled) return;
     // Single-backend hubs always clamp to clusterMaxZoom + 1 (spec §6.1):
     // a single small city's bbox fitted with normal padding lands in the
     // macro tier, where one giant ring covers a city the user already
@@ -64,21 +81,28 @@
     const backendCount = get(backends).length;
     const fitOpts = { padding: [20, 20, 20, 380], duration: 0 };
     if (backendCount <= 1) fitOpts.maxZoom = clusterMaxZoom + 1;
-    map.getView().fit(
-      transformExtent(bbox, 'EPSG:4326', 'EPSG:3857'),
+    latestMap.getView().fit(
+      transformExtent(latestBbox, 'EPSG:4326', 'EPSG:3857'),
       fitOpts,
     );
     fitDone = true;
     detachMap?.();
     detachBbox?.();
-    detachMap = detachBbox = null;
+    detachBackends?.();
+    detachMap = detachBbox = detachBackends = null;
   }
 
   onMount(() => {
-    let latestMap = null;
-    let latestBbox = null;
-    detachMap = mapStore.subscribe(m => { latestMap = m; tryFit(latestMap, latestBbox); });
-    detachBbox = aggregatedBbox.subscribe(b => { latestBbox = b; tryFit(latestMap, latestBbox); });
+    detachMap = mapStore.subscribe(m => { latestMap = m; tryFit(); });
+    detachBbox = aggregatedBbox.subscribe(b => { latestBbox = b; tryFit(); });
+    detachBackends = backends.subscribe(bs => {
+      // Settled = registry loaded AND every backend's get_meta has resolved
+      // (success or error). A backend that errors keeps `bbox: null`, which
+      // aggregatedBbox already excludes; the only thing the settle-gate
+      // changes is the *clamp decision* in tryFit.
+      backendsSettled = bs.length > 0 && bs.every(b => !b.loading);
+      tryFit();
+    });
 
     // Attach the hub orchestrator once the map is published. The orchestrator
     // fans out per-tier RPCs across registered backends on every (debounced)
@@ -99,6 +123,7 @@
   onDestroy(() => {
     detachMap?.();
     detachBbox?.();
+    detachBackends?.();
     detachOrchestrator?.();
   });
 </script>
@@ -112,6 +137,7 @@
   searchExtent={aggregatedBbox}
   nearestFetcher={fetchNearestAcrossBackends}
   {resolveSlugToBackendUrl}
+  {getAllBackendUrls}
   {dataContribLinks}
 >
   {#snippet instancePanel()}

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -17,7 +17,11 @@
   // both the region count in the pill and the zero-reachable messaging.
   $: reachable = $backends.filter(b => !b.error && !b.loading);
   $: regionCount = reachable.length;
-  $: playgroundCount = reachable.reduce((acc, b) => acc + (b.featureCount || 0), 0);
+  // Total playgrounds across reachable backends. Sourced from each backend's
+  // `playgroundCount` (from `get_meta`, region-wide total) since the hub
+  // orchestrator no longer eagerly loads every backend's polygons; it
+  // fetches the per-tier RPCs on moveend instead.
+  $: playgroundCount = reachable.reduce((acc, b) => acc + (b.playgroundCount || 0), 0);
   $: isLoading = !$registryError && $backends.length === 0;
   $: hasRegistryError = !!$registryError;
 

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -2,7 +2,7 @@
   import { _ } from 'svelte-i18n';
   import { X } from 'lucide-svelte';
 
-  /** @type {Array<{ url: string, name: string, version: string|null, loading: boolean, error: string|null, featureCount: number }>} */
+  /** @type {Array<{ url: string, name: string, version: string|null, loading: boolean, error: string|null, playgroundCount: number }>} */
   export let backends;
   /** @type {string | null} */
   export let registryError;
@@ -86,7 +86,7 @@
           {:else}
             <div class="instance-status text-muted">
               <i class="bi bi-geo-alt-fill me-1"></i>
-              {$_('hub.playgroundCount', { values: { count: b.featureCount } })}
+              {$_('hub.playgroundCount', { values: { count: b.playgroundCount } })}
             </div>
           {/if}
         </li>

--- a/app/src/hub/MacroView.svelte
+++ b/app/src/hub/MacroView.svelte
@@ -1,0 +1,94 @@
+<script>
+  // Country-level macro view (P2 §5).
+  //
+  // Subscribes to the backends store and rebuilds one Point feature per
+  // backend at the backend's bbox centroid, with stacked-ring properties
+  // (count + completeness) sourced from each backend's cached `get_meta`
+  // response. The resulting features live in `source` and are styled by
+  // `macroRingStyleFn` (registered on `macroLayer` in Map.svelte).
+  //
+  // The orchestrator is what *decides* whether the macro layer is visible —
+  // this component just keeps the source contents in sync so a tier toggle
+  // shows the latest data without a fetch round-trip. Cost: one O(N)
+  // rebuild per backends-store update (poll every 5 min + initial load).
+  //
+  // Pre-P1 backends ship `get_meta` without the `complete/partial/missing`
+  // extension. Their entries arrive with `completeness: null`; we render
+  // those as a flat gray ring (everything in the "restricted" segment) so
+  // the operator sees "data quality unknown" rather than a misleading
+  // healthy-but-empty zero ring.
+  //
+  // Offline backends are flagged on the feature; the renderer branches to a
+  // dashed outline + "offline" label. Health currently comes from the
+  // federationHealth stub (always healthy) — the same wiring applies once
+  // `add-federation-health-exposition` lands the real signal.
+
+  import { onDestroy } from 'svelte';
+  import Feature from 'ol/Feature.js';
+  import Point from 'ol/geom/Point.js';
+  import { transform } from 'ol/proj.js';
+  import { isBackendHealthy } from './federationHealth.js';
+
+  /** @type {import('svelte/store').Readable<Array>} */
+  export let backends;
+  /** @type {import('ol/source/Vector.js').default} */
+  export let source;
+
+  function bboxCentroid(bbox) {
+    if (!bbox || bbox.length !== 4) return null;
+    const [minLon, minLat, maxLon, maxLat] = bbox;
+    return [(minLon + maxLon) / 2, (minLat + maxLat) / 2];
+  }
+
+  function buildFeature(backend) {
+    const centroid = bboxCentroid(backend.bbox);
+    if (!centroid) return null;
+    const offline = !isBackendHealthy(backend);
+    // Pre-P1 backends → unknown completeness; map the count into the
+    // restricted bucket so the renderer draws a flat gray ring.
+    const c = backend.completeness;
+    const count = backend.playgroundCount ?? 0;
+    const props = c
+      ? {
+          count,
+          complete:   c.complete,
+          partial:    c.partial,
+          missing:    c.missing,
+          restricted: 0,
+        }
+      : {
+          count,
+          complete:   0,
+          partial:    0,
+          missing:    0,
+          restricted: count,
+        };
+    return new Feature({
+      geometry: new Point(transform(centroid, 'EPSG:4326', 'EPSG:3857')),
+      _tier:        'macro',
+      _backendUrl:  backend.url,
+      _backendSlug: backend.slug ?? null,
+      _bbox:        backend.bbox,
+      _offline:     offline,
+      _name:        backend.name ?? backend.region ?? backend.slug ?? backend.url,
+      ...props,
+    });
+  }
+
+  // Rebuild on every store update. Backends typically change shape twice
+  // per session (initial load + 5-min poll) and number <20, so a full
+  // clear+addFeatures is well below any perceptible cost.
+  const detach = backends.subscribe(($backends) => {
+    if (!source) return;
+    const features = $backends
+      .map(buildFeature)
+      .filter(Boolean);
+    source.clear();
+    source.addFeatures(features);
+  });
+
+  onDestroy(() => {
+    detach();
+    if (source) source.clear();
+  });
+</script>

--- a/app/src/hub/bboxRouter.js
+++ b/app/src/hub/bboxRouter.js
@@ -1,0 +1,46 @@
+// Hub bbox router (P2 §1.3).
+//
+// Pure function: given a viewport bbox in WGS84 and the current backends
+// list, return the subset whose own bbox intersects the viewport.
+// The hub orchestrator uses this so a Paris user's moveend doesn't query
+// Berlin / Hamburg / etc. backends.
+//
+// Caveat: this assumes both bboxes have `minLon ≤ maxLon`. A bbox that
+// crosses the antimeridian (e.g. Russia, Pacific island chains) is
+// conventionally encoded with `minLon > maxLon` and would fail every
+// intersection test here, silently dropping the backend from the router's
+// output. No current deployment hits this; fix when a Pacific federation
+// becomes real (split the wrapped bbox at ±180 before testing).
+
+function isFiniteBbox(bb) {
+  return Array.isArray(bb) && bb.length === 4 && bb.every(Number.isFinite);
+}
+
+/**
+ * Test whether two `[minLon, minLat, maxLon, maxLat]` bboxes (WGS84) intersect.
+ * Returns true on touch (shared edge).
+ */
+function bboxesIntersect(a, b) {
+  if (!a || !b) return false;
+  const [ax0, ay0, ax1, ay1] = a;
+  const [bx0, by0, bx1, by1] = b;
+  return ax0 <= bx1 && ax1 >= bx0 && ay0 <= by1 && ay1 >= by0;
+}
+
+/**
+ * Return the subset of `backends` whose bbox intersects `viewportBbox`.
+ *
+ * @param {[number, number, number, number] | null} viewportBbox  WGS84
+ * @param {Array<{ bbox: [number,number,number,number] | null }>} backends
+ * @returns {Array} same shape as input, filtered
+ */
+export function selectBackends(viewportBbox, backends) {
+  // null viewport (initial mount before the map has computed an extent) →
+  // include every backend; the orchestrator's tier logic decides.
+  if (viewportBbox === null) return backends;
+  // NaN / non-finite tuple → treat as no filter; without this guard every
+  // numeric comparison against NaN is false and the router would silently
+  // exclude every backend.
+  if (!isFiniteBbox(viewportBbox)) return backends;
+  return backends.filter(b => bboxesIntersect(viewportBbox, b.bbox));
+}

--- a/app/src/hub/fanOut.js
+++ b/app/src/hub/fanOut.js
@@ -1,0 +1,107 @@
+// Hub fan-out utility (P2 §2).
+//
+// Invokes a fetcher against every selected backend in parallel, surfaces
+// each result as it arrives via an `onResult` callback so the map can
+// repaint progressively, and returns a Promise that resolves when every
+// backend has settled (success, error, or per-backend timeout).
+//
+// Design choices:
+//   * One AbortController per fan-out — `signal.abort()` cancels every
+//     in-flight request together (typical case: superseded by a new
+//     moveend in the orchestrator).
+//   * Per-backend timeout (default 5 s) so a single slow peer can't
+//     block the merged render.
+//   * One backend's failure does not reject the fan-out promise; it is
+//     surfaced as `{ ok: false, error, backendUrl }` to the callback.
+//   * Per-session warn-once for timeouts to avoid console spam.
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const _warnedTimeoutBackends = new Set();
+
+/**
+ * @callback FanOutFetcher
+ * @param {string} backendUrl
+ * @param {AbortSignal} signal
+ * @returns {Promise<any>}  arbitrary fetcher payload
+ *
+ * @callback FanOutOnResult
+ * @param {{ ok: true, value: any, backendUrl: string } | { ok: false, error: Error, backendUrl: string }} entry
+ * @returns {void}
+ *
+ * @param {Object} opts
+ * @param {FanOutFetcher} opts.fetcher
+ * @param {Array<{ url: string }>} opts.backends
+ * @param {AbortSignal} [opts.signal]    parent signal (e.g. orchestrator-wide AbortController)
+ * @param {FanOutOnResult} [opts.onResult]  invoked once per backend as soon as that backend settles
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<Array<{ ok: boolean, value?: any, error?: Error, backendUrl: string }>>}
+ *   resolves with every backend's outcome in arrival order
+ */
+export async function fanOut({
+  fetcher,
+  backends,
+  signal,
+  onResult,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+  if (typeof fetcher !== 'function') {
+    throw new TypeError('fanOut: `fetcher` must be a function');
+  }
+  if (!backends?.length) return [];
+
+  const controller = new AbortController();
+  const onParentAbort = () => controller.abort(signal?.reason);
+  if (signal) {
+    if (signal.aborted) controller.abort(signal.reason);
+    else signal.addEventListener('abort', onParentAbort, { once: true });
+  }
+
+  const results = [];
+
+  const tasks = backends.map((b) => {
+    // Per-backend AbortController is load-bearing: a single slow peer's
+    // per-request timeout aborts only its own request without cancelling
+    // every other backend's in-flight fetch (which `controller.abort()`
+    // would do). Don't fold this into `controller`.
+    const perBackendController = new AbortController();
+    const onCancel = () => perBackendController.abort(controller.signal.reason);
+    if (controller.signal.aborted) perBackendController.abort(controller.signal.reason);
+    else controller.signal.addEventListener('abort', onCancel, { once: true });
+
+    // Single timer covers both warn-once and per-backend abort. Two timers
+    // at the same delay race each other in the macrotask queue and can
+    // produce spurious warns when one observes the other's not-yet-aborted
+    // state.
+    const timer = setTimeout(() => {
+      if (perBackendController.signal.aborted) return;
+      if (!_warnedTimeoutBackends.has(b.url)) {
+        _warnedTimeoutBackends.add(b.url);
+        console.warn(`[fanOut] backend ${b.url} timed out after ${timeoutMs} ms (warn-once)`);
+      }
+      perBackendController.abort(new Error('per-backend timeout'));
+    }, timeoutMs);
+
+    return fetcher(b.url, perBackendController.signal)
+      .then(value => {
+        const entry = { ok: true, value, backendUrl: b.url };
+        results.push(entry);
+        onResult?.(entry);
+      })
+      .catch(error => {
+        const entry = { ok: false, error, backendUrl: b.url };
+        results.push(entry);
+        onResult?.(entry);
+      })
+      .finally(() => {
+        clearTimeout(timer);
+      });
+  });
+
+  try {
+    await Promise.all(tasks);
+  } finally {
+    if (signal) signal.removeEventListener('abort', onParentAbort);
+  }
+
+  return results;
+}

--- a/app/src/hub/federationHealth.js
+++ b/app/src/hub/federationHealth.js
@@ -1,0 +1,28 @@
+// Federation health signal — stub for the P2 hub orchestrator.
+//
+// The real `federation-status.json` (per-backend reachability + freshness)
+// ships in `add-federation-health-exposition`. Until that change lands, this
+// module assumes every registered backend is online so P2 can wire the
+// "skip offline backends" hook without blocking on health.
+//
+// Once health-exposition lands, replace `isBackendHealthy` with a poll of
+// `/federation-status.json` and merge into the backends store.
+
+/**
+ * Returns true while the backend should be queried by the hub orchestrator.
+ *
+ * @param {{ url: string }} backend
+ * @returns {boolean}
+ */
+export function isBackendHealthy(_backend) {
+  // STUB: always healthy. See module comment.
+  return true;
+}
+
+/**
+ * Filter a backends list to only the healthy ones, applied AFTER the bbox
+ * router so the orchestrator's fan-out skips known-down peers entirely.
+ */
+export function filterHealthy(backends) {
+  return backends.filter(isBackendHealthy);
+}

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -76,7 +76,29 @@ export function attachHubOrchestrator({
   // serviceable when one peer is on a pre-tier release.
   const backendUseLegacy = new Set();
   const backendLegacyWarned = new Set();
-  const detachStore = backendsStore.subscribe(b => { allBackends = b; });
+  // Per-backend "malformed cluster bucket" warning de-dup. A backend returning
+  // a bucket with non-finite lon/lat would otherwise place a feature at
+  // [NaN, NaN] (projects to ~0,0) or trip Supercluster's KDBush; we drop
+  // those buckets and warn at most once per backend per session.
+  const backendMalformedBucketWarned = new Set();
+  // Skip the very first subscribe-firing — the synchronous initial value is
+  // the registry's empty bootstrap, and the first real load triggers the
+  // immediate `orchestrate()` call at the bottom of this function. After
+  // that, subsequent emissions (5-min poll, bbox refresh, backend
+  // add/remove) need to re-render the active tier against the new set.
+  let initialBackendsSet = false;
+  const detachStore = backendsStore.subscribe(b => {
+    allBackends = b;
+    if (!initialBackendsSet) {
+      initialBackendsSet = true;
+      return;
+    }
+    // Backends changed (registry poll or registry mutation) — re-orchestrate
+    // on the same debounce as moveend so a flurry of poll-driven updates
+    // collapses to one fan-out. `debounced` is defined below; safe to call
+    // because the subscribe callback is async w.r.t. attach time.
+    debounced();
+  });
 
   function clearSourcesAndProgress() {
     polygonSource.clear();
@@ -87,6 +109,12 @@ export function attachHubOrchestrator({
   async function orchestrate() {
     const view = map.getView();
     const zoom = view.getZoom();
+    // OL `getZoom()` returns `undefined` when the view's resolution doesn't
+    // map to an integer zoom (boot, mid-animation, fractional resolution).
+    // `tierForZoom(undefined)` would fall through every `<=` to `'polygon'`,
+    // dispatching a continent-wide bbox fan-out at boot. Skip until the
+    // next moveend brings a finite zoom.
+    if (!Number.isFinite(zoom)) return;
     const tier = tierForZoom(zoom);
     activeTierStore.set(tier);
 
@@ -163,8 +191,21 @@ export function attachHubOrchestrator({
         onResult: (entry) => {
           if (signal.aborted) return;
           if (entry.ok && Array.isArray(entry.value)) {
+            let droppedMalformed = 0;
             for (const b of entry.value) {
+              // Drop buckets with non-finite coordinates rather than
+              // pushing a `[NaN, NaN]` Point that projects to lon=0,lat=0
+              // (Gulf of Guinea) or trips Supercluster's KDBush. Warn
+              // at most once per backend per session.
+              if (!Number.isFinite(b.lon) || !Number.isFinite(b.lat)) {
+                droppedMalformed += 1;
+                continue;
+              }
               accumulated.push(bucketToSuperclusterPoint(b, entry.backendUrl));
+            }
+            if (droppedMalformed > 0 && !backendMalformedBucketWarned.has(entry.backendUrl)) {
+              backendMalformedBucketWarned.add(entry.backendUrl);
+              console.warn(`[hub-tier] backend ${entry.backendUrl} returned ${droppedMalformed} cluster bucket(s) with non-finite lon/lat — dropped`);
             }
             // Reload the index with the accumulated set and re-render.
             // Supercluster's `load` is O(N); for cluster-tier viewport
@@ -193,11 +234,15 @@ export function attachHubOrchestrator({
         signal,
         onResult: (entry) => {
           if (signal.aborted) return;
+          // Clear the source on the *first* arrival regardless of `ok` so
+          // an all-error fan-out doesn't leave ghost polygons from the
+          // previous viewport. The latch fires exactly once per
+          // orchestrate() call; subsequent arrivals append.
+          if (polygonFirstArrival) {
+            polygonFirstArrival = false;
+            polygonSource.clear();
+          }
           if (entry.ok) {
-            if (polygonFirstArrival) {
-              polygonFirstArrival = false;
-              polygonSource.clear();
-            }
             const backend = backendByUrl.get(entry.backendUrl);
             const features = parsePolygonFeatures(entry.value, entry.backendUrl, backend);
             polygonSource.addFeatures(features);
@@ -258,8 +303,13 @@ export function attachHubOrchestrator({
   };
 }
 
+// Matches the exact format thrown by api.js fetchers: `<rpc> failed: 404`.
+// Anchored on the trailing `failed: 404` so a transient error whose message
+// happens to mention "404" elsewhere (URL fragment, payload echo) cannot
+// permanently degrade a backend to the legacy fallback for the rest of the
+// session.
 function isNotFound(err) {
-  return typeof err?.message === 'string' && /\b404\b/.test(err.message);
+  return typeof err?.message === 'string' && /failed: 404$/.test(err.message);
 }
 
 // Wrap a server cluster bucket in the GeoJSON shape Supercluster expects.

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -1,0 +1,335 @@
+// Hub-mode tiered orchestrator (P2 §3).
+//
+// Mirrors the standalone tieredOrchestrator but fans every per-tier fetch
+// out across the registry's backends, filtered by viewport (bboxRouter) and
+// federation health (federationHealth — currently stubbed).
+//
+// Three tiers:
+//   zoom ≤ macroMaxZoom              → 'macro'   — no fetches; the macro
+//                                                  view component renders
+//                                                  one ring per backend
+//                                                  from the cached
+//                                                  backendsStore.
+//   macroMaxZoom < zoom ≤ clusterMaxZoom → 'cluster' — fanOut over
+//                                                  fetchPlaygroundClusters
+//   zoom > clusterMaxZoom            → 'polygon' — fanOut over
+//                                                  fetchPlaygroundsBbox
+//
+// Per-fan-out AbortController is replaced (and the previous one aborted)
+// on every moveend, so superseded fan-outs cancel their in-flight per-
+// backend requests via the fanOut's plumbing.
+//
+// Cluster and polygon sources are progressively repainted as each backend
+// settles (via fanOut's onResult callback). Cross-backend re-clustering
+// (Supercluster) is §4 — for §3 the cluster source just concatenates
+// every backend's buckets, which can show visible seams at borders. §4
+// fixes that.
+
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
+import GeoJSON from 'ol/format/GeoJSON.js';
+import { transform, transformExtent } from 'ol/proj.js';
+import Supercluster from 'supercluster';
+
+import {
+  fetchPlaygroundClusters,
+  fetchPlaygroundsBbox,
+  fetchPlaygrounds,
+} from '../lib/api.js';
+import { clusterMaxZoom, macroMaxZoom } from '../lib/config.js';
+import { activeTierStore } from '../stores/tier.js';
+import { hubLoadingStore } from '../stores/hubLoading.js';
+import { selectBackends } from './bboxRouter.js';
+import { filterHealthy } from './federationHealth.js';
+import { fanOut } from './fanOut.js';
+import { debounce } from '../lib/utils.js';
+
+const geojsonFormat = new GeoJSON();
+
+export function tierForZoom(zoom) {
+  if (zoom <= macroMaxZoom)   return 'macro';
+  if (zoom <= clusterMaxZoom) return 'cluster';
+  return 'polygon';
+}
+
+/**
+ * Wire the hub orchestrator to a map + the registry's backends store.
+ *
+ * @param {Object} opts
+ * @param {import('ol/Map.js').default} opts.map
+ * @param {import('svelte/store').Readable<Array>} opts.backendsStore
+ * @param {import('ol/source/Vector.js').default} opts.clusterSource
+ * @param {import('ol/source/Vector.js').default} opts.polygonSource
+ * @returns {() => void} detach function
+ */
+export function attachHubOrchestrator({
+  map,
+  backendsStore,
+  clusterSource,
+  polygonSource,
+}) {
+  let abort = null;
+  let allBackends = [];
+  // Sticky per-backend legacy fallback. When a backend's tier RPC 404s once,
+  // every subsequent fan-out for that backend uses fetchPlaygrounds (region-
+  // scoped, P1 deprecated) instead, with a one-time warning. Keeps the hub
+  // serviceable when one peer is on a pre-tier release.
+  const backendUseLegacy = new Set();
+  const backendLegacyWarned = new Set();
+  const detachStore = backendsStore.subscribe(b => { allBackends = b; });
+
+  function clearSourcesAndProgress() {
+    polygonSource.clear();
+    clusterSource.clear();
+    hubLoadingStore.set({ loaded: 0, total: 0, settling: false });
+  }
+
+  async function orchestrate() {
+    const view = map.getView();
+    const zoom = view.getZoom();
+    const tier = tierForZoom(zoom);
+    activeTierStore.set(tier);
+
+    if (abort) abort.abort();
+    abort = new AbortController();
+    const signal = abort.signal;
+
+    if (tier === 'macro') {
+      // The MacroView component (P2 §5) renders directly from
+      // backendsStore. Clear feature sources so old cluster / polygon
+      // features from a previous higher zoom don't bleed through.
+      clearSourcesAndProgress();
+      return;
+    }
+
+    const extent3857 = view.calculateExtent(map.getSize());
+    const viewportBbox = transformExtent(extent3857, 'EPSG:3857', 'EPSG:4326');
+    const selected = filterHealthy(selectBackends(viewportBbox, allBackends));
+
+    if (selected.length === 0) {
+      clearSourcesAndProgress();
+      return;
+    }
+
+    hubLoadingStore.set({ loaded: 0, total: selected.length, settling: true });
+
+    // Per-backend lookup map; the polygon onResult needs the backend's slug
+    // so it can stamp `_backendSlug` on each feature. O(1) per arrival.
+    const backendByUrl = new Map(selected.map(b => [b.url, b]));
+
+    // First-arrival latch per source — clears stale features from the prior
+    // tier on the *first* backend's response, then onResult adds features
+    // incrementally. Avoids N source.clear()+addFeatures cycles per moveend.
+    // Polygon tier still uses a first-arrival latch (it appends rather than
+    // re-derives on every arrival). Cluster tier doesn't need one — every
+    // arrival re-runs the Supercluster pipeline and clears+adds the full
+    // re-rendered set, so a separate latch would be dead.
+    let polygonFirstArrival = true;
+
+    if (tier === 'cluster') {
+      const z = Math.floor(zoom);
+      // §4.1 — cross-backend re-clustering via Supercluster. Each backend's
+      // server-bucketed cells are fed in as weighted points; on each
+      // arrival we load the accumulated set and re-emit the merged
+      // clusters so a viewport spanning two backends shows a single seam-
+      // less ring per cell instead of two overlapping rings at the border.
+      const accumulated = [];
+      const sc = new Supercluster({
+        radius: 60,
+        // Match the OL tile model (256 px); Supercluster's default extent
+        // is 512 which would effectively double the clustering radius
+        // relative to the server's cell-size table.
+        extent: 256,
+        maxZoom: clusterMaxZoom,
+        map: (p) => ({
+          count:      p.count,
+          complete:   p.complete,
+          partial:    p.partial,
+          missing:    p.missing,
+          restricted: p.restricted,
+        }),
+        reduce: (acc, p) => {
+          acc.count      += p.count;
+          acc.complete   += p.complete;
+          acc.partial    += p.partial;
+          acc.missing    += p.missing;
+          acc.restricted += p.restricted;
+        },
+      });
+      await fanOut({
+        fetcher: (url, sig) => clusterFetcherFor(url)(z, extent3857, url, sig),
+        backends: selected,
+        signal,
+        onResult: (entry) => {
+          if (signal.aborted) return;
+          if (entry.ok && Array.isArray(entry.value)) {
+            for (const b of entry.value) {
+              accumulated.push(bucketToSuperclusterPoint(b, entry.backendUrl));
+            }
+            // Reload the index with the accumulated set and re-render.
+            // Supercluster's `load` is O(N); for cluster-tier viewport
+            // sizes this is well under a millisecond. The source-clear
+            // here also covers the first-arrival "wipe stale features
+            // from the prior tier" need, so no separate latch is needed
+            // on this branch.
+            sc.load(accumulated);
+            const clusters = sc.getClusters(viewportBbox, z);
+            clusterSource.clear();
+            clusterSource.addFeatures(clusters.map(superclusterFeatureToOl));
+          } else if (!entry.ok && isNotFound(entry.error)) {
+            markBackendLegacy(entry.backendUrl);
+          }
+          hubLoadingStore.update(s => ({ ...s, loaded: s.loaded + 1 }));
+        },
+      });
+      if (!signal.aborted) {
+        hubLoadingStore.update(s => ({ ...s, settling: false }));
+      }
+    } else {
+      // polygon tier
+      await fanOut({
+        fetcher: (url, sig) => polygonFetcherFor(url)(extent3857, url, sig),
+        backends: selected,
+        signal,
+        onResult: (entry) => {
+          if (signal.aborted) return;
+          if (entry.ok) {
+            if (polygonFirstArrival) {
+              polygonFirstArrival = false;
+              polygonSource.clear();
+            }
+            const backend = backendByUrl.get(entry.backendUrl);
+            const features = parsePolygonFeatures(entry.value, entry.backendUrl, backend);
+            polygonSource.addFeatures(features);
+          } else if (isNotFound(entry.error)) {
+            markBackendLegacy(entry.backendUrl);
+          }
+          hubLoadingStore.update(s => ({ ...s, loaded: s.loaded + 1 }));
+        },
+      });
+      if (!signal.aborted) {
+        hubLoadingStore.update(s => ({ ...s, settling: false }));
+      }
+    }
+  }
+
+  // Pick the per-backend cluster fetcher. If we've previously seen a 404
+  // from this backend's tier RPC, return [] without dispatching any fetch
+  // — the legacy `get_playgrounds(relation_id)` RPC doesn't bucket, and
+  // downloading every polygon in the region just to discard them at the
+  // cluster tier wastes bandwidth without any visible benefit. The user
+  // sees a temporary hole over that backend until they zoom past
+  // `clusterMaxZoom`, where the polygon tier will use the legacy fetch.
+  function clusterFetcherFor(url) {
+    if (backendUseLegacy.has(url)) {
+      return async () => [];
+    }
+    return fetchPlaygroundClusters;
+  }
+
+  function polygonFetcherFor(url) {
+    if (backendUseLegacy.has(url)) {
+      return async (_extent, baseUrl, signal) => {
+        return fetchPlaygrounds(baseUrl, signal);
+      };
+    }
+    return fetchPlaygroundsBbox;
+  }
+
+  function markBackendLegacy(url) {
+    backendUseLegacy.add(url);
+    if (!backendLegacyWarned.has(url)) {
+      backendLegacyWarned.add(url);
+      console.warn(`[hub-tier] backend ${url} returned 404 on a tier RPC — falling back to legacy get_playgrounds for the rest of the session`);
+    }
+  }
+
+  const debounced = debounce(orchestrate, 300);
+  map.on('moveend', debounced);
+  // Initial dispatch runs immediately (not debounced) so first paint
+  // doesn't wait on a moveend.
+  orchestrate();
+
+  return () => {
+    debounced.cancel?.();
+    if (abort) abort.abort();
+    map.un('moveend', debounced);
+    detachStore();
+  };
+}
+
+function isNotFound(err) {
+  return typeof err?.message === 'string' && /\b404\b/.test(err.message);
+}
+
+// Wrap a server cluster bucket in the GeoJSON shape Supercluster expects.
+// All count fields are coerced to 0 if missing — Supercluster's `reduce`
+// callback adds them in place, and a single `undefined` would propagate
+// `NaN` through every downstream cluster's count fields silently.
+// `_backendUrl` is preserved on the singleton case so a cluster of one can
+// still route its cluster-click zoom to the right backend if needed.
+function bucketToSuperclusterPoint(b, backendUrl) {
+  return {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [b.lon, b.lat] },
+    properties: {
+      count:       b.count      ?? 0,
+      complete:    b.complete   ?? 0,
+      partial:     b.partial    ?? 0,
+      missing:     b.missing    ?? 0,
+      restricted:  b.restricted ?? 0,
+      _backendUrl: backendUrl,
+    },
+  };
+}
+
+// Convert a Supercluster output feature (cluster or singleton) into an
+// OL Feature with the props the existing cluster-style renderer expects.
+function superclusterFeatureToOl(c) {
+  const [lon, lat] = c.geometry.coordinates;
+  const f = new Feature({
+    geometry: new Point(transform([lon, lat], 'EPSG:4326', 'EPSG:3857')),
+  });
+  if (c.properties.cluster) {
+    // Multi-bucket merge — the reduce callback summed the per-bucket counts.
+    // We don't expose `cluster_id` here: Supercluster's drill-down APIs
+    // (`getClusterExpansionZoom`, `getLeaves`) need the index instance,
+    // which is local to the orchestrate() call and GC'd when it returns.
+    // Re-introduce only when a future click handler retains the index.
+    f.setProperties({
+      _tier:       'cluster',
+      count:       c.properties.count,
+      complete:    c.properties.complete,
+      partial:     c.properties.partial,
+      missing:     c.properties.missing,
+      restricted:  c.properties.restricted,
+    });
+  } else {
+    // Singleton — original bucket properties pass through.
+    f.setProperties({
+      _tier:       'cluster',
+      _backendUrl: c.properties._backendUrl,
+      count:       c.properties.count,
+      complete:    c.properties.complete,
+      partial:     c.properties.partial,
+      missing:     c.properties.missing,
+      restricted:  c.properties.restricted,
+    });
+  }
+  return f;
+}
+
+function parsePolygonFeatures(geojson, backendUrl, backend) {
+  // Legacy fetchPlaygrounds also returns a FeatureCollection — same
+  // parsing path works for both bbox-scoped and legacy responses.
+  if (!geojson || !geojson.features) return [];
+  const features = geojsonFormat.readFeatures(geojson, {
+    dataProjection:    'EPSG:4326',
+    featureProjection: 'EPSG:3857',
+  });
+  features.forEach(f => {
+    f.set('_backendUrl', backendUrl);
+    if (backend?.slug) f.set('_backendSlug', backend.slug);
+  });
+  return features;
+}

--- a/app/src/hub/macroRingStyle.js
+++ b/app/src/hub/macroRingStyle.js
@@ -1,0 +1,141 @@
+// Canvas renderer for the country-level macro view (P2 §5).
+//
+// Macro rings represent an entire backend's catalogue at zoom ≤ macroMaxZoom.
+// They differ from cluster-tier rings in two ways:
+//
+//   1. Always rendered as rings, never as the cluster-tier single-child dot
+//      (a backend with one playground is still a "region", not a singleton).
+//   2. Two visual variants — healthy (filled segments + count) and offline
+//      (dashed outline, muted, "offline" label, last known count).
+//
+// The bitmap cache from clusterStyle.js isn't reused here: macro features are
+// at most one per registered backend (typically <20), so per-frame redraws
+// cost <1 ms and the cache key complexity isn't worth it.
+
+import Style from 'ol/style/Style.js';
+import { radiusForCount } from '../lib/clusterStyle.js';
+
+const COLOR = {
+  complete:   '#228b22', // legend "complete"  fill base
+  partial:    '#eab308', // legend "partial"   fill base
+  missing:    '#ef4444', // legend "missing"   fill base
+  restricted: '#9ca3af', // tailwind gray-400 — also used for unknown-completeness rings
+};
+const RING_WIDTH      = 14; // slightly thicker than cluster (12) for country-scale prominence
+const CENTER_FILL     = 'rgba(255, 255, 255, 0.95)';
+const CENTER_STROKE   = '#1f2937';
+const CENTER_TEXT     = '#1f2937';
+const OFFLINE_STROKE  = '#9ca3af';
+const OFFLINE_FILL    = 'rgba(255, 255, 255, 0.85)';
+const OFFLINE_TEXT    = '#6b7280';
+const COUNT_FONT      = 'bold 22px ui-monospace, "SF Mono", Menlo, system-ui, -apple-system, sans-serif';
+const LABEL_FONT      = '600 11px system-ui, -apple-system, "Helvetica Neue", sans-serif';
+
+function quantiseSegments(complete, partial, missing, restricted) {
+  const total = complete + partial + missing + restricted || 1;
+  const c10 = Math.round((complete   / total) * 10);
+  const p10 = Math.round((partial    / total) * 10);
+  const m10 = Math.round((missing    / total) * 10);
+  // Rounding can over- or under-shoot 10; clamp the residual into the
+  // restricted bucket so the four arcs always sum to a full circle.
+  const r10 = Math.max(0, 10 - c10 - p10 - m10);
+  return [c10, p10, m10, r10];
+}
+
+function renderHealthyMacroRing(pixelCoords, state) {
+  const [x, y]     = pixelCoords;
+  const f          = state.feature;
+  const count      = f.get('count')      ?? 0;
+  const complete   = f.get('complete')   ?? 0;
+  const partial    = f.get('partial')    ?? 0;
+  const missing    = f.get('missing')    ?? 0;
+  const restricted = f.get('restricted') ?? 0;
+  const ctx        = state.context;
+  const radius     = radiusForCount(count);
+
+  const tenths = quantiseSegments(complete, partial, missing, restricted);
+  const colors = [COLOR.complete, COLOR.partial, COLOR.missing, COLOR.restricted];
+
+  ctx.lineWidth = RING_WIDTH;
+  ctx.lineCap   = 'butt';
+  let start = -Math.PI / 2; // 12 o'clock
+  for (let i = 0; i < 4; i++) {
+    if (tenths[i] === 0) continue;
+    const end = start + (tenths[i] / 10) * Math.PI * 2;
+    ctx.beginPath();
+    ctx.arc(x, y, radius, start, end);
+    ctx.strokeStyle = colors[i];
+    ctx.stroke();
+    start = end;
+  }
+
+  // Inner disc + count
+  ctx.beginPath();
+  ctx.arc(x, y, radius - RING_WIDTH / 2 - 1, 0, Math.PI * 2);
+  ctx.fillStyle   = CENTER_FILL;
+  ctx.strokeStyle = CENTER_STROKE;
+  ctx.lineWidth   = 1;
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle    = CENTER_TEXT;
+  ctx.font         = COUNT_FONT;
+  if ('fontFeatureSettings' in ctx) ctx.fontFeatureSettings = '"tnum" 1';
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(formatCount(count), x, y + 0.5);
+}
+
+function renderOfflineMacroRing(pixelCoords, state) {
+  const [x, y]   = pixelCoords;
+  const f        = state.feature;
+  const count    = f.get('count') ?? 0;
+  const ctx      = state.context;
+  const radius   = radiusForCount(count);
+
+  // Dashed outline ring — no segment colours since the data is stale.
+  ctx.lineWidth   = RING_WIDTH;
+  ctx.lineCap     = 'butt';
+  ctx.strokeStyle = OFFLINE_STROKE;
+  ctx.setLineDash([8, 5]);
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Inner disc — keeps the count + label legible against the basemap.
+  ctx.beginPath();
+  ctx.arc(x, y, radius - RING_WIDTH / 2 - 1, 0, Math.PI * 2);
+  ctx.fillStyle   = OFFLINE_FILL;
+  ctx.strokeStyle = OFFLINE_STROKE;
+  ctx.lineWidth   = 1;
+  ctx.fill();
+  ctx.stroke();
+
+  // Last-known count, shifted up to make room for the "offline" label.
+  ctx.fillStyle    = OFFLINE_TEXT;
+  ctx.font         = COUNT_FONT;
+  if ('fontFeatureSettings' in ctx) ctx.fontFeatureSettings = '"tnum" 1';
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(formatCount(count), x, y - 7);
+
+  ctx.font = LABEL_FONT;
+  ctx.fillText('offline', x, y + 11);
+}
+
+// Compact display: 65000 → "65k", 1500 → "1.5k", <1000 unchanged. Spec
+// scenario uses 65000 directly but at radius 44 the digit string blows
+// outside the inner disc; the "k" suffix keeps it inside.
+function formatCount(n) {
+  if (n < 1000) return String(n);
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${Math.round(n / 1000)}k`;
+}
+
+const healthyStyle = new Style({ renderer: renderHealthyMacroRing });
+const offlineStyle = new Style({ renderer: renderOfflineMacroRing });
+
+export function macroRingStyleFn(feature) {
+  return feature.get('_offline') ? offlineStyle : healthyStyle;
+}

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -1,14 +1,16 @@
-// Hub registry — loads the registry JSON, fetches playgrounds from each
-// backend in parallel, populates a shared OL VectorSource, and periodically
-// refreshes. Exposes derived stores and a multi-backend nearest fetcher.
+// Hub registry — loads the registry JSON, fetches per-backend metadata
+// (`get_meta`) on a 5-min poll, exposes the resulting `backends` readable
+// store, and provides a multi-backend nearest-playground fetcher.
+//
+// Note (P2 §3): the eager `get_playgrounds(relation_id)` fetch that this
+// module used to do at startup has moved to `hubOrchestrator.js`, which
+// fans out the per-tier RPCs (clusters / bbox-polygons) on every moveend.
+// The registry now only handles registry discovery + metadata + nearest.
 
 import { readable, writable, derived } from 'svelte/store';
-import GeoJSON from 'ol/format/GeoJSON.js';
 import { registryUrl, hubPollInterval } from '../lib/config.js';
 import { fetchMeta } from '../lib/api.js';
 import { isValidSlug } from '../lib/deeplink.js';
-
-const geojsonFormat = new GeoJSON();
 
 // Per-backend timeout for multi-backend nearest fan-out. A slow or unreachable
 // backend contributes zero results but never stalls the user interaction.
@@ -26,19 +28,29 @@ const NEAREST_MAX_DISTANCE_M = 25_000;
  *   slug: string | null,
  *   loading: boolean,
  *   error: string | null,
- *   featureCount: number,
  *   version: string | null,
  *   region: string | null,
  *   bbox: [minLon, minLat, maxLon, maxLat] | null,
+ *   playgroundCount: number,                          // from get_meta.playground_count (P1)
+ *   completeness: { complete, partial, missing } | null, // from get_meta (P1)
  * }
+ *
+ * `completeness` is `null` until `get_meta` returns, AND stays `null` if the
+ * backend is on a pre-P1 release that doesn't ship the three completeness
+ * fields. Downstream macro-view rendering uses this sentinel to distinguish
+ * "stale / pre-P1 backend" from "actual zero-playground region".
+ *
+ * Each `loadBackend` call replaces the entry in the `backends` array with a
+ * new object identity (immutable patch via `{ ...prev, ...patch }`) so
+ * memoised consumers (e.g. macro-view rings) can use reference equality.
  */
 
 /**
  * Creates a registry that loads backend status into a Svelte readable store
- * and populates `vectorSource` with playground features (tagged with
- * `_backendUrl` and, when present, `_backendSlug`).
+ * and exposes derived stores + a multi-backend nearest fetcher. The hub
+ * orchestrator (P2 §3) consumes the `backends` store to drive bbox routing
+ * and per-tier fan-out; the registry no longer touches any vector source.
  *
- * @param {import('ol/source/Vector.js').default} vectorSource
  * @returns {{
  *   backends: import('svelte/store').Readable<Array>,
  *   registryError: import('svelte/store').Readable<string|null>,
@@ -46,7 +58,7 @@ const NEAREST_MAX_DISTANCE_M = 25_000;
  *   fetchNearestAcrossBackends: (lat: number, lon: number, limit?: number) => Promise<Array>,
  * }}
  */
-export function createRegistry(vectorSource) {
+export function createRegistry() {
   let backends = [];
   let pollTimer = null;
   const registryError = writable(null);
@@ -56,47 +68,42 @@ export function createRegistry(vectorSource) {
       set([...backends]);
     }
 
-    async function loadBackend(backend) {
-      backend.loading = true;
-      backend.error = null;
+    function patchBackend(url, patch) {
+      const idx = backends.findIndex(b => b.url === url);
+      if (idx < 0) return null;
+      const updated = { ...backends[idx], ...patch };
+      backends[idx] = updated;
       notify();
+      return updated;
+    }
+
+    async function loadBackend(backend) {
+      patchBackend(backend.url, { loading: true, error: null });
 
       try {
-        const [meta, geojson] = await Promise.all([
-          fetchMeta(backend.url).catch(() => null),
-          fetchPlaygroundsHub(backend.url),
-        ]);
+        const meta = await fetchMeta(backend.url);
 
+        const patch = { loading: false };
         if (meta) {
-          backend.version = meta.version ?? null;
-          backend.region  = meta.name    ?? null;
-          backend.bbox    = Array.isArray(meta.bbox) && meta.bbox.length === 4 ? meta.bbox : null;
-          if (!backend.name && backend.region) backend.name = backend.region;
+          patch.version         = meta.version ?? null;
+          patch.region          = meta.name    ?? null;
+          patch.bbox            = Array.isArray(meta.bbox) && meta.bbox.length === 4 ? meta.bbox : null;
+          patch.playgroundCount = meta.playground_count ?? 0;
+          // Pre-P1 backends omit the three completeness fields. Use a null
+          // sentinel for `completeness` in that case so the macro view can
+          // render a "no completeness data" treatment instead of an
+          // all-zero ring (which would look like a healthy empty region).
+          const hasCompleteness = ['complete', 'partial', 'missing'].every(k => k in meta);
+          patch.completeness = hasCompleteness
+            ? { complete: meta.complete, partial: meta.partial, missing: meta.missing }
+            : null;
+          if (!backend.name && patch.region) patch.name = patch.region;
         }
 
-        // Parse first — only touch the map if parsing succeeds
-        const features = geojsonFormat.readFeatures(geojson, {
-          dataProjection:    'EPSG:4326',
-          featureProjection: 'EPSG:3857',
-        });
-        features.forEach(f => {
-          f.set('_backendUrl', backend.url);
-          if (backend.slug) f.set('_backendSlug', backend.slug);
-        });
-
-        // Atomic swap: remove stale then add new in the same JS turn
-        const stale = vectorSource.getFeatures().filter(f => f.get('_backendUrl') === backend.url);
-        if (stale.length) vectorSource.removeFeatures(stale);
-        vectorSource.addFeatures(features);
-
-        backend.featureCount = features.length;
-        backend.loading      = false;
+        patchBackend(backend.url, patch);
       } catch (err) {
-        backend.error   = err.message;
-        backend.loading = false;
+        patchBackend(backend.url, { error: err.message, loading: false });
       }
-
-      notify();
     }
 
     async function loadAll() {
@@ -110,15 +117,16 @@ export function createRegistry(vectorSource) {
         // Support both { instances: [...] } and bare array formats
         const entries = Array.isArray(data) ? data : (data.instances ?? []);
         backends = entries.map(entry => ({
-          url:          entry.url,
-          name:         entry.name || entry.url,
-          slug:         normaliseSlug(entry.slug, entry.url),
-          loading:      true,
-          error:        null,
-          featureCount: 0,
-          version:      null,
-          region:       null,
-          bbox:         null,
+          url:             entry.url,
+          name:            entry.name || entry.url,
+          slug:            normaliseSlug(entry.slug, entry.url),
+          loading:         true,
+          error:           null,
+          version:         null,
+          region:          null,
+          bbox:            null,
+          playgroundCount: 0,
+          completeness:    null, // populated after get_meta lands; see status-shape JSDoc
         }));
         notify();
 
@@ -205,14 +213,6 @@ function normaliseSlug(raw, url) {
   if (isValidSlug(raw)) return raw;
   console.warn(`[registry] invalid slug "${raw}" on backend ${url} — treating as missing`);
   return null;
-}
-
-/** Fetches all playgrounds from a backend without passing a relation_id —
- *  the backend uses its own configured default. */
-async function fetchPlaygroundsHub(baseUrl) {
-  const res = await fetch(`${baseUrl}/rpc/get_playgrounds`);
-  if (res.ok) return res.json();
-  throw new Error(`get_playgrounds failed: ${res.status}`);
 }
 
 /** Per-backend nearest-playgrounds call with a timeout. Returns [] on any

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -93,7 +93,14 @@ export function createRegistry() {
           // sentinel for `completeness` in that case so the macro view can
           // render a "no completeness data" treatment instead of an
           // all-zero ring (which would look like a healthy empty region).
-          const hasCompleteness = ['complete', 'partial', 'missing'].every(k => k in meta);
+          //
+          // The `Number.isFinite` check (rather than `k in meta`) also
+          // collapses `null` and `NaN` sentinels into the unknown branch
+          // — without it, a backend that ships `{ complete: null, partial:
+          // null, missing: null }` would pass the `in` test, then poison
+          // the macro renderer's `quantiseSegments` with NaN tenths and
+          // produce an invisible ring with no error surface.
+          const hasCompleteness = ['complete', 'partial', 'missing'].every(k => Number.isFinite(meta[k]));
           patch.completeness = hasCompleteness
             ? { complete: meta.complete, partial: meta.partial, missing: meta.missing }
             : null;

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -13,13 +13,25 @@ let _fetchPlaygroundsDeprecationWarned = false;
  * @deprecated Since v0.2.7 — use {@link fetchPlaygroundsBbox} with a viewport
  *   extent. The region-scoped `get_playgrounds` RPC will be removed in the
  *   release after next. See openspec change add-tiered-playground-delivery.
+ *
+ * @param {string} baseUrl  PostgREST base URL (defaults to apiBaseUrl).
+ * @param {AbortSignal} [signal]  Optional cancellation signal — honoured so the
+ *   hub orchestrator's per-fan-out abort cancels in-flight legacy fallbacks.
+ *
+ * Hub usage note: when called from the hub's per-backend legacy fallback,
+ * `osmRelationId` is the hub's *global* config (typically `0`), which is not
+ * meaningful to the target backend. The query string omits `relation_id`
+ * entirely when it is falsy so the backend's own SQL default takes over.
  */
-export async function fetchPlaygrounds(baseUrl = defaultApiBaseUrl) {
+export async function fetchPlaygrounds(baseUrl = defaultApiBaseUrl, signal) {
     if (!_fetchPlaygroundsDeprecationWarned) {
         _fetchPlaygroundsDeprecationWarned = true;
         console.warn('[api] fetchPlaygrounds is deprecated — use fetchPlaygroundsBbox. Scheduled for removal in the release after next.');
     }
-    const res = await fetch(`${baseUrl}/rpc/get_playgrounds?relation_id=${osmRelationId}`);
+    const url = osmRelationId
+        ? `${baseUrl}/rpc/get_playgrounds?relation_id=${osmRelationId}`
+        : `${baseUrl}/rpc/get_playgrounds`;
+    const res = await fetch(url, { signal });
     if (res.ok) return res.json();
     throw new Error(`get_playgrounds failed: ${res.status}`);
 }

--- a/app/src/lib/clusterStyle.js
+++ b/app/src/lib/clusterStyle.js
@@ -32,7 +32,11 @@ const bitmapCache = new Map();
 // Radii bumped substantially for strong visual prominence at zoom ≤ 13
 // (two-tier design — no centroid tier). Original spec values were
 // 12/14/18/22; here we roughly double them.
-function radiusForCount(count) {
+//
+// Exported for macro-view reuse (P2 §5) — the spec scenario
+// "Macro ring position and sizing" requires that backend rings use the same
+// size scale as cluster rings.
+export function radiusForCount(count) {
   if (count <   10) return 26;
   if (count <  100) return 32;
   if (count < 1000) return 38;

--- a/app/src/lib/config.js
+++ b/app/src/lib/config.js
@@ -46,3 +46,13 @@ export const hubPollInterval = c.hubPollInterval ?? 300;
 //   zoom ≤ clusterMaxZoom → cluster layer (get_playground_clusters)
 //   zoom >  clusterMaxZoom → polygon layer (get_playgrounds_bbox)
 export const clusterMaxZoom = c.clusterMaxZoom ?? 13;
+
+// --- Federated clustering (P2, hub mode only) ---
+
+// Below this zoom the hub renders a country-level macro view (one ring per
+// backend at its bbox centroid, sized by playground_count) and the
+// orchestrator skips per-tier fetches entirely.
+//   zoom ≤ macroMaxZoom              → macro view (no fan-out)
+//   macroMaxZoom < zoom ≤ clusterMaxZoom → cluster tier fan-out
+//   zoom >  clusterMaxZoom            → polygon tier fan-out
+export const macroMaxZoom = c.macroMaxZoom ?? 5;

--- a/app/src/stores/hubLoading.js
+++ b/app/src/stores/hubLoading.js
@@ -1,0 +1,14 @@
+// Hub-tier load progress (P2 §3.5).
+//
+// Written by the hub orchestrator on each fan-out:
+//   { loaded: number, total: number, settling: boolean }
+//
+// `total` = number of backends in the current fan-out (after bbox + health
+// filtering); `loaded` increments per-backend as `onResult` fires; `settling`
+// is true between the start of a fan-out and its `Promise.all` resolution.
+//
+// Consumed by InstancePanel to surface partial-load state in the pill
+// ("3/5 regions loaded") so users see federation responsiveness.
+
+import { writable } from 'svelte/store';
+export const hubLoadingStore = writable({ loaded: 0, total: 0, settling: false });

--- a/app/src/stores/tier.js
+++ b/app/src/stores/tier.js
@@ -1,6 +1,12 @@
-// Active zoom-tier for the three-layer playground renderer.
-// Written by the tieredOrchestrator on moveend; read by Map.svelte to toggle
-// layer visibility. Values: null | 'cluster' | 'centroid' | 'polygon'.
+// Active zoom-tier for the playground renderer.
+//
+// Written by the orchestrator on moveend; read by Map.svelte to toggle
+// layer visibility. Values:
+//   null       — orchestrator hasn't run yet (boot state)
+//   'cluster'  — cluster layer visible (server-bucketed rings)
+//   'polygon'  — polygon layer visible (full GeoJSON polygons)
+//   'macro'    — hub-only: macro view visible, no cluster/polygon fetches
+//                (P2 — country-level rings rendered from cached get_meta)
 //
 // Default is null so Map.svelte can hide all layers until the orchestrator
 // has run at least once. This avoids a flash of the empty polygon layer on

--- a/docs/ops/federated-deployment.md
+++ b/docs/ops/federated-deployment.md
@@ -38,6 +38,7 @@ Each data-node runs the full `data-node-ui` profile so the shipped nginx config 
 - One OSM relation ID and one Geofabrik PBF URL per data-node ([how to find them](manual-deploy.md#step-1-find-your-regions-osm-relation-id)).
 - HTTPS-terminating reverse proxy in front of each data-node in production — the browser must be able to fetch the data-node's `/api/` over HTTPS when the Hub itself is served over HTTPS.
 - When co-locating nodes on one host, give each its own `APP_PORT` (e.g. `8080`, `8081`, `8082`) and its own `COMPOSE_PROJECT_NAME` (e.g. `spieli-fulda`, `spieli-neuhof`, `spieli-hub`) so port bindings and Docker resource names don't collide.
+- **Data-node version**: each data-node must run a release that ships the tiered playground API (`get_playground_clusters`, `get_playgrounds_bbox`, `get_playground`) and the completeness fields on `get_meta` (`complete`, `partial`, `missing`). These landed in the same release that introduced this walkthrough; an older data-node still joins successfully but degrades to a legacy fallback path — see the [federation reference's Federation endpoints table](../reference/federation.md#federation-endpoints) for the degradation matrix. If you can, upgrade every data-node before pointing a current Hub at it.
 
 ## Step 1 — Stand up each data-node
 
@@ -172,7 +173,9 @@ The Hub has no importer, no database, no `run --rm importer` step.
 2. You should see the map render, fit to the union of all configured regions, with the instance pill in the bottom-left showing the aggregated region + playground counts (localized German: e.g. `2 Regionen · <count> Spielplätze` with a globe icon).
 3. Open DevTools → Network and reload. You should see:
    - One `GET /registry.json` from the Hub's origin.
-   - One `GET /rpc/get_meta` and one `GET /rpc/get_playgrounds` per data-node, cross-origin, returning 200.
+   - One `GET /rpc/get_meta` per data-node, cross-origin, returning 200 with `playground_count` + `bbox` + completeness fields.
+   - On the first moveend, either `GET /rpc/get_playground_clusters?...` (cluster tier, zoom ≤ 13) or `GET /rpc/get_playgrounds_bbox?...` (polygon tier, zoom ≥ 14) per data-node whose bbox intersects the viewport. A data-node whose bbox sits entirely outside the viewport receives no request — that's the bbox router (see the federation reference's [Scale and clustering](../reference/federation.md#scale-and-clustering) section) doing its job, not a bug.
+   - At zoom ≤ 5 (continental view) you should see no per-playground requests at all — the country-level macro view renders entirely from the cached `get_meta` response. One ring per data-node.
 4. Click the instance pill — the drawer lists both backends with their playground count. (A version badge renders only when a backend's `get_meta` exposes a `version` field, which the SQL function doesn't today, so the badge slot stays empty in current releases.)
 5. Click a playground in each region — the selection panel opens with that region's data.
 

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -54,14 +54,17 @@ The second backend uses `OSM_RELATION_ID2` from `.env` (default: `454881` = Neuh
 
 ## Federation endpoints
 
-Each regional instance exposes two endpoints (available since v0.2.1):
+Each regional instance exposes the tiered playground API plus the federation discovery endpoint. A backend that joins a P2-capable Hub (the current code) must implement all four tier endpoints — see [API reference](api.md) for full request/response shapes.
 
-| Endpoint | Description |
-|---|---|
-| `GET /api/rpc/get_playgrounds` | Full GeoJSON FeatureCollection of all playgrounds in the region |
-| `GET /api/rpc/get_meta` | Instance metadata: OSM relation name, playground count, bounding box |
+| Endpoint | Description | Used at |
+|---|---|---|
+| `GET /api/rpc/get_meta` | Instance metadata: OSM relation name, playground count, bounding box, completeness counts | macro tier + registry discovery |
+| `GET /api/rpc/get_playground_clusters` | Pre-aggregated cluster buckets `{lon, lat, count, complete, partial, missing, restricted}` for a viewport | cluster tier (zoom ≤ `clusterMaxZoom`) |
+| `GET /api/rpc/get_playgrounds_bbox` | GeoJSON FeatureCollection of polygons inside a viewport | polygon tier (zoom > `clusterMaxZoom`) |
+| `GET /api/rpc/get_playground` | Single-feature lookup by `osm_id` | deeplink hydration |
+| `GET /api/rpc/get_playgrounds` | **Deprecated** — region-scoped FeatureCollection. The Hub falls back to it once per backend per session if a tier RPC 404s, with a one-time warning | legacy fallback only |
 
-CORS is enabled on `/api/` so the Hub can query instances cross-origin from the browser.
+CORS is enabled on `/api/` so the Hub can query instances cross-origin from the browser. Backends running pre-P1 releases (no tier RPCs, no completeness extension to `get_meta`) still join successfully — the macro view shows them as "data quality unknown" (flat gray ring) and the cluster tier silently skips them rather than burning bandwidth on a region-wide legacy fetch that would be discarded.
 
 ## Registry
 
@@ -91,6 +94,73 @@ The Hub renders the same layout as a standalone regional map, with two additions
 - **Deep-link scheme**: see the [deep-link behaviour table](registry-json.md#deep-link-behaviour) in the registry reference.
 
 The scale-line sits just below the pill in the same bottom-left corner. All other controls (search, filters, locate, zoom, contribute) are shared with standalone mode and behave identically.
+
+## Scale and clustering
+
+The Hub is designed to stay responsive across two and thirty backends without any per-deployment tuning. It does this with three zoom tiers and a bbox router, so a Europe-wide viewport doesn't pull every polygon from every backend, and a city-block viewport doesn't ship a redundant continental aggregate.
+
+### Zoom tiers
+
+| Zoom | Tier | What ships per backend | Where the work happens |
+|---|---|---|---|
+| `0–5` (`≤ macroMaxZoom`) | **macro** | nothing — uses cached `get_meta` | client renders one ring per backend at the bbox centroid |
+| `6–13` (`≤ clusterMaxZoom`) | **cluster** | `get_playground_clusters(z, bbox)` returns pre-aggregated buckets | server bucketing + client re-clustering across border seams |
+| `14+` | **polygon** | `get_playgrounds_bbox(bbox)` returns full GeoJSON polygons | client just concatenates per-backend polygons (each tagged with `_backendUrl`) |
+
+`macroMaxZoom` and `clusterMaxZoom` are independent config knobs (defaults 5 and 13). The macro tier is hub-only — standalone reads `macroMaxZoom` but never enters the macro tier.
+
+### Bbox routing — only intersecting backends are queried
+
+Every backend's `get_meta` response carries a `bbox`. On every (debounced) moveend, the Hub intersects the current viewport with each backend's bbox and only fans out to backends whose bbox intersects. A viewport over Berlin doesn't issue a request to a Köln-only backend; a viewport spanning the German-Polish border issues parallel requests to both backends.
+
+The bboxes are refreshed on the existing 5-minute registry poll, so a backend that extends its OSM relation mid-session sees the change at the next poll without a hub restart.
+
+### Fan-out and progressive render
+
+The Hub invokes each selected backend's tier RPC in parallel via a single `AbortController`. As each backend's response arrives, the matching layer (cluster or polygon source) is repainted incrementally — a fast backend's contribution shows within ~100 ms even if a slower peer takes 2 seconds. Per-backend timeout is 5 s; a backend that exceeds it is omitted from the current tier with a one-time console warning, and the map stays interactive.
+
+Every moveend constructs a fresh `AbortController` and aborts the previous one, so superseded fan-outs cancel their in-flight per-backend requests via the inner controller.
+
+### Cross-backend re-clustering
+
+At the cluster tier, two backends covering adjacent regions both ship their own bucket grids. Without re-clustering, the seam at their shared border shows as two overlapping rings. The Hub feeds each backend's buckets into a per-fan-out [Supercluster](https://github.com/mapbox/supercluster) instance as weighted points and re-emits merged clusters whose `{count, complete, partial, missing, restricted}` totals are the sum of the contributing buckets — a single seamless ring per cell.
+
+The polygon tier doesn't re-cluster — every backend's polygons render in a single vector source, each feature tagged with `_backendUrl` so selection routes back to the right backend.
+
+### Country-level macro view
+
+At `zoom ≤ macroMaxZoom` the Hub renders one stacked-ring per registered backend, sized by `playground_count` and segmented by the `{complete, partial, missing}` counts the P1 `get_meta` extension ships. No per-playground fetch is issued at this zoom — the rings come entirely from the cached registry metadata.
+
+Clicking a macro ring animates `view.fit` to the backend's bbox, which lands in the cluster or polygon tier and triggers a tier fetch scoped to that backend only.
+
+Backends marked as offline (via `federation-status.json`, when [add-federation-health-exposition](../../openspec/changes/add-federation-health-exposition/proposal.md) ships) render as a dashed outline with their last-known count and an "offline" label, so the operator sees that the region exists but isn't currently reachable.
+
+### Architecture flow
+
+```mermaid
+flowchart LR
+    user[User pans / zooms map] --> moveend[Debounced moveend<br/>300 ms]
+    moveend --> tier{tierForZoom}
+    tier -- "z ≤ 5" --> macro[Macro view<br/>reads cached get_meta]
+    tier -- "z 6–13" --> cluster[Cluster tier]
+    tier -- "z ≥ 14" --> polygon[Polygon tier]
+
+    cluster --> bbox[bboxRouter.selectBackends<br/>viewport ∩ each bbox]
+    polygon --> bbox
+
+    bbox --> health[federationHealth.filterHealthy<br/>skip ok=false backends]
+    health --> fanout[fanOut<br/>parallel AbortController<br/>per-backend 5 s timeout]
+
+    fanout -- "cluster tier" --> sc[Supercluster<br/>map + reduce per backend bucket]
+    fanout -- "polygon tier" --> concat[Concatenate features<br/>stamp _backendUrl]
+
+    sc --> render[Repaint clusterSource<br/>incrementally per arrival]
+    concat --> render2[Append to polygonSource<br/>incrementally per arrival]
+
+    macro --> macroLayer[Render macroSource<br/>one ring per backend]
+```
+
+Each box in the cluster/polygon path runs once per moveend. Fan-out is the only step that produces network traffic; everything else is in-memory.
 
 ## See also
 

--- a/oci/app/docker-entrypoint.sh
+++ b/oci/app/docker-entrypoint.sh
@@ -24,6 +24,7 @@ window.APP_CONFIG = {
   mapZoom:           ${MAP_ZOOM:-6},
   mapMinZoom:        ${MAP_MIN_ZOOM:-4},
   clusterMaxZoom:    ${CLUSTER_MAX_ZOOM:-13},
+  macroMaxZoom:      ${MACRO_MAX_ZOOM:-5},
   parentOrigin:      '${SAFE_PARENT_ORIGIN}'
 };
 JSEOF

--- a/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
@@ -34,9 +34,17 @@ For any tier that requires a per-backend fetch, the hub SHALL invoke each select
 
 #### Scenario: Progressive render
 
-- **WHEN** the hub fans out a centroid fetch to backends A, B, and C, and C takes 2 seconds while A and B respond in 100 ms
-- **THEN** the centroid layer renders data from A and B within ~100 ms (plus debounce)
+- **WHEN** the hub fans out a cluster fetch to backends A, B, and C, and C takes 2 seconds while A and B respond in 100 ms
+- **THEN** the cluster layer renders data from A and B within ~100 ms (plus debounce)
 - **AND** C's contribution appears when its response settles, without re-rendering the whole map
+
+<!--
+  The original spec scenario read "centroid fetch" — pre-pivot the hub had
+  three tiers (cluster/centroid/polygon). Centroid was dropped in P1's
+  two-tier pivot; the same progressive-render requirement applies to the
+  cluster tier.
+-->
+
 
 #### Scenario: Slow backend does not block the paint
 
@@ -108,7 +116,7 @@ At the cluster tier, merged cluster buckets from multiple backends SHALL be re-c
 
 ### Requirement: Hub renders a country-level macro view at zoom 0–5
 
-At zoom levels at or below `clusterMaxZoom` (default 10; the macro tier starts at 5), the hub SHALL render one stacked-ring feature per registered backend, sized and segmented by the backend's `get_meta` aggregate counts, without fetching any per-playground data.
+At zoom levels at or below `macroMaxZoom` (default 5; introduced as a separate config knob during implementation so the cluster tier can keep its own `clusterMaxZoom = 13` threshold), the hub SHALL render one stacked-ring feature per registered backend, sized and segmented by the backend's `get_meta` aggregate counts, without fetching any per-playground data.
 
 #### Scenario: Macro view renders one ring per backend
 

--- a/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/add-federated-playground-clustering/specs/federated-playground-clustering/spec.md
@@ -106,7 +106,7 @@ At the cluster tier, merged cluster buckets from multiple backends SHALL be re-c
 - **WHEN** backend A returns buckets summing to count 2000 and backend B returns buckets summing to count 1500 inside the viewport
 - **THEN** the rendered cluster layer, after re-clustering, shows a total count of 3500 across its rings
 - **AND** the sum of `complete` segments equals the sum of `complete` inputs from A and B
-- **AND** likewise for `partial` and `missing`
+- **AND** likewise for `partial`, `missing`, and `restricted` (the four-segment ring shipped with P1's restricted bucket)
 
 #### Scenario: Border clusters merge visually
 
@@ -132,15 +132,17 @@ At zoom levels at or below `macroMaxZoom` (default 5; introduced as a separate c
 
 #### Scenario: Macro ring segments reflect completeness
 
-- **WHEN** backend A has `{complete: 12000, partial: 30000, missing: 23000}` in its `get_meta` response
-- **THEN** A's ring displays three segments proportional to 12 : 30 : 23
+- **WHEN** backend A has `{complete: 12000, partial: 30000, missing: 23000}` in its `get_meta` response (P1 `get_meta` doesn't yet ship `restricted`; macro view treats it as zero in that case)
+- **THEN** A's ring displays segments proportional to 12 : 30 : 23 : 0 (the four-segment renderer collapses the empty `restricted` arc)
 - **AND** colours match the playground polygon completeness colours
+- **WHEN** a backend extends `get_meta` with `restricted` in a future release
+- **THEN** the macro ring renders four segments including the gray-hatched restricted arc, matching the cluster ring's four-segment layout
 
 #### Scenario: Macro ring click zooms to backend bbox
 
 - **WHEN** the user clicks a macro-view ring
 - **THEN** the map view animates to fit the backend's bbox with standard padding
-- **AND** the zoom lands in the cluster or centroid tier (depending on bbox size)
+- **AND** the zoom lands in the cluster or polygon tier (depending on bbox size — centroid tier was dropped in P1's two-tier pivot)
 - **AND** a tier fetch is issued to (only) that backend after the moveend debounce
 
 ### Requirement: Hub polygon tier concatenates without re-merging
@@ -166,8 +168,8 @@ When only one backend is registered, the hub's initial `view.fit` SHALL clamp to
 #### Scenario: Single-backend hub lands above macro threshold
 
 - **WHEN** a hub starts with exactly one backend whose bbox corresponds to a small region (e.g. a single city)
-- **THEN** the initial map fit zoom is at least `clusterMaxZoom + 1` (default 11)
-- **AND** the user sees cluster or centroid features on first paint, not macro rings
+- **THEN** the initial map fit zoom is at least `clusterMaxZoom + 1` (default 14, since `clusterMaxZoom` defaults to 13)
+- **AND** the user sees cluster or polygon features on first paint, not macro rings
 
 #### Scenario: Multi-backend hub lands in whatever tier the union bbox dictates
 

--- a/openspec/changes/add-federated-playground-clustering/tasks.md
+++ b/openspec/changes/add-federated-playground-clustering/tasks.md
@@ -110,15 +110,22 @@
 
 ## 7. Hub — filter-aware cluster badge under federation
 
-- [ ] 7.1 At the centroid tier, the filter badge computation runs over merged centroids from all contributing backends; no per-backend change needed beyond P1
-- [ ] 7.2 At the cluster tier, no filter badge (same rule as P1)
-- [ ] 7.3 At the macro tier, no filter badge (decision D6 in design.md)
+Most of this section is moot post-pivot — the centroid tier was dropped in
+P1, and the cluster-tier filter badge is itself a P1 deferred task. What
+remains is a federation-side verification that the existing polygon-tier
+filter rendering carries over unchanged when polygons come from multiple
+backends.
+
+- [-] 7.1 ~~Centroid tier filter badge across merged centroids~~ — **N/A in two-tier design**. Centroid tier was dropped during the P1 pivot; the badge requirement now lives entirely with P1's cluster-tier work.
+- [x] 7.2 No client-side filter badge at the cluster tier in hub mode — same rule as P1. Federation-specific note: when the P1 cluster-tier badge ships, Supercluster's `reduce` callback in `hubOrchestrator.js` already sums named bucket fields (cf. §4.4); adding a `match_count` field there is a one-line change at that point. Tracked as a follow-up gated on the P1 badge.
+- [x] 7.3 No filter badge at the macro tier — design decision D6. The macro ring shows aggregate completeness for the entire region; a "47k of 65k match the soccer filter" badge over France carries no actionable signal at continental scale.
+- [x] 7.4 Polygon tier — verified that `Map.svelte`'s reactive `playgroundLayer.setStyle(feature => matchesFilters(...) ? playgroundStyleFn(feature) : null)` path works unchanged when polygons originate from multiple backends. `matchesFilters` reads OSM property keys (`osm_id`, `surface`, `access`, `has_soccer`, etc.) that the P1 schema guarantees uniform across federation members, so no per-backend filter logic is needed. Polygons that don't match the active filter are simply not rendered, regardless of which backend supplied them.
 
 ## 8. Docs
 
-- [ ] 8.1 Add a "Scale and clustering" section to `docs/reference/federation.md` describing the zoom tiers, bbox routing, and the country-level macro view
-- [ ] 8.2 Update `docs/ops/federated-deployment.md` (coming in `document-federated-hub-deployment`) with a note that backends must implement `add-tiered-playground-delivery` before joining a hub running this code
-- [ ] 8.3 Add an architecture diagram (mermaid or simple ASCII) showing hub → bbox-router → fan-out → re-cluster → render
+- [x] 8.1 Added a "Scale and clustering" section to `docs/reference/federation.md` covering the three zoom tiers (with their per-tier RPCs), bbox routing semantics, fan-out + progressive render, cross-backend re-clustering, and the country-level macro view (including offline rendering). Updated the Federation endpoints table to list all four tier RPCs + the deprecated legacy fallback, with a note about pre-P1 backend graceful degradation.
+- [x] 8.2 Added a tier-RPC prerequisite to `docs/ops/federated-deployment.md` Prerequisites section (data-nodes must ship the tiered API + completeness extension; older data-nodes degrade rather than fail). Updated the Step 4 verification list to point at `get_playground_clusters` / `get_playgrounds_bbox` per moveend instead of the deprecated `get_playgrounds`, and called out the macro-tier "no per-playground requests" expectation at zoom ≤ 5.
+- [x] 8.3 Embedded a mermaid `flowchart LR` in `docs/reference/federation.md` showing user moveend → tier dispatch → bboxRouter → federationHealth filter → fanOut → (Supercluster | concat) → source repaint, plus the macro-view branch that bypasses fan-out entirely.
 
 ## 9. Verification
 

--- a/openspec/changes/add-federated-playground-clustering/tasks.md
+++ b/openspec/changes/add-federated-playground-clustering/tasks.md
@@ -1,46 +1,112 @@
 ## 1. Hub — bbox routing and backend metadata
 
-- [ ] 1.1 Extend `app/src/hub/registry.js` (or add `app/src/hub/backends.js`) to cache each backend's `bbox` field from its `get_meta` response
-- [ ] 1.2 Expose a readable `backendsStore` emitting `{ url, slug, name, bbox, playgroundCount, completeness: {complete, partial, missing} }` per backend
-- [ ] 1.3 Add `app/src/hub/bboxRouter.js` — pure function `selectBackends(viewportBbox, backends) => backends[]` that returns only backends whose cached bbox intersects the viewport
-- [ ] 1.4 Keep bboxes fresh by re-invoking `get_meta` on the existing 5-minute registry poll
-- [ ] 1.5 Integrate `federation-status.json` as a filter: backends with `ok: false` are excluded from the router's output (soft fallback when the status file is absent — treat every backend as reachable)
+- [x] 1.1 Backend `bbox` is cached on the existing registry-poll path (`app/src/hub/registry.js::loadBackend`); this section augments it with the new fields rather than introducing a separate `backends.js`.
+- [x] 1.2 `backends` readable store now emits per-entry `playgroundCount` and `completeness: {complete, partial, missing}` populated from `get_meta` (the P1 extension). JSDoc shape comment updated.
+- [x] 1.3 New pure module `app/src/hub/bboxRouter.js` exports `selectBackends(viewportBbox, backends)` — bbox intersection filter (touch counts).
+- [x] 1.4 Bboxes refresh on the existing 5-min registry poll (`schedulePoll` re-runs `loadBackend` for every entry, which re-reads `get_meta`).
+- [x] 1.5 New `app/src/hub/federationHealth.js` exposes `isBackendHealthy` + `filterHealthy` — **stubbed** to "always healthy" with a clear module comment. Real implementation lands when `add-federation-health-exposition` ships `/federation-status.json`.
 
 ## 2. Hub — fan-out with progressive render
 
-- [ ] 2.1 Create `app/src/hub/fanOut.js` — `fanOut(fetcher, backends, signal)` invokes `fetcher(backendUrl, signal)` in parallel across `backends`, emits each response as it settles via an async iterator or callback
-- [ ] 2.2 Fan-out shares a single `AbortController` across its invocations; on cancel, every in-flight request is aborted
-- [ ] 2.3 Per-backend per-request timeout (default 5s); timed-out backends are logged once per session and excluded from the current fan-out
-- [ ] 2.4 Errors from one backend do not reject the fan-out promise; they are surfaced as `{ ok: false, error, backendUrl }` entries
+- [x] 2.1 New `app/src/hub/fanOut.js` exports `fanOut({ fetcher, backends, signal, onResult, timeoutMs })`. Invokes the fetcher per-backend in parallel; `onResult` callback fires per-arrival for progressive render.
+- [x] 2.2 One inner `AbortController` aborts every in-flight request together; honours a parent `signal` from the orchestrator.
+- [x] 2.3 Per-backend timeout defaults to 5000 ms; timed-out backends are warned exactly once per session (module-level Set tracks the warning).
+- [x] 2.4 Errors are caught and surfaced as `{ ok: false, error, backendUrl }`; the fan-out promise resolves with every backend's outcome rather than rejecting.
+
+### Review Findings — §1 + §2 foundation, Pass 1 (bmad-code-review, 2026-04-25)
+
+#### Medium
+- [x] [Review][Patch] **Pre-P1 backend indistinguishable from zero playgrounds**. `meta.complete ?? 0` collapses missing fields and a 0 result into the same shape, so a legacy backend (no `get_meta` extension) renders as healthy-but-empty in the macro view. Use a `null` sentinel for `completeness` whenever any of the three fields is absent. [app/src/hub/registry.js loadBackend + initial state] (Medium)
+- [x] [Review][Patch] **Backends store mutates entries in place**. `backend.bbox = …` etc. doesn't change object identity, defeating any future memoised consumer (macro-view rings keyed by `prev[i] === curr[i]`). Replace with `backends[idx] = { ...backend, ...patch }` so identity changes on every update. [app/src/hub/registry.js loadBackend] (Medium)
+
+#### Low
+- [x] [Review][Patch] **Antimeridian bbox silently dropped**. `bboxesIntersect` assumes `minLon ≤ maxLon`. A backend with bbox crossing ±180° won't match any normal viewport. No active deployment hits this today, but document the limitation in the function header. [app/src/hub/bboxRouter.js] (Low)
+- [x] [Review][Patch] **`selectBackends([NaN,...], …)` silently excludes everything**. Every numeric comparison against `NaN` is false, so a viewport tuple containing NaN looks like a valid bbox to the truthiness check but filters out every backend. Add a finite-number guard. [app/src/hub/bboxRouter.js] (Low)
+- [x] [Review][Patch] **`fanOut` fetcher not validated** — a missing/non-function fetcher rejects every task with the same error, masking the bug at the call site. Defensive guard with a clear throw. [app/src/hub/fanOut.js] (Low)
+- [x] [Review][Patch] **Two timers per backend race the warn-once log**. The cosmetic warning timer can fire just before the abort timer if both land in the same tick. Merge into a single timer that warns then aborts. [app/src/hub/fanOut.js] (Low)
+- [x] [Review][Patch] **Per-backend `AbortController` layering reads as redundant**. Add an inline comment so a future cleanup doesn't strip it (it's load-bearing for "one slow peer doesn't kill the others"). [app/src/hub/fanOut.js] (Nit)
+
+#### Deferred (scope / pre-existing)
+- **`_warnedTimeoutBackends` never resets** (potential leak; suppresses second-degradation warns). LRU/reset belongs with the §5 observability story. Defer.
+- **No Vitest unit tests** for the pure modules. Same deferral as P1 §7.1; project doesn't ship a unit-test runner. Track for the eventual runner addition.
+- **federationHealth stub doesn't emit "absent" warning**. Spec scenario lives with the real impl in `add-federation-health-exposition`. Defer.
+- **`fetchMeta` strips unknown fields at the registry boundary** (forward-compat fragility). Real fix is to whitelist or pass-through; flag for §5 if it grows new fields.
+
+### Dismissed
+- Blind: bbox edge-touch counts. Intentional — matches OL viewport semantics.
+- Edge: tests/helpers.js doesn't mock the new completeness fields. Existing tests don't assert on them; will be added when §5 wires the macro view.
+- Edge: `signal?.removeEventListener` in finally with `once: true` listeners. Verified self-correcting.
+- Auditor: `playgroundCount` / `completeness` not strictly required by any §1 spec scenario — they are inputs to §4/§5. Foundation work is justified by the proposal's "What Changes" list.
 
 ## 3. Hub — zoom-tier orchestrator
 
-- [ ] 3.1 Replace the existing "fetch all playgrounds from every backend" logic in `HubApp.svelte` with a moveend-driven orchestrator mirroring P1's standalone pattern but using `fanOut`
-- [ ] 3.2 Three tiers (cluster / centroid / polygon) map to `fetchPlaygroundClusters`, `fetchPlaygroundCentroids`, `fetchPlaygroundsBbox` fanned-out across the selected backends
-- [ ] 3.3 Below `clusterMaxZoom` (zoom 0–5), the orchestrator dispatches nothing — the macro view renders from the cached `backendsStore` only
-- [ ] 3.4 On tier transition, abort the previous fan-out before kicking off the new tier's
-- [ ] 3.5 Expose hub-tier bookkeeping via a `hubLoadingStore` so the instance pill can show partial-loaded state (e.g. "3/5 regions loaded")
+- [x] 3.1 New `app/src/hub/hubOrchestrator.js` — moveend-driven, debounced 300 ms, mirrors P1's `tieredOrchestrator.js`. `HubApp.svelte` attaches it once the map publishes; the registry's eager `get_playgrounds` fetch is gone (registry is now metadata-only).
+- [x] 3.2 Two tiers wired (post-pivot, matching P1's two-tier client design — centroid tier dropped). `cluster` → `fanOut(fetchPlaygroundClusters, ...)`; `polygon` → `fanOut(fetchPlaygroundsBbox, ...)`. Centroid RPC stays server-shipped for future federation reuse.
+- [x] 3.3 New `'macro'` tier — added new `macroMaxZoom` config (default 5). At `zoom ≤ macroMaxZoom` the orchestrator sets `activeTierStore = 'macro'`, clears feature sources, and fires no fan-out; the actual macro-view rendering lives in §5 and reads `backendsStore` directly.
+- [x] 3.4 Each `orchestrate()` call aborts the prior fan-out's `AbortController` before constructing a new one; `fanOut` then propagates abort to every per-backend request via its inner controller.
+- [x] 3.5 New `app/src/stores/hubLoading.js` writable `{loaded, total, settling}`. Orchestrator updates per `fanOut.onResult` arrival; consumers (instance pill in §5 follow-up) can render "3/5 regions loaded" partial state.
+
+### Review Findings — §3 hub orchestrator, Pass 1 (bmad-code-review, 2026-04-25)
+
+#### High
+- [x] [Review][Patch] **Hub deeplinks hang at low zoom**. `tryRestoreFromHash` previously relied on the registry's eager `get_playgrounds` populating the polygon source; with the orchestrator-driven fetch, the polygon source stays empty at cluster + macro tiers. Restore hub-mode hydration via `fetchPlaygroundByOsmId(parsed.osmId, slugResolvedUrl)` when `parsed.slug && resolveSlugToBackendUrl` is present. Slug-less hub broadcast deeplinks remain a defer (no good way to choose a backend). [app/src/components/AppShell.svelte tryRestoreFromHash] (High)
+- [x] [Review][Patch] **Hub Playwright tests will fail**. `stubHubRegistry` in `tests/helpers.js` doesn't route `/rpc/get_playground_clusters`, `/rpc/get_playgrounds_bbox`, or `/rpc/get_playground`; the meta fixture omits `playground_count` + completeness fields so InstancePanel pill renders "0 playgrounds". Extend the stub. [tests/helpers.js] (High)
+- [x] [Review][Patch] **Initial fit can land at macro tier on multi-backend hubs** → empty map until §5 macro-view component ships. Add fit-clamp: when ≤ 1 backend, `maxZoom: clusterMaxZoom + 1`; for multi-backend hubs that union to a low-zoom fit, fit to a maxZoom that keeps cluster tier active until §5. [app/src/hub/HubApp.svelte tryFit] (High — covers spec §6.1 ahead of schedule)
+
+#### Medium
+- [x] [Review][Patch] **Hub has no per-backend legacy fallback**. Standalone falls back to `fetchPlaygrounds(relation_id)` once per session if any tier RPC 404s; hub silently sees `entry.ok=false` per backend forever. Track per-backend `useLegacy` Set in the orchestrator; on first 404 for a backend, log once and route subsequent fan-outs for that backend through `fetchPlaygrounds`. [app/src/hub/hubOrchestrator.js] (Medium)
+- [x] [Review][Patch] **N source.clear()+addFeatures cycles per moveend**. Each backend arrival rebuilds the entire source. Switch to: clear source on the *first* arrival (so stale features clear cleanly), then `addFeatures(newFeatures)` incrementally for subsequent arrivals. [app/src/hub/hubOrchestrator.js fillClusterSource / fillPolygonSource] (Medium)
+- [x] [Review][Patch] **Spec doc out of sync**. `specs/.../spec.md` still uses `clusterMaxZoom` for the macro threshold; code introduced `macroMaxZoom` (default 5). Update spec wording to match implementation. [openspec/.../spec.md] (Medium)
+
+#### Nit
+- [x] [Review][Patch] **O(N²) selected.find per polygon arrival**. Build a `Map<url, backend>` once before the fan-out and look up by key per onResult. Trivial, future-proofs as backend count grows. [app/src/hub/hubOrchestrator.js polygon tier] (Nit)
+
+#### Deferred (out of §3 scope)
+- **`hubLoadingStore` no consumer yet** — pill still uses pre-existing `firstLoadSettled` latch. Wire in §5 follow-up when InstancePanel updates land alongside the macro-view component.
+- **`detachAttach()` race in HubApp** — only fires on map remount (HMR/dev). Latent.
+- **macroMaxZoom in standalone entrypoint as dead config** — harmless; standalone reads but never uses it.
+- **Empty `selected` (Pacific pan) renders nothing with no message** — UX cliff but acceptable for §3 scope; address with a "no backends in this region" overlay in §5 if it surfaces in usage.
+- **`accumulated` unbounded** — same exposure as P1 standalone (pre-existing).
 
 ## 4. Hub — client-side re-clustering
 
-- [ ] 4.1 Cluster tier: merged buckets from all backends' `get_playground_clusters` are fed into a Supercluster instance as weighted points; `map`/`reduce` callbacks preserve `{count, complete, partial, missing}`
-- [ ] 4.2 Centroid tier: merged centroids from all backends' `get_playground_centroids` fed into a single Supercluster index; filter attrs preserved per-feature
-- [ ] 4.3 Polygon tier: per-backend `get_playgrounds_bbox` results are concatenated into a single `VectorSource` (no re-clustering needed); each feature tagged with `_backendUrl` for selection routing
-- [ ] 4.4 On each fan-out partial arrival, the relevant Supercluster index is incrementally updated (`load` with the accumulated set) and the map repaints
+- [x] 4.1 Cluster tier in `hubOrchestrator.js` now feeds each backend's server buckets into a per-fan-out Supercluster instance as weighted points. The `map` callback projects the per-bucket counts into the cluster properties; the `reduce` callback sums `{count, complete, partial, missing, restricted}` so cross-backend merges at borders render as a single seamless ring instead of two overlapping ones. `supercluster` dep reinstated (was uninstalled during the P1 two-tier pivot).
+- [-] 4.2 ~~Centroid tier Supercluster~~ **N/A in the two-tier design** (centroid tier was dropped during the P1 pivot). The `get_playground_centroids` RPC still ships server-side for federation reuse but the client doesn't index it.
+- [x] 4.3 Polygon tier already concatenated per-backend results into a single source in §3 (`fillPolygonSource` + per-feature `_backendUrl` / `_backendSlug` stamping in `parsePolygonFeatures`).
+- [x] 4.4 On each fan-out partial arrival the cluster Supercluster index is reloaded with the accumulated set and the source is re-rendered; `load` is O(N) and well under a millisecond at cluster-tier viewport sizes.
+
+### Review Findings — §4 Supercluster, Pass 1 (bmad-code-review, 2026-04-25)
+
+#### High
+- [x] [Review][Patch] **NaN propagation in `reduce` if any bucket count field is missing**. Only `restricted` is defensively coerced to `0`. If a backend ever omits `count/complete/partial/missing`, every downstream cluster renders with `NaN` counts. Coerce all five fields in `bucketToSuperclusterPoint`. [hubOrchestrator.js bucketToSuperclusterPoint] (High)
+- [x] [Review][Patch] **Legacy backend at cluster tier downloads its entire region** via `fetchPlaygrounds(baseUrl)` and discards the result. Wasted bandwidth + invisible region with no UI signal. Skip the fetch entirely and return `[]` for legacy backends at cluster tier; the user sees a hole until they zoom past `clusterMaxZoom` (where legacy fetch is reused at the polygon tier). [hubOrchestrator.js clusterFetcherFor] (High)
+- [x] [Review][Patch] **`cluster_id` emitted on multi-backend cluster features but never consumable** — `sc` is local to `orchestrate()` and GC'd before any click handler could call `sc.getClusterExpansionZoom`. Strip `cluster_id` so the API doesn't suggest a capability that isn't there. (Re-add when a future click handler retains the index.) [hubOrchestrator.js superclusterFeatureToOl] (High)
+- [x] [Review][Patch] **Supercluster radius mismatch with OL tile model**. Default `extent: 512` doubles the effective clustering radius vs the OL 256-px tile expectation. Pass `extent: 256` so the radius corresponds to the grid the server cells were sized against. [hubOrchestrator.js Supercluster constructor] (High)
+
+#### Medium
+- [x] [Review][Patch] **Redundant `clusterSource.clear()` on first arrival**. The first-arrival latch clears, but the body's clear-and-fill on every arrival makes that latch dead. Remove the latch in the cluster branch (the polygon branch still needs it). [hubOrchestrator.js cluster onResult] (Medium)
+- [x] [Review][Patch] **Spec scenarios mention only three counts**, code sums five. Update spec scenarios to include `restricted` so they match the rendered four-segment ring (matches the P1 amendment that already shipped). [openspec/.../spec.md re-cluster + macro scenarios] (Medium)
+
+#### Deferred (out of §4 scope)
+- **`hubLoadingStore.loaded` increments on legacy-discarded responses** — masks "this backend silently degraded" in the spinner. Surface a separate `degraded` count when wiring the InstancePanel consumer in §5.
+- **Per-moveend Supercluster allocation churn** — could memoise on `(selected, accumulated hash)`. Acceptable today; revisit if rapid-pan jank is observable.
+- **Cluster click → `getClusterExpansionZoom` integration** — requires persisting `sc` across orchestrations. Architectural; defer.
+- **Antimeridian viewport** — same gap as bboxRouter; document.
+- **`p.restricted ?? 0` already defended in bucketToSuperclusterPoint** — verified self-correcting after the High #1 patch.
 
 ## 5. Hub — country-level macro view (zoom 0–5)
 
-- [ ] 5.1 Create `app/src/hub/MacroView.svelte` — renders one OL feature per backend at the backend's bbox centroid
-- [ ] 5.2 Macro-view features use the same stacked-ring renderer from P1 (`stackedRingRenderer`) with count, complete, partial, missing from the backend's cached `get_meta` completeness counts
-- [ ] 5.3 Backends with `ok: false` (from federation-status) render as outlined (stroke-only) rings with a muted colour and a small "offline" label
-- [ ] 5.4 Clicking a macro-view ring animates `view.fit` to the backend's bbox, which naturally lands in the cluster or centroid tier
-- [ ] 5.5 Hover over a macro ring shows a tooltip with region name, playground count, and data freshness (from `federation-status.json` or `get_meta.data_version`)
-- [ ] 5.6 Macro view visibility is gated on `zoom <= clusterMaxZoom`
+- [x] 5.1 Created `app/src/hub/MacroView.svelte` — subscribes to the registry's backends store and rebuilds one OL Point feature per backend at the backend's bbox centroid (EPSG:3857). Mounted as a side-effect-only child of `HubApp.svelte`; the source is owned by the hub and threaded through `AppShell` to `Map.svelte`.
+- [x] 5.2 New `app/src/hub/macroRingStyle.js` parallels the cluster renderer: same legend palette, same `radiusForCount` size scale (now exported from `clusterStyle.js`), but always renders as a ring (no count<=1 dot fallback) and uses the four-segment layout with the P1 `restricted` arc. Pre-P1 backends with `completeness: null` render as a flat gray ring (count routed into the restricted bucket — visual signal "data quality unknown" rather than a misleading healthy zero).
+- [x] 5.3 Offline backends — flagged on the feature via `_offline: !isBackendHealthy(backend)` — render with the dashed stroke-only `OFFLINE_STROKE`, a muted inner disc, the last-known count, and a small "offline" label. Currently `isBackendHealthy` is the stub from §1.5 (always true); the wiring is forward-compatible with the real `federation-status.json` signal from `add-federation-health-exposition`.
+- [x] 5.4 Macro hits in `Map.svelte`'s click handler animate `view.fit(transformExtent(bbox4326, ...))` with the standard 420 px left padding for the side panel; the orchestrator's debounced moveend then lands in the cluster or polygon tier and fan-out scopes naturally to the clicked backend.
+- [-] 5.5 ~~Hover tooltip with region name, count, data freshness~~ — **deferred to a §5 follow-up**. The feature carries `_name`, `count`, and `_offline` props ready to consume; the existing `HoverPreview` is wired for playground polygons rather than rings, so wiring the macro tooltip needs a small dedicated tooltip component. Tracked as a Known Limitation rather than a §5 blocker since the macro ring's visual already conveys count + completeness + offline state.
+- [x] 5.6 Tier-driven visibility extended in `Map.svelte::tierUnsubscribe` — `macroLayer.setVisible(tier === 'macro')`. The orchestrator already publishes `'macro'` for `zoom ≤ macroMaxZoom` (separate config knob from `clusterMaxZoom`, see §3.3).
 
 ## 6. Hub — initial map fit clamp
 
-- [ ] 6.1 When only one backend is registered, clamp the initial `view.fit` to `maxZoom: clusterMaxZoom + 1` or higher (so single-backend hubs don't land in the macro view spuriously)
-- [ ] 6.2 When multiple backends are registered, initial fit uses the union of their bboxes as today; if that union sits at or below `clusterMaxZoom`, the macro view takes over and the fit is correct by construction
+- [x] 6.1 `HubApp.svelte::tryFit` reads `get(backends).length` at fit time. With ≤ 1 backend the fit options carry `maxZoom: clusterMaxZoom + 1`, so a single small region cannot land in the macro tier. The §3 review pre-shipped a universal clamp; §5 narrowed it to single-backend so multi-backend continent overviews can use the macro view.
+- [x] 6.2 Multi-backend hubs (`backendCount > 1`) fit without `maxZoom`; the union bbox naturally lands in whatever tier it spans. With §5 macro view shipped, a low-zoom union (e.g. Germany + France) renders the macro tier with one ring per backend instead of an empty map.
 
 ## 7. Hub — filter-aware cluster badge under federation
 

--- a/openspec/changes/add-federated-playground-clustering/tasks.md
+++ b/openspec/changes/add-federated-playground-clustering/tasks.md
@@ -127,6 +127,52 @@ backends.
 - [x] 8.2 Added a tier-RPC prerequisite to `docs/ops/federated-deployment.md` Prerequisites section (data-nodes must ship the tiered API + completeness extension; older data-nodes degrade rather than fail). Updated the Step 4 verification list to point at `get_playground_clusters` / `get_playgrounds_bbox` per moveend instead of the deprecated `get_playgrounds`, and called out the macro-tier "no per-playground requests" expectation at zoom ≤ 5.
 - [x] 8.3 Embedded a mermaid `flowchart LR` in `docs/reference/federation.md` showing user moveend → tier dispatch → bboxRouter → federationHealth filter → fanOut → (Supercluster | concat) → source repaint, plus the macro-view branch that bypasses fan-out entirely.
 
+### Review Findings — §5 macro view + §6 fit clamp + §7/§8 docs, Pass 1 (bmad-code-review, 2026-04-26)
+
+#### Decision resolved → patch
+- [x] [Review][Patch] **Slug-less hub broadcast deeplinks regress at cluster tier** — *resolved 2026-04-26 to option 1*: implemented broadcast fan-out via `fetchPlaygroundByOsmId` across every registered backend when `parsed.slug` is absent and `resolveSlugToBackendUrl` is available (hub mode). First successful response wins; multiple matches log a duplicate-osm_id warning. New `getAllBackendUrls` callback wired through HubApp → AppShell. [tests/hub-deeplink.spec.js + AppShell.svelte tryRestoreFromHash + HubApp.svelte] (High)
+
+#### High
+- [x] [Review][Patch] **`stubHubRegistry` overrides `meta` instead of merging defaults**. Switched to `const meta = { ...defaults, ...(b.meta ?? {}) }` so existing hub tests' partial-meta fixtures still get `playground_count` + completeness fields. Restores `hub-pill` / `hub-smoke` / `hub-deeplink` against the new code path. [tests/helpers.js stubHubRegistry get_meta] (High)
+- [x] [Review][Patch] **Hub legacy fallback is structurally broken** — chose option (a) **fix `fetchPlaygrounds`** rather than dropping the fallback (preserves the docs-promised graceful degradation in §8). `fetchPlaygrounds(baseUrl, signal)` now honours the optional signal AND omits `relation_id` from the URL when `osmRelationId` is falsy (hub mode), so the backend's own SQL default takes over. [app/src/lib/api.js fetchPlaygrounds] (High)
+
+#### Medium
+- [x] [Review][Patch] **`tierForZoom(undefined)` falls through to polygon tier**. Added `if (!Number.isFinite(zoom)) return;` early-guard in `orchestrate()` so non-integer-resolution boot states don't dispatch a continent-wide bbox fan-out. [app/src/hub/hubOrchestrator.js orchestrate] (Medium)
+- [x] [Review][Patch] **Backends store updates don't re-orchestrate**. The `backendsStore.subscribe` callback now triggers the same debounced `orchestrate` used for moveend on every subsequent emission (initial sync emission still skipped via `initialBackendsSet` flag). A 5-min poll that reveals a bbox change re-renders the active tier within 300 ms. [app/src/hub/hubOrchestrator.js attachHubOrchestrator] (Medium)
+- [x] [Review][Patch] **Polygon first-arrival latch leaves ghost features**. Moved the `polygonFirstArrival` clear outside the `if (entry.ok)` branch so an all-error fan-out also wipes stale features. [app/src/hub/hubOrchestrator.js polygon onResult] (Medium)
+- [x] [Review][Patch] **`tryFit` latches the clamp on the first bbox emission**. Added a `backendsSettled` gate (`bs.every(b => !b.loading)`) so the clamp decision waits for every registered backend's first `get_meta` to resolve. Multi-backend hubs no longer accidentally latch the single-backend clamp when one backend returns first. [app/src/hub/HubApp.svelte tryFit] (Medium)
+- [x] [Review][Patch] **Spec text out-of-sync after §3+§4 review patches missed two scenarios**. Updated four scenarios in `spec.md`: (a) "default 11" → "default 14"; (b) macro-ring 3-segment scenario annotated to acknowledge P1 `get_meta` doesn't ship `restricted` yet, with a follow-up scenario for when it does; (c) "centroid tier" → "polygon tier" in the macro-click scenario; (d) re-cluster scenario adds `restricted` to the parity list. [openspec/.../spec.md] (Medium)
+
+#### Low
+- [-] [Review][Patch] **`hubLoadingStore.loaded` increments after abort** — *verified non-issue on closer inspection*. The `if (signal.aborted) return;` early-return at the top of each onResult callback correctly skips the increment; the original Edge Hunter finding self-corrected in the same paragraph. No code change applied. (Low — dismissed)
+- [x] [Review][Patch] **`isNotFound` regex too broad**. Tightened from `/\b404\b/` to `/failed: 404$/` to match the exact error format thrown by `api.js` fetchers (`<rpc> failed: 404`). A transient error mentioning "404" elsewhere can no longer permanently degrade a backend to the legacy fallback. [app/src/hub/hubOrchestrator.js isNotFound] (Low)
+- [x] [Review][Patch] **`get_meta` completeness fields accept null sentinel via `in` check**. Replaced `k in meta` with `Number.isFinite(meta[k])` so a backend that ships the keys with `null` or `NaN` values falls into the unknown-completeness branch instead of producing an invisible NaN ring. [app/src/hub/registry.js loadBackend] (Low)
+- [x] [Review][Patch] **`bucketToSuperclusterPoint` accepts non-finite `lon/lat`**. The cluster fan-out's bucket loop now skips buckets with non-finite coordinates and warns at most once per backend per session via `backendMalformedBucketWarned`. [app/src/hub/hubOrchestrator.js cluster onResult] (Low)
+
+#### Deferred (acknowledged in design or pre-existing)
+- **Offline-backend rendering scenarios** — `isBackendHealthy` stub means no offline ring can ever render and the bbox router can't exclude offline backends. Documented as forward-compat with `add-federation-health-exposition`; spec scenarios are unverifiable until that change ships. (Acceptance Auditor High; defer matches §1.5 deferral.)
+- **`/federation-status.json` absent fallback** — Same: scenario lives with the real impl in `add-federation-health-exposition`. (Acceptance Auditor High; matches §1+§2 deferral.)
+- **Backend recovery transition pathway** — Same dependency on health-exposition.
+- **§9 Playwright multi-backend verification** — Out of scope per PR body; ships in a follow-up PR.
+- **Backend marked legacy never recovers in-session** — Architectural; flagged in §3 review deferrals.
+- **Cluster click can't drill down via Supercluster APIs** — Documented; `sc` GC'd per orchestrate; click handler does +2-zoom which works.
+- **Initial `orchestrate()` races `tryFit`** — One wasted, immediately-aborted fan-out at boot. Bounded waste, not a correctness issue.
+- **`detachAttach()` self-unsubscribe pattern** — Works in practice (Svelte parent.onMount fires before child mounts); flagged for future cleanup.
+- **`tests/helpers.js` `get_playground` returns `features[0]` fallback** — Pattern is consistent with the pre-existing standalone helper; changing both is wider than this PR.
+- **`_warnedTimeoutBackends` never resets** — Already deferred in §1+§2 review.
+
+### Dismissed
+- Blind: `fanOut` abort error type doesn't propagate parent reason — no consumer checks `err.name === 'AbortError'`.
+- Blind: `signal.addEventListener`/`removeEventListener` asymmetry — cosmetic, no-op when listener wasn't registered.
+- Blind: `fetchPlaygroundClusters` argument order — verified `(zoom, extent, baseUrl, signal)` matches `api.js` exactly.
+- Blind: `MacroView.source.clear()` on destroy — HubApp tears down `MacroView` before `Map` in practice.
+- Blind: `AppShell` hydration `defaultBackendUrl` null edge — unchanged from pre-diff for standalone; nullish-coalesce already handles it downstream.
+- Blind: `InstancePanel` `||` vs `??` for `playgroundCount` — `0` is the boundary value and both behave the same.
+- Blind: `bboxRouter` returns input array by reference for null/non-finite viewport — no caller mutates the result.
+- Blind: HubApp `get(backends)` import not visible in diff — verified imported pre-diff.
+- Edge: MacroView subscription captures `source` prop in closure — HubApp creates `macroSource` once and never reassigns; not a real bug.
+- Auditor: slow backend warn-once not per-backend — verified `_warnedTimeoutBackends` is keyed on `b.url`, spec-compliant.
+
 ## 9. Verification
 
 - [ ] 9.1 Playwright: on a two-backend test registry, load the hub at zoom 4, assert macro rings appear for both backends with correct counts; zoom in and assert transitions to cluster tier trigger fan-out to both backends

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -184,10 +184,14 @@ export async function stubHubRegistry(page, { instanceA, instanceB }) {
   });
   await page.route('**/rpc/get_meta**', route =>
     dispatch(route, (b) => {
-      // Default to a meta payload that includes the P1 completeness fields
-      // so InstancePanel + macro view (when it ships in §5) render sensibly.
+      // Merge defaults under the supplied meta so existing tests that pass
+      // a partial meta (just `name`/`version`/`bbox`) still render the P1
+      // completeness fields + playground_count the InstancePanel pill and
+      // macro view need. Without this merge, hub-pill / hub-smoke /
+      // hub-deeplink would all see playground_count=0 and the pill
+      // would render "0 Spielplätze" instead of the asserted total.
       const features = b.playgrounds?.features ?? [];
-      const meta = b.meta ?? {
+      const defaults = {
         name: b.name ?? b.slug,
         bbox: [13.4, 52.5, 13.5, 52.6],
         playground_count: features.length,
@@ -195,6 +199,7 @@ export async function stubHubRegistry(page, { instanceA, instanceB }) {
         partial: 0,
         missing: features.length,
       };
+      const meta = { ...defaults, ...(b.meta ?? {}) };
       return {
         status: 200,
         contentType: 'application/json',

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -150,12 +150,57 @@ export async function stubHubRegistry(page, { instanceA, instanceB }) {
       body: JSON.stringify(b.playgrounds),
     }))
   );
-  await page.route('**/rpc/get_meta**', route =>
+  // Hub orchestrator (P2 §3) calls bbox-scoped + cluster RPCs per backend
+  // on every moveend. Stub them with the same per-backend playgrounds
+  // fixture so existing hub tests don't time out on unstubbed routes.
+  await page.route('**/rpc/get_playgrounds_bbox**', route =>
     dispatch(route, (b) => ({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(b.meta ?? null),
+      body: JSON.stringify(b.playgrounds),
     }))
+  );
+  await page.route('**/rpc/get_playground_clusters**', route =>
+    dispatch(route, (_b) => ({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]), // no cluster buckets — keeps cluster tier rendering empty for hub tests that exercise polygon tier
+    }))
+  );
+  await page.route('**/rpc/get_playground?**', route => {
+    // Single-playground hydration: match the requested osm_id against the
+    // backend's fixture.
+    const url = new URL(route.request().url());
+    const wantedId = Number(url.searchParams.get('osm_id'));
+    return dispatch(route, (b) => {
+      const features = b.playgrounds?.features ?? [];
+      const match = features.find(f => f.properties?.osm_id === wantedId) ?? features[0] ?? null;
+      return {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(match),
+      };
+    });
+  });
+  await page.route('**/rpc/get_meta**', route =>
+    dispatch(route, (b) => {
+      // Default to a meta payload that includes the P1 completeness fields
+      // so InstancePanel + macro view (when it ships in §5) render sensibly.
+      const features = b.playgrounds?.features ?? [];
+      const meta = b.meta ?? {
+        name: b.name ?? b.slug,
+        bbox: [13.4, 52.5, 13.5, 52.6],
+        playground_count: features.length,
+        complete: 0,
+        partial: 0,
+        missing: features.length,
+      };
+      return {
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(meta),
+      };
+    })
   );
   await page.route('**/rpc/get_equipment**', route =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ type: 'FeatureCollection', features: [] }) })


### PR DESCRIPTION
## Summary

Hub mode now drives per-tier RPC fan-out across registered backends with bbox-scoped routing, client-side cross-backend re-clustering, and a country-level macro view. Implements §1–§8 of `add-federated-playground-clustering`; §9 (Playwright multi-backend verification) ships as a follow-up PR. Closes part of #285.

- **§1 bbox routing** — `bboxRouter.selectBackends` filters fan-out targets by viewport ∩ each backend's `get_meta` bbox (refreshed on the existing 5-min registry poll).
- **§2 fan-out** — `fanOut({ fetcher, backends, signal, onResult })` runs per-backend in parallel with one `AbortController` per fan-out, single warn-then-abort 5 s timer per backend, and one-time timeout warnings.
- **§3 orchestrator** — moveend-driven, debounced 300 ms, three tiers (`macro` / `cluster` / `polygon`) plus per-backend legacy fallback when a tier RPC 404s.
- **§4 re-cluster** — Supercluster instance per fan-out indexes accumulated per-backend buckets and emits seamless cross-border rings; `extent: 256` matches the OL tile model.
- **§5 macro view** — new `MacroView.svelte` syncs backends → vector source as Point features at each backend's bbox centroid; new `macroRingStyle.js` renders the same legend palette as cluster rings (always as a ring) plus a dashed offline variant. Pre-P1 backends with `completeness: null` route into the restricted segment ("data quality unknown").
- **§6 fit clamp** — single-backend hubs clamp to `maxZoom: clusterMaxZoom + 1`; multi-backend hubs accept the union bbox so the macro view legitimately renders the continent overview.
- **§7 filter behaviour** — verified polygon-tier filter rendering inherits from standalone unchanged; centroid-tier badge is moot post-pivot; cluster-tier badge stays absent (will sum via Supercluster's reduce when P1's deferred badge work ships).
- **§8 docs** — federation.md "Scale and clustering" section + mermaid architecture diagram + Federation endpoints table updated. federated-deployment.md gains the tier-RPC prerequisite + Step 4 verification list points at the tier RPCs.

Spec strict-valid (`openspec validate add-federated-playground-clustering --strict`). Build green. Live-browser tested locally for cluster/polygon/macro tier transitions on the two-backend dev compose.

## Test plan

- [ ] CI: `make build` green
- [ ] CI: existing Playwright suite green (no behavioural regression on hub deeplink, instance pill, polygon-tier rendering)
- [ ] Local: hub mode at zoom 3 renders one ring per backend with correct counts; clicking a ring fits to backend bbox and lands in cluster/polygon tier
- [ ] Local: pan across the Fulda↔Neuhof border at cluster tier — clusters merge seamlessly with summed counts
- [ ] Local: stop one backend mid-session — surviving backend(s) still render; stopped backend logs a one-time timeout warning
- [ ] Local: deeplink hash (`#fulda/W123…`) resolves correctly from a cold load at low zoom

## Follow-ups (out of scope for this PR)

- §9 Playwright multi-backend verification (own PR — heavier than the surrounding sections, deserves its own review pass)
- Macro hover tooltip (deferred §5.5; the rings already convey count + completeness + offline)
- `hubLoadingStore` consumer wiring on the instance pill (deferred §3.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)