### PR TITLE
fix(hub): TDZ + broadcast deeplink hotfix for #287

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -88,13 +88,24 @@
   export let resolveSlugToBackendUrl = null;
 
   /**
-   * Hub-only "list every registered backend URL" accessor. Used by the
-   * slug-less deeplink path to broadcast `fetchPlaygroundByOsmId` across
-   * every backend; the first match wins, duplicates log a warning.
+   * Hub-only "list every registered backend" accessor returning
+   * `[{ url, slug }, ...]`. The slug is preserved through the broadcast
+   * hydration so a slug-less hash can still rewrite to its canonical
+   * `#<slug>/W<id>` form once the matching backend is identified.
    * Standalone passes `null`.
-   * @type {(() => string[]) | null}
+   * @type {(() => Array<{url: string, slug: string|null}>) | null}
    */
   export let getAllBackendUrls = null;
+
+  /**
+   * Hub-only registration: AppShell calls this with a callback to be invoked
+   * on every backends-store update. Used to re-trigger `tryRestoreFromHash`
+   * when a slug becomes resolvable (post-registry-load) or backends arrive
+   * after the initial source-change retry has stalled. Returns an unsubscribe.
+   * Standalone passes `null` and the source-change trigger alone is enough.
+   * @type {((cb: () => void) => () => void) | null}
+   */
+  export let onBackendsUpdate = null;
 
   // ── URL hash restore ──────────────────────────────────────────────────────
   //
