### PR TITLE
feat(hub): import timestamps + osm_id dedup for overlapping backends

### DIFF
--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -9,6 +9,7 @@
 
   import { createRegistry } from './registry.js';
   import { mapStore } from '../stores/map.js';
+  import { activeTierStore } from '../stores/tier.js';
 
   // Generic OSM wiki link for the contribution modal (hub is region-agnostic).
   const HUB_WIKI_URL = 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
@@ -51,6 +52,10 @@
   }
 
   onMount(() => {
+    // Hub mode loads all polygons directly — no tier orchestrator runs here.
+    // Keep the polygon layer visible until a proper hub orchestrator lands.
+    activeTierStore.set('polygon');
+
     let latestMap = null;
     let latestBbox = null;
     detachMap = mapStore.subscribe(m => { latestMap = m; tryFit(latestMap, latestBbox); });

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -11,6 +11,18 @@
 
   let drawerEl;
 
+  function relativeTime(iso) {
+    if (!iso) return null;
+    const diff = Date.now() - new Date(iso).getTime();
+    const mins  = Math.round(diff / 60_000);
+    const hours = Math.round(diff / 3_600_000);
+    const days  = Math.round(diff / 86_400_000);
+    if (mins  <  2) return $_('hub.timeJustNow');
+    if (mins  < 60) return $_('hub.timeMinutesAgo', { values: { n: mins  } });
+    if (hours < 24) return $_('hub.timeHoursAgo',   { values: { n: hours } });
+    return $_('hub.timeDaysAgo', { values: { n: days } });
+  }
+
   // Focus trap: keep keyboard focus inside the drawer while it's open. The
   // pill's own ESC handling closes the drawer — here we only trap Tab.
   function handleKeydown(e) {
@@ -87,6 +99,22 @@
             <div class="instance-status text-muted">
               <i class="bi bi-geo-alt-fill me-1"></i>
               {$_('hub.playgroundCount', { values: { count: b.featureCount } })}
+            </div>
+            <div class="instance-timestamps">
+              <span class="timestamp-label">{$_('hub.importedAt')}:</span>
+              {#if b.importedAt}
+                <span title={b.importedAt}>{relativeTime(b.importedAt)}</span>
+              {:else}
+                <span class="text-muted">{$_('hub.timestampUnknown')}</span>
+              {/if}
+            </div>
+            <div class="instance-timestamps">
+              <span class="timestamp-label">{$_('hub.osmDataAge')}:</span>
+              {#if b.osmDataAge}
+                <span title={b.osmDataAge}>{relativeTime(b.osmDataAge)}</span>
+              {:else}
+                <span class="text-muted">{$_('hub.timestampUnknown')}</span>
+              {/if}
             </div>
           {/if}
         </li>
@@ -200,5 +228,16 @@
 
   .instance-status {
     font-size: 0.75rem;
+  }
+
+  .instance-timestamps {
+    font-size: 0.72rem;
+    color: #6b7280;
+    margin-top: 0.1rem;
+  }
+
+  .timestamp-label {
+    color: #9ca3af;
+    margin-right: 0.2rem;
   }
 </style>

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -30,6 +30,9 @@ const NEAREST_MAX_DISTANCE_M = 25_000;
  *   version: string | null,
  *   region: string | null,
  *   bbox: [minLon, minLat, maxLon, maxLat] | null,
+ *   importedAt: string | null,   // ISO timestamp of last import run
+ *   osmDataAge: string | null,   // ISO timestamp of OSM extract replication
+ *   relationId: number | null,
  * }
  */
 
@@ -68,9 +71,12 @@ export function createRegistry(vectorSource) {
         ]);
 
         if (meta) {
-          backend.version = meta.version ?? null;
-          backend.region  = meta.name    ?? null;
-          backend.bbox    = Array.isArray(meta.bbox) && meta.bbox.length === 4 ? meta.bbox : null;
+          backend.version    = meta.version     ?? null;
+          backend.region     = meta.name        ?? null;
+          backend.bbox       = Array.isArray(meta.bbox) && meta.bbox.length === 4 ? meta.bbox : null;
+          backend.importedAt = meta.imported_at  ?? null;
+          backend.osmDataAge = meta.osm_data_age ?? null;
+          backend.relationId = meta.relation_id  ?? null;
           if (!backend.name && backend.region) backend.name = backend.region;
         }
 
@@ -80,14 +86,38 @@ export function createRegistry(vectorSource) {
           featureProjection: 'EPSG:3857',
         });
         features.forEach(f => {
-          f.set('_backendUrl', backend.url);
+          f.set('_backendUrl',  backend.url);
+          f.set('_relationId',  backend.relationId);
           if (backend.slug) f.set('_backendSlug', backend.slug);
         });
 
-        // Atomic swap: remove stale then add new in the same JS turn
+        // Atomic swap: remove stale then add new in the same JS turn.
+        // Dedup by osm_id: keep the feature whose backend has the newer
+        // osm_data_age; null osm_data_age is treated as oldest.
         const stale = vectorSource.getFeatures().filter(f => f.get('_backendUrl') === backend.url);
         if (stale.length) vectorSource.removeFeatures(stale);
-        vectorSource.addFeatures(features);
+
+        const toAdd = [];
+        for (const feature of features) {
+          const osmId = feature.get('osm_id');
+          const existing = osmId != null
+            ? vectorSource.getFeatures().find(f => f.get('osm_id') === osmId)
+            : null;
+          if (existing) {
+            const existingAge = existing.get('_backendUrl')
+              ? backends.find(b => b.url === existing.get('_backendUrl'))?.osmDataAge ?? null
+              : null;
+            const incomingAge = backend.osmDataAge ?? null;
+            if (incomingAge && (!existingAge || incomingAge > existingAge)) {
+              console.debug(`[hub] dedup: replacing ${existing.get('_backendUrl')} with ${backend.url} for osm_id ${osmId} (${backend.url} is fresher)`);
+              vectorSource.removeFeature(existing);
+              toAdd.push(feature);
+            }
+          } else {
+            toAdd.push(feature);
+          }
+        }
+        vectorSource.addFeatures(toAdd);
 
         backend.featureCount = features.length;
         backend.loading      = false;
@@ -119,6 +149,9 @@ export function createRegistry(vectorSource) {
           version:      null,
           region:       null,
           bbox:         null,
+          importedAt:   null,
+          osmDataAge:   null,
+          relationId:   null,
         }));
         notify();
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -31,3 +31,12 @@ END
 $$;
 
 GRANT USAGE ON SCHEMA api TO web_anon;
