### PR TITLE
fix(importer): playground_stats MV unions multipolygon relation fragments (#297)

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -19,9 +19,15 @@ DROP MATERIALIZED VIEW IF EXISTS public.playground_stats CASCADE;
 
 CREATE MATERIALIZED VIEW public.playground_stats AS
   WITH region AS (
-    SELECT way FROM planet_osm_polygon
+    -- osm2pgsql can emit multiple polygon rows per relation when the
+    -- relation is a multipolygon (states with exclaves / lakes / etc.) or
+    -- when member ways were clipped by a narrow PBF extract. ST_Union keeps
+    -- every fragment; LIMIT 1 picks one and silently drops the rest, which
+    -- on multipolygon relations like Baden-Württemberg (osm relation 62611,
+    -- 4 fragments) collapses the MV to a tiny subset of its true size.
+    -- Same pattern as get_playgrounds / get_meta below.
+    SELECT ST_Union(way) AS way FROM planet_osm_polygon
     WHERE osm_id = -${OSM_RELATION_ID}
-    LIMIT 1
   ),
   all_playgrounds AS (
     SELECT p.osm_id, p.way, p.name, p.operator, p.access, p.surface, p.tags


### PR DESCRIPTION
## Summary

`importer/api.sql:21-25` (the `playground_stats` MV's region CTE) used `LIMIT 1` to pick the relation polygon. For **multipolygon** relations (e.g. Baden-Württemberg, OSM relation 62611, 4 fragments) that drops 99%+ of features. Single-polygon relations (Fulda's Hessen-62700) were unaffected — the bug was invisible until BaWü was deployed.

The same file's `get_playgrounds` (line 147) and `get_meta` (line 907) both already use `ST_Union(way)` with a comment explaining exactly why. One-line fix to make the MV match.

## Production impact (https://spieli.eu)

Verified before fix:

```
Backend bawue.spieli.eu (relation 62611):
  planet_osm_polygon (leisure=playground):                14017
  WITH ST_Union region: count of playgrounds within:      13857
  playground_stats (broken MV):                               3   ← reports this to clients
  get_meta playground_count (joins broken MV):                3
```

After fix, `make db-apply` will rebuild the MV with all 13,857 rows.

## Test plan

- [x] Local: `make db-apply` applies cleanly against the seeded Fulda fixture (single polygon — 4 playgrounds, unchanged — confirms no regression on single-polygon relations).
- [x] `make test` — 29/29 passing.
- [ ] Production rollout: on each multipolygon-relation backend, pull the latest `:rc` importer image (or apply `api.sql` directly via psql) and run `make db-apply`. Confirm `SELECT count(*) FROM playground_stats` matches the relation's actual playground population.

Closes #297

Assisted-by: ClaudeCode:claude-opus-4-7