@@ -171,13 +182,13 @@
     // Hub + slug-less broadcast — handled separately because it's the
     // only path that fans out across multiple backends in parallel.
     if (!parsed.slug && resolveSlugToBackendUrl && getAllBackendUrls) {
-      const urls = getAllBackendUrls();
-      if (urls.length === 0) return; // backends still loading — retry on next change
+      const targets = getAllBackendUrls();
+      if (targets.length === 0) return; // backends still loading — retry on next change
       hydrating = true;
       try {
-        const settled = await Promise.all(urls.map(url =>
+        const settled = await Promise.all(targets.map(({ url, slug }) =>
           fetchPlaygroundByOsmId(parsed.osmId, url)
-            .then(feat => feat ? { feat, url } : null)
+            .then(feat => feat ? { feat, url, slug } : null)
             .catch(() => null),
         ));
         const matches = settled.filter(Boolean);
@@ -185,19 +196,25 @@
           console.warn(`[deeplink] osm_id ${parsed.osmId} matched ${matches.length} backends — selecting the first`);
         }
         if (matches.length > 0) {
-          const { feat, url } = matches[0];
+          const { feat, url, slug } = matches[0];
           const olFeatures = geojsonFormat.readFeatures(
             { type: 'FeatureCollection', features: [feat] },
             { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' },
           );
-          for (const f of olFeatures) f.set('_backendUrl', url);
+          // Stamp both URL and (when present) slug — the slug is what the
+          // selection store uses to rewrite the hash from `#W<id>` to the
+          // canonical `#<slug>/W<id>` form on broadcast hits.
+          for (const f of olFeatures) {
+            f.set('_backendUrl', url);
+            if (slug) f.set('_backendSlug', slug);
+          }
           playgroundSource.addFeatures(olFeatures);
           // The standard match path inside `playgroundSource.on('change')`
           // will pick up the freshly-added features and complete the
           // selection + fit on the next tick.
         } else if (!warnedHydrationFailed) {
           warnedHydrationFailed = true;
-          console.warn(`[deeplink] no playground found for osm_id ${parsed.osmId} across ${urls.length} backend(s)`);
+          console.warn(`[deeplink] no playground found for osm_id ${parsed.osmId} across ${targets.length} backend(s)`);
           hashRestored = true;
         }
       } catch (err) {
@@ -265,7 +282,16 @@
     tryRestoreFromHash();
     // Otherwise wait for the source to populate.
     playgroundSource.on('change', tryRestoreFromHash);
-    return () => playgroundSource.un('change', tryRestoreFromHash);
+    // Hub-mode also retries on every backends-store update — covers the
+    // case where the initial tryRestoreFromHash runs before the registry
+    // has loaded (slug not yet resolvable, or `getAllBackendUrls` returns
+    // []), and the polygon source never changes at cluster tier so the
+    // source-change retry alone never fires.
+    const detachBackends = onBackendsUpdate?.(tryRestoreFromHash);
+    return () => {
+      playgroundSource.un('change', tryRestoreFromHash);
+      detachBackends?.();
+    };
   });
 
   let dataModalOpen = false;

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -44,8 +44,19 @@
 
   // Sync accessor for the slug-less broadcast deeplink path. AppShell fans
   // `fetchPlaygroundByOsmId` across these URLs in parallel; first hit wins.
+  // Also returns each backend's slug so the broadcast result can stamp
+  // `_backendSlug` on the hydrated feature — preserves the
+  // `#W<id>` → `#<slug>/W<id>` URL canonicalisation.
   function getAllBackendUrls() {
-    return get(backends).map(b => b.url);
+    return get(backends).map(b => ({ url: b.url, slug: b.slug ?? null }));
+  }
+
+  // Hub-only retry hook for AppShell.tryRestoreFromHash. The deeplink
+  // restore needs to re-run when the registry settles (slug becomes
+  // resolvable, broadcast URLs become available) — the polygon source
+  // never changes at cluster tier so the source-change retry isn't enough.
+  function subscribeBackendsForHashRetry(cb) {
+    return backends.subscribe(cb);
   }
 
   // Initial region fit: once the map is ready, every registered backend has
@@ -66,6 +77,7 @@
   let detachMap = null;
   let detachBbox = null;
   let detachBackends = null;
+  let detachMapAttach = null;
 
   function tryFit() {
     if (fitDone || !latestMap || !latestBbox || !backendsSettled) return;
@@ -108,7 +120,15 @@
     // fans out per-tier RPCs across registered backends on every (debounced)
     // moveend, populates clusterSource / polygonSource, and writes the
     // active tier to activeTierStore for layer-visibility toggling.
-    const detachAttach = mapStore.subscribe(map => {
+    //
+    // Map.svelte's onMount fires before HubApp's (children before parent in
+    // Svelte's lifecycle), so by the time we subscribe here, mapStore
+    // already has a value and the callback fires SYNCHRONOUSLY. That makes
+    // any self-unsubscribe pattern (`const detachAttach = ...; detachAttach()`)
+    // hit a TDZ on the const inside its own first invocation. We instead
+    // hold the unsubscribe externally and detach via onDestroy / once the
+    // attachment has run.
+    detachMapAttach = mapStore.subscribe(map => {
       if (!map || detachOrchestrator) return;
       detachOrchestrator = attachHubOrchestrator({
         map,
@@ -116,7 +136,9 @@
         clusterSource,
         polygonSource,
       });
-      detachAttach();
+      // Detach asynchronously so we're not unsubscribing while still inside
+      // svelte's subscriber dispatch loop.
+      queueMicrotask(() => { detachMapAttach?.(); detachMapAttach = null; });
     });
   });
 
@@ -124,6 +146,7 @@
     detachMap?.();
     detachBbox?.();
     detachBackends?.();
+    detachMapAttach?.();
     detachOrchestrator?.();
   });
 </script>
@@ -138,6 +161,7 @@
   nearestFetcher={fetchNearestAcrossBackends}
   {resolveSlugToBackendUrl}
   {getAllBackendUrls}
+  onBackendsUpdate={subscribeBackendsForHashRetry}
   {dataContribLinks}
 >
   {#snippet instancePanel()}

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -81,6 +81,13 @@ export function attachHubOrchestrator({
   // [NaN, NaN] (projects to ~0,0) or trip Supercluster's KDBush; we drop
   // those buckets and warn at most once per backend per session.
   const backendMalformedBucketWarned = new Set();
+  // The debounced orchestrator is referenced from the backends-subscribe
+  // callback below as well as the moveend handler below. Declare early so
+  // both references resolve out of TDZ regardless of how Svelte schedules
+  // the synchronous subscribe firings — see the §5 review for the original
+  // crash this avoids.
+  const debounced = debounce(orchestrate, 300);
+
   // Skip the very first subscribe-firing — the synchronous initial value is
   // the registry's empty bootstrap, and the first real load triggers the
   // immediate `orchestrate()` call at the bottom of this function. After
@@ -95,8 +102,7 @@ export function attachHubOrchestrator({
     }
     // Backends changed (registry poll or registry mutation) — re-orchestrate
     // on the same debounce as moveend so a flurry of poll-driven updates
-    // collapses to one fan-out. `debounced` is defined below; safe to call
-    // because the subscribe callback is async w.r.t. attach time.
+    // collapses to one fan-out.
     debounced();
   });
 
@@ -289,7 +295,6 @@ export function attachHubOrchestrator({
     }
   }
 
-  const debounced = debounce(orchestrate, 300);
   map.on('moveend', debounced);
   // Initial dispatch runs immediately (not debounced) so first paint
   // doesn't wait on a moveend.

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -169,12 +169,15 @@ export async function stubHubRegistry(page, { instanceA, instanceB }) {
   );
   await page.route('**/rpc/get_playground?**', route => {
     // Single-playground hydration: match the requested osm_id against the
-    // backend's fixture.
+    // backend's fixture. Returns `null` on no match — production behaviour;
+    // a `features[0]` fallback would mask broadcast deeplink correctness
+    // (the slug-less broadcast counts each backend's response as a
+    // potential match).
     const url = new URL(route.request().url());
     const wantedId = Number(url.searchParams.get('osm_id'));
     return dispatch(route, (b) => {
       const features = b.playgrounds?.features ?? [];
-      const match = features.find(f => f.properties?.osm_id === wantedId) ?? features[0] ?? null;
+      const match = features.find(f => f.properties?.osm_id === wantedId) ?? null;
       return {
         status: 200,
         contentType: 'application/json',


### PR DESCRIPTION
## Summary

PR #287 (federated playground clustering) merged with three regressions caught only by the local Playwright run. Main is currently red on hub tests. This restores it.

The fixes ride on commit `2af5fde` from the original PR branch — that commit was authored before merge but pushed too late to land in #287.

- **TDZ in HubApp's `mapStore` self-unsubscribe pattern**. Map.svelte's `onMount` fires before HubApp's, so when `const detachAttach = mapStore.subscribe(...)` runs, the store already has a value and the callback fires synchronously while the const is still in TDZ. Held the unsubscribe in an outer `let detachMapAttach`, detach via `queueMicrotask` + `onDestroy`. (Originally B16 in the bmad review; dismissed as "works in practice" — wasn't.)

- **TDZ in hubOrchestrator's backends-store re-orchestrate hook**. The `debounced` const referenced from inside the subscribe callback was declared after the subscribe; moved declaration above.

- **AppShell hash-restore needed to retry on backends-store updates**, not just on polygon-source change. At cluster tier the polygon source never changes, so a slug that wasn't yet resolvable at initial mount stayed unresolvable forever. New optional `onBackendsUpdate(cb)` prop wired from HubApp via `subscribeBackendsForHashRetry`.

- **Slug-less hub broadcast deeplink** now stamps both `_backendUrl` AND `_backendSlug` on the hydrated feature so the URL canonicalises from `#W<id>` to `#<slug>/W<id>`. `getAllBackendUrls` accordingly returns `[{url, slug}]` instead of bare URLs.

- **`tests/helpers.js` `get_playground` stub** now returns `null` on no match (matches production); the `features[0]` fallback was masking broadcast correctness — the slug-less broadcast counts each backend's response as a potential match, so the fallback produced spurious "matched 2 backends" warnings and wrong feature selection.

## Test plan

- [x] Full Playwright suite green locally (24/24)
- [ ] CI: `make build` green
- [ ] CI: full Playwright suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)