+
+-- Singleton table to persist importer run metadata across container restarts.
+-- Written by import.sh after each successful osm2pgsql run; read by get_meta().
+CREATE TABLE IF NOT EXISTS api.meta (
+  id            int PRIMARY KEY CHECK (id = 1),
+  imported_at   TIMESTAMPTZ,
+  osm_data_age  TIMESTAMPTZ
+);
+GRANT SELECT ON api.meta TO web_anon;

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -97,3 +97,4 @@ The scale-line sits just below the pill in the same bottom-left corner. All othe
 - [API reference](api.md) — request/response shapes for the tiered playground RPCs (`get_playground_clusters`, `get_playgrounds_bbox`, `get_playground`, `get_meta`).
 - [Federated Deployment](../ops/federated-deployment.md) — step-by-step walkthrough for standing up one Hub + N data-nodes.
 - [`registry.json` reference](registry-json.md) — registry schema, slug rules, derived aggregate behaviours.
+- [Hub Data Overlap and Feature Dedup](hub-data-overlap.md) — how the hub resolves duplicate playgrounds when backends cover overlapping regions.

--- a/docs/reference/hub-data-overlap.md
+++ b/docs/reference/hub-data-overlap.md
@@ -1,0 +1,76 @@
+# Hub Data Overlap and Feature Dedup
+
+In hub mode multiple regional backends are merged onto a single map. When two backends cover overlapping geographic areas — for example a state-wide Hessen backend and a city-specific Fulda backend that sits inside Hessen — the same OSM playground can appear in both `get_playgrounds` responses. This page explains how the hub detects and resolves those collisions.
+
+## Why collisions happen
+
+The hub fetches all playgrounds from every registered backend independently and merges them into a shared OpenLayers `VectorSource`. Two backends legitimately overlap when one covers a large administrative area and another covers a subdivision of it. This is a documented, supported deployment topology, not a misconfiguration.
+
+Without dedup, each playground in the overlap zone would have two polygon features stacked on top of each other. OpenLayers picks the topmost feature on click, making click behaviour and deep-link restore non-deterministic.
+
+## Dedup algorithm
+
+Dedup runs in `registry.js` `loadBackend()` at VectorSource insertion time — not at fetch time and not server-side. The key is `osm_id` (the raw OpenStreetMap way or relation ID).
+
+For each incoming feature:
+
+1. **Look up existing feature** by `osm_id` in the VectorSource.
+2. **If no existing feature** → add normally (no dedup needed).
+3. **If existing feature found** → compare `osm_data_age` values:
+
+| Incoming `osm_data_age` | Existing `osm_data_age` | Result |
+|---|---|---|
+| newer (later ISO timestamp) | any | Replace existing with incoming |
+| older or equal | any non-null | Keep existing, discard incoming |
+| `null` | any | Keep existing, discard incoming |
+| non-null | `null` | Replace existing with incoming |
+| `null` | `null` | Keep existing (first-loader wins) |
+
+The tie-breaking rule — first-loader wins when both ages are null — is intentional. In the expected topology the broader backend (Hessen) loads before the narrower one (Fulda). When both import from the same Geofabrik weekly release the Hessen copy lands first and is not disturbed by the Fulda copy. Operators who want Fulda to always win should either ensure Fulda has a genuine replication timestamp or register Fulda before Hessen in `registry.json`.
+
+When a replacement happens, a `[hub] dedup` line is logged at `console.debug` level:
+
+```
+[hub] dedup: replacing https://hessen.example.com/api with https://fulda.example.com/api for osm_id 12345 (fulda is fresher)
+```
+
+## Timestamp fields
+
+Each backend exposes two timestamps via `get_meta()`:
+
+| Field | Meaning | Null when |
+|---|---|---|
+| `imported_at` | Wall-clock time of the most recent import run | Never null after the first import |
+| `osm_data_age` | `osmosis_replication_timestamp` from the PBF header | The source PBF has no replication metadata |
+
+### Geofabrik extracts
+
+Geofabrik `.osm.pbf` files (e.g. `hessen-latest.osm.pbf`) do **not** embed an `osmosis_replication_timestamp`. The importer logs a warning and stores `NULL` for `osm_data_age`. This is expected and harmless: the dedup algorithm degrades gracefully to first-loader wins, and the InstancePanel shows "unknown" for OSM data age.
+
+Replication timestamps are present in PBFs produced by the daily/minutely Osmosis replication chain (e.g. planet diff files). If you control your PBF pipeline you can inject a timestamp to enable freshness-based dedup.
+
+### InstancePanel display
+
+Both timestamps appear in the InstancePanel backend drawer as relative times ("3 hours ago"). Hovering over a timestamp shows the full ISO 8601 string as a tooltip. When `osm_data_age` is null the field shows "unknown".
+
+`imported_at` tells you when the operator last ran the importer. `osm_data_age` tells you how old the underlying OSM extract is. A backend can have a very recent `imported_at` but an old `osm_data_age` if the operator re-ran the importer without downloading a fresh PBF — this is why both fields are exposed.
+
+## Operational guidance
+
+**Standard two-backend setup (one large, one small region):**
+
+Register the broader backend first in `registry.json`. It loads first and populates the VectorSource. The narrower backend loads second; its features that share `osm_id` with the broader backend are dropped (both have null `osm_data_age`). Non-overlapping features from the narrower backend are always added. This is the correct and expected behaviour.
+
+**To have the narrower backend win for its coverage area:**
+
+Ensure the narrower backend's PBF carries a replication timestamp (i.e. is newer than the broader backend's PBF). When `osm_data_age` differs the fresher backend always wins, regardless of load order.
+
+**Diagnosing a missing-playground report:**
+
+Check the browser console for `[hub] dedup:` lines. If a playground that should appear from backend B is being suppressed by backend A, check whether A's `osm_data_age` is newer or null and B's is null. The InstancePanel timestamps help here.
+
+## See also
+
+- [`registry.json` reference](registry-json.md) — full registry schema, slug rules, and aggregated bounding-box behaviour.
+- [Federation](federation.md) — hub setup, local development topology, and federation endpoints.
+- [API reference](api.md) — `get_meta()` response shape including `imported_at` and `osm_data_age`.

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -885,6 +885,16 @@ GRANT EXECUTE ON FUNCTION api.get_trees(float8, float8, float8, float8) TO web_a
 --    Returns instance metadata for federation (Hub discovery).
 --    Includes the OSM relation name, playground count, and bounding box.
 -- =========================================================================
+
+-- Singleton table persisting importer timestamps. Created here (idempotent)
+-- so it exists on upgraded stacks where db/init.sql has already run.
+CREATE TABLE IF NOT EXISTS api.meta (
+  id            int PRIMARY KEY CHECK (id = 1),
+  imported_at   TIMESTAMPTZ,
+  osm_data_age  TIMESTAMPTZ
+);
+GRANT SELECT ON api.meta TO web_anon;
+
 DROP FUNCTION IF EXISTS api.get_meta(bigint);
 
 CREATE OR REPLACE FUNCTION api.get_meta(relation_id bigint DEFAULT ${OSM_RELATION_ID})
@@ -929,7 +939,9 @@ AS $$
                            ST_YMin((SELECT geom FROM bbox)),
                            ST_XMax((SELECT geom FROM bbox)),
                            ST_YMax((SELECT geom FROM bbox))
-                         ]
+                         ],
+    'imported_at',       (SELECT imported_at  FROM api.meta WHERE id = 1),
+    'osm_data_age',      (SELECT osm_data_age FROM api.meta WHERE id = 1)
   );
 $$;
 

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -186,11 +186,37 @@ osm2pgsql \
 echo "[importer] osm2pgsql finished."
 
 # --------------------------------------------------------------------------- #
+# Record import timestamps (extracted now, written after api.sql creates table)
+# --------------------------------------------------------------------------- #
+OSM_DATA_AGE=""
+if osmium_output=$(osmium fileinfo --json "$IMPORT_PBF" 2>/dev/null); then
+    OSM_DATA_AGE=$(echo "$osmium_output" | jq -r '.header.option.osmosis_replication_timestamp // empty' 2>/dev/null || true)
+    if [ -z "$OSM_DATA_AGE" ]; then
+        echo "[importer] WARNING: osmosis_replication_timestamp not present in PBF header — osm_data_age will be NULL"
+    fi
+else
+    echo "[importer] WARNING: osmium fileinfo failed — osm_data_age will be NULL"
+fi
+
+# --------------------------------------------------------------------------- #
 # Create PostgREST API schema (views / functions)
 # --------------------------------------------------------------------------- #
 echo "[importer] Applying API schema..."
 envsubst '$OSM_RELATION_ID' < /api.sql \
     | psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+
+# --------------------------------------------------------------------------- #
+# Upsert timestamps — api.meta is guaranteed to exist after api.sql runs above
+# --------------------------------------------------------------------------- #
+# Validate timestamp format before interpolating to prevent injection
+if echo "$OSM_DATA_AGE" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'; then
+    AGE_EXPR="'${OSM_DATA_AGE}'"
+else
+    AGE_EXPR="NULL"
+fi
+psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+    -c "INSERT INTO api.meta (id, imported_at, osm_data_age) VALUES (1, now(), ${AGE_EXPR}) ON CONFLICT (id) DO UPDATE SET imported_at = EXCLUDED.imported_at, osm_data_age = EXCLUDED.osm_data_age;"
+echo "[importer] Timestamps recorded (osm_data_age=${OSM_DATA_AGE:-NULL})."
 
 # --------------------------------------------------------------------------- #
 # Notify PostgREST to reload its schema cache

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -17,7 +17,14 @@
     "hint": "Klepněte na hřiště pro zobrazení podrobností",
     "shareBtn": "Sdílet hřiště",
     "osmBtn": "Zobrazit na OpenStreetMap",
-    "closeBtn": "Zavřít"
+    "closeBtn": "Zavřít",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Fotografie, název a podrobnosti k dispozici",
@@ -100,6 +107,13 @@
   },
   "modal": {
     "closeBtn": "Zavřít",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Zpět na mapu",
     "streetPhoto": "Fotografie ulice",
     "prevPhoto": "Předchozí fotografie",

--- a/locales/de.json
+++ b/locales/de.json
@@ -371,7 +371,14 @@
     "pillExpand": "Instanz-Liste öffnen",
     "pillCollapse": "Instanz-Liste schließen",
     "drawerTitle": "Verfügbare Instanzen",
-    "closeBtn": "Schließen"
+    "closeBtn": "Schließen",
+    "importedAt": "Importiert",
+    "osmDataAge": "OSM-Datenstand",
+    "timestampUnknown": "unbekannt",
+    "timeJustNow": "gerade eben",
+    "timeMinutesAgo": "vor {n} Min.",
+    "timeHoursAgo": "vor {n} Std.",
+    "timeDaysAgo": "vor {n} Tagen"
   },
   "details": {
     "sizeLabel": "Größe",

--- a/locales/en.json
+++ b/locales/en.json
@@ -371,7 +371,14 @@
     "pillExpand": "Show instance list",
     "pillCollapse": "Hide instance list",
     "drawerTitle": "Available instances",
-    "closeBtn": "Close"
+    "closeBtn": "Close",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "details": {
     "sizeLabel": "Size",

--- a/locales/es.json
+++ b/locales/es.json
@@ -17,7 +17,14 @@
     "hint": "Toca un parque para ver detalles",
     "shareBtn": "Compartir parque",
     "osmBtn": "Ver en OpenStreetMap",
-    "closeBtn": "Cerrar"
+    "closeBtn": "Cerrar",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Fotos, nombre y detalles disponibles",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Cerrar",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Volver al mapa",
     "streetPhoto": "Foto de calle",
     "prevPhoto": "Foto anterior",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -17,7 +17,14 @@
     "hint": "Appuyer sur une aire de jeux pour les détails",
     "shareBtn": "Partager",
     "osmBtn": "Voir sur OpenStreetMap",
-    "closeBtn": "Fermer"
+    "closeBtn": "Fermer",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Photos, nom & détails disponibles",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Fermer",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Retour à la carte",
     "streetPhoto": "Photo de rue",
     "prevPhoto": "Photo précédente",

--- a/locales/it.json
+++ b/locales/it.json
@@ -17,7 +17,14 @@
     "hint": "Tocca un parco giochi per i dettagli",
     "shareBtn": "Condividi parco",
     "osmBtn": "Visualizza su OpenStreetMap",
-    "closeBtn": "Chiudi"
+    "closeBtn": "Chiudi",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Foto, nome e dettagli disponibili",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Chiudi",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Torna alla mappa",
     "streetPhoto": "Foto di strada",
     "prevPhoto": "Foto precedente",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -17,7 +17,14 @@
     "hint": "遊び場をタップして詳細を表示",
     "shareBtn": "遊び場を共有",
     "osmBtn": "OpenStreetMapで表示",
-    "closeBtn": "閉じる"
+    "closeBtn": "閉じる",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "写真・名称・詳細あり",
@@ -90,6 +97,13 @@
   },
   "modal": {
     "closeBtn": "閉じる",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "地図に戻る",
     "streetPhoto": "ストリート写真",
     "prevPhoto": "前の写真",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -17,7 +17,14 @@
     "hint": "Tik op een speeltuin voor details",
     "shareBtn": "Speeltuin delen",
     "osmBtn": "Bekijk op OpenStreetMap",
-    "closeBtn": "Sluiten"
+    "closeBtn": "Sluiten",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Foto's, naam & details beschikbaar",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Sluiten",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Terug naar de kaart",
     "streetPhoto": "Straatfoto",
     "prevPhoto": "Vorige foto",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -17,7 +17,14 @@
     "hint": "Dotknij plac zabaw, aby zobaczyć szczegóły",
     "shareBtn": "Udostępnij plac zabaw",
     "osmBtn": "Zobacz na OpenStreetMap",
-    "closeBtn": "Zamknij"
+    "closeBtn": "Zamknij",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Zdjęcia, nazwa i szczegóły dostępne",
@@ -105,6 +112,13 @@
   },
   "modal": {
     "closeBtn": "Zamknij",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Wróć do mapy",
     "streetPhoto": "Zdjęcie uliczne",
     "prevPhoto": "Poprzednie zdjęcie",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -17,7 +17,14 @@
     "hint": "Toque num parque para ver detalhes",
     "shareBtn": "Partilhar parque",
     "osmBtn": "Ver no OpenStreetMap",
-    "closeBtn": "Fechar"
+    "closeBtn": "Fechar",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Fotos, nome e detalhes disponíveis",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Fechar",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Voltar ao mapa",
     "streetPhoto": "Foto de rua",
     "prevPhoto": "Foto anterior",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -17,7 +17,14 @@
     "hint": "Tryck på en lekplats för detaljer",
     "shareBtn": "Dela lekplats",
     "osmBtn": "Visa på OpenStreetMap",
-    "closeBtn": "Stäng"
+    "closeBtn": "Stäng",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Foton, namn och detaljer tillgängliga",
@@ -95,6 +102,13 @@
   },
   "modal": {
     "closeBtn": "Stäng",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Tillbaka till kartan",
     "streetPhoto": "Gatufoto",
     "prevPhoto": "Föregående foto",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -17,7 +17,14 @@
     "hint": "Натисніть на майданчик, щоб побачити деталі",
     "shareBtn": "Поділитися майданчиком",
     "osmBtn": "Переглянути на OpenStreetMap",
-    "closeBtn": "Закрити"
+    "closeBtn": "Закрити",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago"
   },
   "completeness": {
     "complete": "Фотографії, назва та деталі доступні",
@@ -105,6 +112,13 @@
   },
   "modal": {
     "closeBtn": "Закрити",
+    "importedAt": "Imported",
+    "osmDataAge": "OSM data age",
+    "timestampUnknown": "unknown",
+    "timeJustNow": "just now",
+    "timeMinutesAgo": "{n} min. ago",
+    "timeHoursAgo": "{n} hr. ago",
+    "timeDaysAgo": "{n} days ago",
     "backToMap": "Повернутися до карти",
     "streetPhoto": "Фото вулиці",
     "prevPhoto": "Попередня фотографія",

--- a/openspec/changes/add-import-timestamps-and-dedup/.openspec.yaml
+++ b/openspec/changes/add-import-timestamps-and-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/add-import-timestamps-and-dedup/design.md
+++ b/openspec/changes/add-import-timestamps-and-dedup/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The hub fetches playgrounds from every backend in `registry.json` and merges them into a single VectorSource. Backends can legitimately cover overlapping regions — a Hessen-wide backend and a Fulda-specific backend coexisting is a documented, supported topology, not an edge case. When both are present, `loadBackend()` adds features from each, resulting in duplicate polygons for playgrounds that fall inside Fulda. OpenLayers picks the topmost feature on click; the deep-link restore path already detects and logs the collision (`[deeplink] osm_id X matched 2 backends`) but takes no action.
+
+Resolving the collision requires a freshness signal on the backend side. Currently `get_meta()` returns no timestamps — the hub has no way to decide whose copy of a playground is more authoritative.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose two meaningful timestamps per backend via `get_meta()`: operator-run time (`imported_at`) and OSM data age (`osm_data_age`)
+- Eliminate duplicate features in the hub VectorSource by deduping on `osm_id`, keeping the copy with the newer `osm_data_age`
+- Surface both timestamps in InstancePanel so operators can observe data staleness without tailing logs
+- Tag `relation_id` onto features for debuggability and future routing logic
+
+**Non-Goals:**
+- Dedup in standalone mode (only one backend, no collision possible)
+- Retroactively correcting stale data already in running backends
+- Bbox-overlap warning in InstancePanel (tracked separately in #251)
+- Changing the dedup strategy for `fetchNearestAcrossBackends` (it already uses the same `osm_data_age` logic)
+
+## Decisions
+
+### D1: Two timestamps, not one
+
+A single `imported_at` timestamp misleads when a backend re-imports from a cached PBF. The operator's timestamp looks fresh while the OSM data is weeks old. `osm_data_age` (the extract's own `osmosis_replication_timestamp`, read via `osmium fileinfo --json`) is the authoritative freshness signal for dedup. `imported_at` is retained because it's a distinct and useful operational signal — operators need to know both "when did the import run?" and "how old is the data?".
+
+**Alternative considered:** Expose only `osm_data_age`. Rejected: operators would lose visibility into import cadence, which matters for diagnosing cron failures.
+
+### D2: Dedup at VectorSource insertion, not at fetch time
+
+Dedup happens in `registry.js` `loadBackend()`, at the point features are added to the VectorSource, not earlier. This keeps the fetch layer simple and stateless. `fetchNearestAcrossBackends` already performs a similar `osm_id`-keyed merge; this change applies the same logic to the main playground load path.
+
+**Alternative considered:** Dedup server-side via a hub-level aggregator. Rejected: the hub has no server tier (static files + registry), and introducing one for dedup alone is disproportionate.
+
+### D3: Newer `osm_data_age` wins, ties go to first-loaded backend
+
+When two backends report the same `osm_data_age` for a given `osm_id` (e.g. both imported from the same weekly Geofabrik release), the feature already in the VectorSource is kept. This avoids unnecessary churn and matches the expected topology where the more-specific backend (Fulda) loads after the broader one (Hessen) — the Hessen copy lands first and is only displaced if the Fulda copy is genuinely fresher.
+
+### D4: `osmium fileinfo --json`, not `osmium fileinfo` text parsing
+
+The JSON output is stable across osmium versions; the text output format has changed between releases. `jq` is already present in the image after #208 lands. If #208 hasn't landed, osmium-tool and jq must be added here independently.
+
+### D5: Singleton `meta` table, not a run-history log
+
+Only the latest timestamps are needed by the hub. A singleton `ON CONFLICT DO UPDATE` row is simpler than a log table and avoids unbounded growth. If a run-history audit log is ever needed, it is a separate concern.
+
+## Risks / Trade-offs
+
+- **`osmium fileinfo` adds ~1s to import run** → negligible compared to the osm2pgsql step; not a concern
+- **Geofabrik extracts without `osmosis_replication_timestamp`** → osmium returns `null`; the importer SHALL treat a null timestamp as "unknown" and store `NULL` in the DB; `get_meta()` returns `null`; the dedup logic falls back to keeping the first-loaded feature
+- **Dedup removes a feature the user clicked moments before the second backend loads** → backends load sequentially in `registry.js`; the VectorSource fires a `change` event; OL re-renders; the user loses the selection if they clicked the now-removed duplicate. Acceptable: this is a transient state during initial hub load and affects only overlapping backends, which are not the common case
+- **`_relationId` property name collides with a future OSM property** → prefixed with `_` to signal internal use; OSM tag names do not use leading underscores
+
+## Migration Plan
+
+1. Add `meta` table to `db/init.sql` (new table; no existing data to migrate)
+2. Update `import.sh` to write timestamps at end of run (idempotent; old runs simply leave the table empty)
+3. Deploy updated importer image — first `make import` after deploy populates the table
+4. Deploy updated app image — `get_meta()` returns the new fields; InstancePanel renders them; dedup logic activates
+5. Existing deployments with no `meta` table: PostgREST returns a 404 on `get_meta` until the importer image is updated and a run completes. Hub degrades gracefully — missing fields are treated as `null`
+
+No rollback complexity. Removing the `meta` table and reverting `import.sh` restores the previous state. Frontend gracefully handles `null` timestamps.
+
+## Open Questions
+
+- Should `osm_data_age` be displayed in InstancePanel as a human-readable relative time (e.g. "3 days ago") or an ISO timestamp? Leaning toward relative for operator UX; ISO available on hover.
+- Should the dedup log message (`[hub] dedup: keeping backend A over B for osm_id X`) be emitted at `debug` or `info` level? Leaning `debug` — it fires for every collision on every load, which would be noisy at `info` in a large hub.

--- a/openspec/changes/add-import-timestamps-and-dedup/proposal.md
+++ b/openspec/changes/add-import-timestamps-and-dedup/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+In hub mode, backends can cover overlapping regions (e.g. Fulda inside Hessen) — an explicitly supported configuration. This causes the same playground to appear twice in the VectorSource, making click behaviour undefined and deep-link restore ambiguous. The symptom is already logged (`[deeplink] osm_id X matched 2 backends`), but no fix is in place. Resolving it requires each backend to expose OSM data freshness so the hub can make a principled dedup decision.
+
+## What Changes
+
+- **Importer**: records two timestamps per successful run — `imported_at` (wall-clock of the run) and `osm_data_age` (the OSM extract's own replication timestamp, read via `osmium fileinfo --json`)
+- **DB schema**: new `meta` singleton table in `db/init.sql` to persist both timestamps across container restarts
+- **`get_meta()` RPC**: extended to return `imported_at` and `osm_data_age` alongside existing fields
+- **`registry.js`**: deduplicates features by `osm_id` at VectorSource insertion time, keeping the feature whose backend reports the newer `osm_data_age`; also tags `relation_id` onto every feature as `_relationId`
+- **InstancePanel**: surfaces `imported_at` and `osm_data_age` per backend so operators can spot stale data without tailing logs
+
+## Capabilities
+
+### New Capabilities
+
+- `import-timestamps`: Importer writes `imported_at` and `osm_data_age` to the `meta` table after each successful run; `get_meta()` exposes both fields
+- `hub-feature-dedup`: Hub deduplicates playground features by `osm_id` across backends at VectorSource insertion time, using `osm_data_age` to pick the fresher source
+
+### Modified Capabilities
+
+<!-- none — no existing spec-level requirements change -->
+
+## Impact
+
+- **`importer/Dockerfile`**: adds `osmium-tool` if #208 has not yet landed (no-op if already present)
+- **`db/init.sql`**: new `meta` table (singleton, `ON CONFLICT DO UPDATE`)
+- **`importer/import.sh`**: new step at end of run — `osmium fileinfo --json`, timestamp extraction, DB upsert
+- **`importer/api.sql`**: `get_meta()` function extended with two new fields
+- **`app/src/registry.js`**: dedup logic added to `loadBackend()`; `_relationId` property added to features
+- **`app/src/components/InstancePanel.svelte`**: new timestamp display rows
+- **No new compose services, no API endpoint changes, no frontend routing changes**

--- a/openspec/changes/add-import-timestamps-and-dedup/specs/hub-feature-dedup/spec.md
+++ b/openspec/changes/add-import-timestamps-and-dedup/specs/hub-feature-dedup/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Features deduplicated by osm_id at VectorSource insertion
+
+When `loadBackend()` adds features from a backend to the shared VectorSource, it SHALL skip any feature whose `osm_id` is already present, unless the incoming feature's backend reports a strictly newer `osm_data_age`.
+
+#### Scenario: Incoming feature is fresher
+
+- **WHEN** a feature with `osm_id` X is being added and `osm_id` X already exists in the VectorSource
+- **AND** the incoming backend's `osm_data_age` is strictly newer than the existing feature's backend's `osm_data_age`
+- **THEN** the existing feature is replaced by the incoming feature
+
+#### Scenario: Incoming feature is older or equal age
+
+- **WHEN** a feature with `osm_id` X is being added and `osm_id` X already exists in the VectorSource
+- **AND** the incoming backend's `osm_data_age` is equal to or older than the existing feature's backend's `osm_data_age`
+- **THEN** the incoming feature is discarded and the existing feature is retained unchanged
+
+#### Scenario: Incoming feature's backend has unknown data age
+
+- **WHEN** a feature with `osm_id` X is being added and the incoming backend's `osm_data_age` is `null`
+- **AND** `osm_id` X already exists in the VectorSource
+- **THEN** the incoming feature is discarded (null age is treated as oldest possible)
+
+#### Scenario: Existing feature's backend has unknown data age
+
+- **WHEN** a feature with `osm_id` X is being added and `osm_id` X already exists in the VectorSource
+- **AND** the existing feature's backend's `osm_data_age` is `null`
+- **AND** the incoming backend's `osm_data_age` is non-null
+- **THEN** the existing feature is replaced by the incoming feature
+
+#### Scenario: No existing feature for osm_id
+
+- **WHEN** a feature with `osm_id` X is being added and `osm_id` X does not yet exist in the VectorSource
+- **THEN** the feature is added normally without any dedup check
+
+---
+
+### Requirement: relation_id tagged onto features
+
+`loadBackend()` SHALL attach the `relation_id` value from `get_meta()` onto every feature it adds to the VectorSource as the property `_relationId`.
+
+#### Scenario: relation_id available from get_meta
+
+- **WHEN** a backend's `get_meta()` returns a non-null `relation_id`
+- **THEN** every feature loaded from that backend has `feature.get('_relationId')` equal to that value
+
+#### Scenario: relation_id absent from get_meta
+
+- **WHEN** a backend's `get_meta()` returns `null` or omits `relation_id`
+- **THEN** every feature loaded from that backend has `feature.get('_relationId')` equal to `null`
+
+---
+
+### Requirement: Dedup applies only in hub mode
+
+The dedup logic SHALL be active only when the app is running in hub mode. Standalone mode SHALL be unaffected.
+
+#### Scenario: Hub mode with overlapping backends
+
+- **WHEN** `appMode` is `"hub"` and two backends share playground features by `osm_id`
+- **THEN** exactly one feature per `osm_id` exists in the VectorSource after both backends have loaded
+
+#### Scenario: Standalone mode unchanged
+
+- **WHEN** `appMode` is `"standalone"`
+- **THEN** `loadBackend()` is not called and no dedup logic runs

--- a/openspec/changes/add-import-timestamps-and-dedup/specs/import-timestamps/spec.md
+++ b/openspec/changes/add-import-timestamps-and-dedup/specs/import-timestamps/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Importer records successful-run timestamp
+
+After each successful osm2pgsql run, the importer SHALL upsert `imported_at = now()` into the `meta` singleton row in the database.
+
+#### Scenario: Successful run writes imported_at
+
+- **WHEN** the importer completes osm2pgsql with exit code 0
+- **THEN** `api.meta.imported_at` is set to the current wall-clock timestamp (UTC)
+
+#### Scenario: Failed run does not update imported_at
+
+- **WHEN** the importer exits with a non-zero status or is killed mid-run
+- **THEN** `api.meta.imported_at` retains its previous value unchanged
+
+---
+
+### Requirement: Importer records OSM extract data age
+
+After each successful osm2pgsql run, the importer SHALL extract the `osmosis_replication_timestamp` from the source PBF using `osmium fileinfo --json` and store it as `osm_data_age` in the `meta` singleton row.
+
+#### Scenario: PBF carries replication timestamp
+
+- **WHEN** `osmium fileinfo --json` returns a non-null `osmosis_replication_timestamp`
+- **THEN** `api.meta.osm_data_age` is set to that timestamp (parsed as UTC)
+
+#### Scenario: PBF does not carry replication timestamp
+
+- **WHEN** `osmium fileinfo --json` returns `null` for `osmosis_replication_timestamp`
+- **THEN** `api.meta.osm_data_age` is set to `NULL`
+- **AND** the import run is NOT aborted
+
+#### Scenario: osmium fileinfo fails
+
+- **WHEN** `osmium fileinfo --json` exits with a non-zero status
+- **THEN** the importer logs a warning and continues
+- **AND** `api.meta.osm_data_age` is set to `NULL`
+
+---
+
+### Requirement: meta table is a singleton
+
+The `meta` table SHALL contain exactly one row, enforced at the schema level.
+
+#### Scenario: Singleton integrity on upsert
+
+- **WHEN** the importer upserts timestamps at end of run
+- **THEN** exactly one row exists in `api.meta` after the upsert
+
+#### Scenario: Direct second-row insertion rejected
+
+- **WHEN** any client attempts to INSERT a second row into `api.meta`
+- **THEN** the insertion fails with a constraint violation
+- **AND** the existing row is unaffected
+
+---
+
+### Requirement: get_meta() exposes both timestamps
+
+The `api.get_meta()` RPC SHALL return `imported_at` and `osm_data_age` in its response alongside existing fields.
+
+#### Scenario: Both timestamps present
+
+- **WHEN** at least one successful import run has completed
+- **THEN** `GET /api/rpc/get_meta` returns a JSON object including `imported_at` (ISO 8601 string) and `osm_data_age` (ISO 8601 string or `null`)
+
+#### Scenario: No import run yet
+
+- **WHEN** the importer has never completed a successful run
+- **THEN** `GET /api/rpc/get_meta` returns `imported_at: null` and `osm_data_age: null`
+
+---
+
+### Requirement: InstancePanel displays both timestamps
+
+The hub InstancePanel SHALL display `imported_at` and `osm_data_age` per backend so operators can observe import cadence and data freshness.
+
+#### Scenario: Both timestamps available
+
+- **WHEN** a backend's `get_meta()` returns non-null `imported_at` and `osm_data_age`
+- **THEN** the InstancePanel shows both values, with `osm_data_age` displayed as a human-readable relative time (e.g. "3 days ago") and the ISO timestamp available on hover
+
+#### Scenario: osm_data_age is null
+
+- **WHEN** a backend's `get_meta()` returns `osm_data_age: null`
+- **THEN** the InstancePanel shows "unknown" for the data age row
+- **AND** `imported_at` is still displayed if available

--- a/openspec/changes/add-import-timestamps-and-dedup/tasks.md
+++ b/openspec/changes/add-import-timestamps-and-dedup/tasks.md
@@ -1,0 +1,45 @@
+## 1. Database schema
+
+- [ ] 1.1 Add `meta` singleton table to `db/init.sql` with `imported_at TIMESTAMPTZ` and `osm_data_age TIMESTAMPTZ`; enforce singleton with a `CHECK (id = 1)` constraint and `ON CONFLICT DO UPDATE`
+- [ ] 1.2 Verify schema applies cleanly with `make db-apply` on a fresh DB
+
+## 2. Importer — Dockerfile
+
+- [ ] 2.1 Add `osmium-tool` to `importer/Dockerfile` if #208 has not yet landed (no-op if already present)
+
+## 3. Importer — import.sh
+
+- [ ] 3.1 After successful osm2pgsql, run `osmium fileinfo --json "$IMPORT_PBF"` and extract `osmosis_replication_timestamp` with `jq`
+- [ ] 3.2 Handle null or missing `osmosis_replication_timestamp`: set `OSM_DATA_AGE` to empty, log a warning, continue
+- [ ] 3.3 Handle `osmium fileinfo` failure (non-zero exit): set `OSM_DATA_AGE` to empty, log a warning, continue
+- [ ] 3.4 Upsert both timestamps into `meta` via `psql`: `INSERT INTO api.meta (id, imported_at, osm_data_age) VALUES (1, now(), '<OSM_DATA_AGE>') ON CONFLICT (id) DO UPDATE SET imported_at = EXCLUDED.imported_at, osm_data_age = EXCLUDED.osm_data_age`
+- [ ] 3.5 Confirm upsert is skipped (or a `NULL` is written) when `OSM_DATA_AGE` is empty
+
+## 4. Database API — get_meta()
+
+- [ ] 4.1 Extend `api.get_meta()` in `importer/api.sql` to `SELECT` and return `imported_at` and `osm_data_age` from `api.meta`
+- [ ] 4.2 Confirm `GET /api/rpc/get_meta` returns both fields (null before first import, populated after)
+- [ ] 4.3 Run `make db-apply` to apply changes to the running DB
+
+## 5. Frontend — registry.js
+
+- [ ] 5.1 In `loadBackend()`, read `osm_data_age` and `relation_id` from the `get_meta()` response and store per-backend
+- [ ] 5.2 Tag `_relationId` onto every feature added by `loadBackend()`
+- [ ] 5.3 Implement dedup: before adding a feature to the VectorSource, check if `osm_id` is already present; keep whichever backend has the newer `osm_data_age` (null treated as oldest)
+- [ ] 5.4 Log a debug message on each dedup replacement: `[hub] dedup: replacing backend A with B for osm_id X (B is fresher)`
+
+## 6. Frontend — InstancePanel
+
+- [ ] 6.1 Pass `imported_at` and `osm_data_age` from `get_meta()` into the InstancePanel component
+- [ ] 6.2 Display `imported_at` as a relative time (e.g. "3 hours ago") with ISO timestamp on hover
+- [ ] 6.3 Display `osm_data_age` as a relative time with ISO timestamp on hover; show "unknown" when `null`
+
+## 7. Verification
+
+- [ ] 7.1 Run `make import` and confirm `api.meta` is populated with both timestamps after the run
+- [ ] 7.2 Run `make import` a second time on the same PBF — confirm `imported_at` advances and `osm_data_age` is stable
+- [ ] 7.3 In hub mode with a Hessen + Fulda backend topology, confirm each `osm_id` appears exactly once in the VectorSource
+- [ ] 7.4 Simulate a stale Hessen backend (older `osm_data_age`) and a fresh Fulda backend — confirm Fulda's feature wins
+- [ ] 7.5 Simulate a backend with `osm_data_age: null` — confirm it loses to any backend with a real timestamp
+- [ ] 7.6 Confirm standalone mode is unaffected: no dedup logic runs, single-backend playground load works as before
+- [ ] 7.7 Confirm InstancePanel shows both timestamps correctly and degrades gracefully when fields are null


### PR DESCRIPTION
## Summary

- **DB schema** (`db/init.sql`, `importer/api.sql`): new `api.meta` singleton table persists `imported_at` and `osm_data_age` across container restarts; `get_meta()` extended to return both fields
- **Importer** (`import.sh`): after each osm2pgsql run, extracts `osmosis_replication_timestamp` via `osmium fileinfo --json` and upserts both timestamps; degrades gracefully when PBF has no replication metadata (Geofabrik extracts)
- **`registry.js`**: deduplicates playground features by `osm_id` at VectorSource insertion time, keeping whichever backend reports the newer `osm_data_age`; tags `_relationId` onto every feature; null age is treated as oldest (first-loader wins)
- **InstancePanel**: shows `imported_at` and `osm_data_age` per backend as relative time with ISO tooltip on hover; "unknown" when null
- **Hub fix** (`HubApp.svelte`): sets `activeTierStore` to `'polygon'` on mount — without an orchestrator both layers remained hidden
- **Docs**: new `docs/reference/hub-data-overlap.md` — data clash topology, dedup algorithm, tie-breaking rules, Geofabrik null-timestamp behaviour, operational guidance
- **Openspec**: archives `openspec/changes/add-import-timestamps-and-dedup/` (design, proposal, specs, tasks)

## Related

- Closes #202
- Bug follow-up: #299 (`playground_stats` LIMIT 1 vs ST_Union for multipolygon regions — separate fix)

## Test plan

- [ ] `make import` → `api.meta` populated with `imported_at` (non-null) and `osm_data_age` (null for Geofabrik PBF, non-null for replication PBF)
- [ ] `GET /api/rpc/get_meta` returns both timestamp fields
- [ ] Hub mode with two backends — InstancePanel shows timestamps per backend; "unknown" for null `osm_data_age`
- [ ] Console shows `[hub] dedup: replacing …` only when a fresher backend displaces an older one
- [ ] Standalone mode unaffected — no dedup logic runs, single-backend load unchanged
- [ ] Hub polygon layer visible on page load (not hidden by null tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)