### PR TITLE
chore(openspec): draft add-cross-backend-osm-id-dedup proposal (#202)

### DIFF
--- a/openspec/changes/add-cross-backend-osm-id-dedup/design.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/design.md
@@ -1,0 +1,107 @@
+## Context
+
+Federation hub mode (`add-federated-playground-clustering`, archived 2026-04-26) fans out per-backend playground RPCs in parallel and renders results into a shared OL `VectorSource`. The cluster tier collapses cross-backend overlap via Supercluster's kd-tree merge on `[lon, lat]`. The polygon tier has no such merge — each backend's `get_playgrounds_bbox` response is appended to the source as-is.
+
+In a non-overlapping topology this is harmless: each `osm_id` exists at exactly one backend. In an overlapping topology — which is a deliberate, supported configuration (issue #251 tracks the InstancePanel UI for it) — the same playground is served by ≥ 2 backends. Today the source ends up with N copies of that feature; OL's hit-detection picks one in arrival order; deep-link restore logs `[deeplink] osm_id X matched 2 backends` and proceeds non-deterministically.
+
+Issue #202 named the problem and proposed dedup. The openspec change directory was never created. PR #295 attempted an implementation directly. Code review rejected it for (a) using table/field names that conflict with the in-flight `add-federation-health-exposition`, (b) string-comparing ISO timestamps lexicographically (TZ-format-sensitive), (c) reading `osmDataAge` from a live backends-store entry that gets mutated mid-cycle (silent drops on the fresher backend's own refresh), (d) O(N²) per-feature lookup, and (e) missing branches for the four corner cases in `(existingAge ± null) × (incomingAge ± null)`. This proposal sets the contract that a clean re-implementation must satisfy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deterministic which-feature-wins rule for any `osm_id` present at ≥ 2 backends.
+- O(N + M) per backend join, not O(N × M).
+- Stable across refresh cycles — a backend's refresh-poll must not transiently swap winners.
+- Compatible with the existing federation surface — no new RPC fields beyond what `add-federation-health-exposition` already adds.
+- Behaviour observable in the existing `[deeplink]` logging path so a future regression surfaces as a logged inconsistency rather than silent click misrouting.
+
+**Non-Goals:**
+
+- Server-side filtering. Backends keep shipping their full bbox-scoped feature sets; the merge is purely client-side.
+- Region-of-truth assignment. "Fulda's polygons always win for Fulda playgrounds" needs per-osm_id metadata that doesn't exist; if it becomes a hard requirement, ship as a separate proposal that adds an `authoritative_region` field somewhere.
+- Cluster tier. Already covered by Supercluster (different mechanism, different merge key).
+- Cross-source merging across the polygon and cluster tiers. They render in disjoint zoom ranges and are independent VectorSources.
+- Selection-store changes. The selection store already keys on `(osm_id, backendUrl)`; dedup happens at insertion time, before selection is involved.
+
+## Decisions
+
+### D1 — Dedup at VectorSource insertion time, not at fetch time
+
+The merge runs in `app/src/hub/registry.js` `loadBackend()` after the stale-removal step (the existing `vectorSource.removeFeatures(stale)` line). Alternative locations considered and rejected:
+
+- **At fetch time, before adding to source**: would require deduping the in-memory backends array of pending features, then a single batched insert. Adds memory pressure (hold N backends' results before any render) and breaks the existing progressive-render contract from `add-federated-playground-clustering` §3.2.
+- **In an OL `VectorSource` subclass** (`addFeature` override): the cleanest separation, but introduces a new module and ties dedup to the source rather than to the federation flow. Reserve for a future refactor if dedup logic grows.
+- **At selection time**: too late — the source still holds duplicates, OL's spatial index still sees N features per spot, hover preview still picks arbitrarily.
+
+Insertion-time dedup runs once per backend join, lives next to the per-backend stale-removal it pairs with, and stays under the existing `loadBackend` lock.
+
+### D2 — Compare by `last_import_at` (numeric), tie-break by URL alphabetical
+
+The merge rule for two features sharing an `osm_id`:
+
+1. Both have `last_import_at` → newer wins (numeric `Date.parse(a) - Date.parse(b)`).
+2. One has `last_import_at`, the other null → the one with a value wins.
+3. Both null OR equal `last_import_at` → URL alphabetical (lower URL string wins).
+
+The numeric compare via `Date.parse` is mandatory — the rejected PR #295's lexicographic string compare flips winners non-deterministically when two backends emit the same instant in different ISO TZ formats (`2026-04-25T12:00:00Z` vs `2026-04-25T14:00:00+02:00`).
+
+URL-alphabetical tie-break is chosen over "first arrival" because:
+
+- Arrival order is non-deterministic across moveends (parallel fan-out).
+- URL is stable across the session (registry doesn't re-rank backends).
+- Easy to reason about in test expectations.
+
+### D3 — Stamp `_lastImportAt` on the kept feature, frozen at insertion time
+
+Each kept feature carries:
+
+- `_backendUrl` (already shipped by `add-federated-playground-clustering`).
+- `_lastImportAt` (new) — the value of `backend.lastImportAt` *at the moment this feature was inserted*. Subsequent reads MUST come from the feature, not from the live backends store entry.
+
+The "frozen value" requirement is load-bearing. PR #295 read the existing-feature's age via `backends.find(b => b.url === existing.get('_backendUrl'))?.osmDataAge`, which is a *live* read of the backends store. By the time a fresher backend's refresh poll fires, its store entry has already been mutated to the new `last_import_at` *before* the dedup loop runs. The comparison `incomingAge > existingAge` then evaluates `freshAge > freshAge → false`, the feature is dropped, and the fresher backend's polygons silently disappear from the source on every refresh. Reading from the feature's own `_lastImportAt` (which was frozen on the previous insertion) avoids the data-race entirely.
+
+### D4 — Pre-index existing features as `Map<osm_id, feature>` once per backend join
+
+For an N-feature backend joining a source already holding M features, the cost should be O(N + M):
+
+- Build the `Map<osm_id, feature>` over M existing features once, before the per-incoming loop.
+- Per-incoming look-up is O(1).
+
+PR #295's `vectorSource.getFeatures().find(f => f.get('osm_id') === osmId)` was O(N × M) — at federation scale (5 backends × 1k features) it ran 5M scans per refresh and blocked the main thread. Reject any future implementation that doesn't pre-index.
+
+### D5 — Null `last_import_at` always loses
+
+A backend that hasn't reported `last_import_at` (either because `add-federation-health-exposition` hasn't merged yet, or because that backend hasn't completed its first import) is never preferred over one that has. This is a deliberate bias toward fresh information when partial information exists.
+
+If both have null, fall through to URL alphabetical (D2 step 3). The rule is total: every `(existing, incoming)` pair has a deterministic winner.
+
+### D6 — Degraded-mode fallback if `add-federation-health-exposition` is delayed
+
+If this change ships before `add-federation-health-exposition`, every backend's `last_import_at` is null. D5 means every comparison falls through to URL-alphabetical. The dedup contract still holds — the source has exactly one feature per `osm_id` and the choice is deterministic — but it's not freshness-aware. Once the upstream change lands, the freshness-tiebreak activates without any code change in this module.
+
+This is intentional: it lets the dedup work ship independently if the federation-health work hits a delay.
+
+### D7 — Single `addFeatures(toAdd)` at the end of the loop, not per-feature
+
+OL's `VectorSource.addFeature` fires `change` events synchronously per call. The polygon-tier renderer reacts to `change` to repaint. Per-feature inserts → N repaints per backend join. Use `addFeatures(toAdd)` once after the loop so the renderer paints the merged set in a single cycle.
+
+The corresponding `removeFeature(existing)` calls inside the loop are unavoidable (the loser must be evicted before its replacement can be added by `addFeatures`), but their `change` events are batched against the subsequent `addFeatures` by OL's existing event coalescing.
+
+## Risks / Trade-offs
+
+- **Pan flicker on `last_import_at` change.** If a backend's refresh-poll arrives with a slightly different `last_import_at` than the previous cycle (importer ran between polls), a feature that was the winner might transiently swap to the other backend before the next refresh re-stabilises. In practice `add-federation-health-exposition`'s import cadence is on the order of hours-to-days, polls are every 5 minutes, and observed flicker should be effectively never.
+- **URL-alphabetical bias.** When tie-breaking on equal/null ages, URL ordering is not policy — it's coincidental. If a deployment names backends `a-fulda` and `z-hessen`, the city backend wins ties; rename to `z-fulda` and the state backend wins. Document this in the dedup section so operators understand the tie-break.
+- **`_relationId` carries opaque payload with no consumer in this change.** Tagging features with `_relationId` is speculative state until a future change consumes it. Keeping it conditional on `add-federation-health-exposition` shipping `relation_id` (which it already does) means we don't ship dead data on pre-FHE backends. Cleaner to drop entirely if no consumer materialises within two release cycles.
+- **OL `getFeatures()` snapshot vs Map staleness.** The `Map<osm_id, feature>` is built once per backend join. Within one join, a `removeFeature(existing)` call followed by another lookup for the same osm_id — possible if the incoming backend somehow has duplicate features for the same `osm_id` *within its own response* — would still find the removed feature in the Map. Mitigation: dedup within a single backend's response is the upstream's problem; if it ships duplicates, the second-seen wins (Map gets overwritten). Document.
+- **Selection-store invalidation.** If the user has selected feature `osm_id=X` from backend A, and backend B's refresh causes A's feature to be evicted, the selection store still holds a reference to the now-removed feature. The selection store already keys on `(osm_id, backendUrl)` per `add-federation-health-exposition`'s spec, but the displayed polygon disappears. Mitigation: surface a one-time toast / log when this happens; defer to a follow-up if the UX is observed to be confusing.
+
+## Migration Plan
+
+None. This is a frontend-only behaviour change that activates as soon as the new code ships. Existing deployments see one feature per `osm_id` from the next moveend onward; no schema migration, no data backfill, no operator action.
+
+## Open Questions / Follow-ups
+
+- **Region-of-truth field on `get_meta`?** A future proposal could add `authoritative_relation_ids: [62700, ...]` so a state-level backend can declare "I'm authoritative for these relation IDs" and the dedup rule could prefer it over a city backend whose relation_id is contained. Out of scope here; track if operators ask.
+- **Source-subclass refactor?** If dedup logic grows (e.g. cluster-tier dedup, or a federation-wide selection store), a `DedupingVectorSource extends VectorSource` is the cleaner home. Defer until there are ≥ 2 use cases.
+- **Selection-store reconciliation when winner changes** — flagged in Risks. Track if observed.

--- a/openspec/changes/add-cross-backend-osm-id-dedup/design.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/design.md
@@ -26,40 +26,54 @@ Issue #202 named the problem and proposed dedup. The openspec change directory w
 
 ## Decisions
 
-### D1 — Dedup at VectorSource insertion time, not at fetch time
+### D1 — Dedup at the polygon-tier `onResult` in `hubOrchestrator.js`, not in `registry.js`
 
-The merge runs in `app/src/hub/registry.js` `loadBackend()` after the stale-removal step (the existing `vectorSource.removeFeatures(stale)` line). Alternative locations considered and rejected:
+The merge runs in `app/src/hub/hubOrchestrator.js` — specifically inside the polygon-tier `onResult` callback, immediately before `polygonSource.addFeatures(features)` — using a per-`orchestrate()`-call `Map<osm_id, Feature>` to look up an existing feature by `osm_id` and apply the merge rule (D2).
 
-- **At fetch time, before adding to source**: would require deduping the in-memory backends array of pending features, then a single batched insert. Adds memory pressure (hold N backends' results before any render) and breaks the existing progressive-render contract from `add-federated-playground-clustering` §3.2.
-- **In an OL `VectorSource` subclass** (`addFeature` override): the cleanest separation, but introduces a new module and ties dedup to the source rather than to the federation flow. Reserve for a future refactor if dedup logic grows.
+Earlier drafts of this proposal (and the rejected PR #295) anchored the dedup in `app/src/hub/registry.js` `loadBackend()`, with a phrase like "after the existing `vectorSource.removeFeatures(stale)` line". On current `main` that line **does not exist**: `registry.js` does not import any `VectorSource`, does not accept one, and does not call `removeFeatures` or `addFeatures`. All polygon `VectorSource` ownership lives in `app/src/hub/HubApp.svelte` and the only code that mutates it is `hubOrchestrator.js` (`polygonSource.clear()`, `polygonSource.addFeatures()`, `polygonSource.removeFeature()`). The `removeFeatures(stale)` line was removed wholesale when `add-federated-playground-clustering` archived (the orchestrator now handles all source mutation; `registry.js` was demoted to "registry discovery + metadata + nearest" per its own header comment). PR #295 reintroduced the line in its own diff, which is one of the architectural reasons it was rejected.
+
+The orchestrator anchor has three concrete benefits:
+
+- `parsePolygonFeatures` is the only place per-feature properties (`_backendUrl`, soon `_lastImportAt`) get stamped — keeping the dedup loop next to it avoids splitting feature-state initialisation across two modules.
+- The polygon-tier `onResult` is already the per-arrival callback in the fan-out — the natural granularity for dedup.
+- A per-`orchestrate()` map is naturally scoped: every new moveend / fan-out re-creates `polygonSource` cleared and the map fresh. No session-wide cache to invalidate.
+
+Alternative locations considered and rejected:
+
+- **An OL `VectorSource` subclass** (`addFeature` override): the cleanest separation, but introduces a new module and ties dedup to the source rather than to the federation flow. Reserve for a future refactor if dedup logic grows beyond `osm_id`.
+- **At fetch time, before any source mutation**: would require buffering N backends' results before the first paint and breaks the existing progressive-render contract from `add-federated-playground-clustering` §3.2.
 - **At selection time**: too late — the source still holds duplicates, OL's spatial index still sees N features per spot, hover preview still picks arbitrarily.
-
-Insertion-time dedup runs once per backend join, lives next to the per-backend stale-removal it pairs with, and stays under the existing `loadBackend` lock.
 
 ### D2 — Compare by `last_import_at` (numeric), tie-break by URL alphabetical
 
-The merge rule for two features sharing an `osm_id`:
+The merge rule for two features sharing an `osm_id`. Define `parseable(v)` ≡ `v != null && Number.isFinite(Date.parse(v))`:
 
-1. Both have `last_import_at` → newer wins (numeric `Date.parse(a) - Date.parse(b)`).
-2. One has `last_import_at`, the other null → the one with a value wins.
-3. Both null OR equal `last_import_at` → URL alphabetical (lower URL string wins).
+1. `parseable(a) && parseable(b)` → newer wins (`Date.parse(a) - Date.parse(b)`, numeric).
+2. `parseable(a)` XOR `parseable(b)` → the parseable one wins.
+3. `!parseable(a) && !parseable(b)` OR `Date.parse(a) === Date.parse(b)` → URL alphabetical: raw JavaScript `<` compare on the unmodified `_backendUrl` string.
 
 The numeric compare via `Date.parse` is mandatory — the rejected PR #295's lexicographic string compare flips winners non-deterministically when two backends emit the same instant in different ISO TZ formats (`2026-04-25T12:00:00Z` vs `2026-04-25T14:00:00+02:00`).
+
+`parseable` collapses three "no-timestamp" inputs into one bucket: JSON `null`, JS `undefined` (property never set), and any string `Date.parse` returns `NaN` for (e.g. truncated ISO without seconds on Safari, garbage data, empty string). All three behave identically under D5 → fall through to URL alphabetical at step 3. This avoids `NaN`-arithmetic falling silently through the step-1 numeric compare (`NaN - NaN === NaN`, neither `> 0` nor `< 0`) — which would otherwise produce a non-deterministic outcome.
 
 URL-alphabetical tie-break is chosen over "first arrival" because:
 
 - Arrival order is non-deterministic across moveends (parallel fan-out).
-- URL is stable across the session (registry doesn't re-rank backends).
+- URL is stable across the session (registry is loaded once at boot; subsequent registry-polls re-fetch `get_meta` per backend but do not re-rank or re-rewrite the URL strings).
 - Easy to reason about in test expectations.
 
-### D3 — Stamp `_lastImportAt` on the kept feature, frozen at insertion time
+The `<` compare is **raw string, code-unit-wise**, against `_backendUrl` as it arrived from the registry. No case-folding, no scheme/trailing-slash normalisation. Operators who want a particular tie-break order should rename the URLs in `registry.json` accordingly. Documenting this explicitly avoids two valid implementations (`a < b` vs `a.localeCompare(b)` vs `a.toLowerCase() < b.toLowerCase()`) silently disagreeing.
 
-Each kept feature carries:
+### D3 — Stamp `_lastImportAt` on each feature at parse time, frozen
 
-- `_backendUrl` (already shipped by `add-federated-playground-clustering`).
-- `_lastImportAt` (new) — the value of `backend.lastImportAt` *at the moment this feature was inserted*. Subsequent reads MUST come from the feature, not from the live backends store entry.
+Each feature emitted by `parsePolygonFeatures` carries:
 
-The "frozen value" requirement is load-bearing. PR #295 read the existing-feature's age via `backends.find(b => b.url === existing.get('_backendUrl'))?.osmDataAge`, which is a *live* read of the backends store. By the time a fresher backend's refresh poll fires, its store entry has already been mutated to the new `last_import_at` *before* the dedup loop runs. The comparison `incomingAge > existingAge` then evaluates `freshAge > freshAge → false`, the feature is dropped, and the fresher backend's polygons silently disappear from the source on every refresh. Reading from the feature's own `_lastImportAt` (which was frozen on the previous insertion) avoids the data-race entirely.
+- `_backendUrl` (already set today — `f.set('_backendUrl', backendUrl)` in `parsePolygonFeatures`).
+- `_lastImportAt` (new) — the value of `backend.lastImportAt` at the moment `parsePolygonFeatures` runs. Subsequent dedup cycles read from the feature (`existing.get('_lastImportAt')`), never from the live `backends` store.
+
+Why frozen-at-parse-time, not live-read: the rejected PR #295 read the existing feature's age via `backends.find(b => b.url === existing.get('_backendUrl'))?.osmDataAge`. On `main` today, the `backends` store uses immutable patches (`backends[idx] = { ...backends[idx], ...patch }`), so a live read happens to be safe today. But there is no architectural guarantee against a future refactor reintroducing in-place mutation — and PR #295's own diff *did* reintroduce in-place mutation, exposing the race. Frozen-at-parse-time is the defensive contract: feature lifecycle and store lifecycle are decoupled, so no future store-mutation refactor can produce a silent-drop regression.
+
+`_lastImportAt` is stored as a string (ISO-8601) or `null` — never `undefined`. Readers MUST treat `feature.get('_lastImportAt') === undefined` (property never set on a pre-this-change feature in a half-rolled-out frontend) and `=== null` identically. The `parseable()` predicate in D2 already collapses both with `NaN`-Date.parse cases, so this is automatic for the merge rule but worth naming so test fixtures don't depend on a particular sentinel.
 
 ### D4 — Pre-index existing features as `Map<osm_id, feature>` once per backend join
 
@@ -82,19 +96,26 @@ If this change ships before `add-federation-health-exposition`, every backend's 
 
 This is intentional: it lets the dedup work ship independently if the federation-health work hits a delay.
 
-### D7 — Single `addFeatures(toAdd)` at the end of the loop, not per-feature
+### D7 — Batch source mutations: `removeFeatures(toRemove)` + `addFeatures(toAdd)`, not per-feature
 
-OL's `VectorSource.addFeature` fires `change` events synchronously per call. The polygon-tier renderer reacts to `change` to repaint. Per-feature inserts → N repaints per backend join. Use `addFeatures(toAdd)` once after the loop so the renderer paints the merged set in a single cycle.
+OL's `VectorSource.addFeature` and `removeFeature` each fire a synchronous `change` event per call (verified — `ol/source/Vector.js`). The polygon-tier renderer reacts to `change` to repaint. Per-feature mutations therefore produce N repaints per backend arrival.
 
-The corresponding `removeFeature(existing)` calls inside the loop are unavoidable (the loser must be evicted before its replacement can be added by `addFeatures`), but their `change` events are batched against the subsequent `addFeatures` by OL's existing event coalescing.
+The reference implementation should:
+
+1. Walk the incoming features once, populating `toAdd` and `toRemove` arrays via the merge rule (D2).
+2. Call `polygonSource.removeFeatures(toRemove)` once — fires one `change` event regardless of array length.
+3. Call `polygonSource.addFeatures(toAdd)` once — fires one `change` event regardless of array length.
+
+Total: two repaints per arrival (or one, if `toRemove` is empty — the common no-overlap case where dedup is a pass-through). PR #302's reference implementation calls `removeFeature` per-loser inside the loop, which works correctly but produces (losers + 1) repaints; the contract above is tighter and cheaper. Either pattern satisfies the spec scenarios — repaint count isn't testable from Playwright without performance instrumentation — but the batched form is the prescribed shape.
+
+Note: there is **no** "OL existing event coalescing" — earlier drafts of this proposal claimed there was. There isn't. Each `removeFeature`/`addFeature` call fires its own event synchronously. The batched form above is the only way to limit repaint count.
 
 ## Risks / Trade-offs
 
-- **Pan flicker on `last_import_at` change.** If a backend's refresh-poll arrives with a slightly different `last_import_at` than the previous cycle (importer ran between polls), a feature that was the winner might transiently swap to the other backend before the next refresh re-stabilises. In practice `add-federation-health-exposition`'s import cadence is on the order of hours-to-days, polls are every 5 minutes, and observed flicker should be effectively never.
-- **URL-alphabetical bias.** When tie-breaking on equal/null ages, URL ordering is not policy — it's coincidental. If a deployment names backends `a-fulda` and `z-hessen`, the city backend wins ties; rename to `z-fulda` and the state backend wins. Document this in the dedup section so operators understand the tie-break.
-- **`_relationId` carries opaque payload with no consumer in this change.** Tagging features with `_relationId` is speculative state until a future change consumes it. Keeping it conditional on `add-federation-health-exposition` shipping `relation_id` (which it already does) means we don't ship dead data on pre-FHE backends. Cleaner to drop entirely if no consumer materialises within two release cycles.
-- **OL `getFeatures()` snapshot vs Map staleness.** The `Map<osm_id, feature>` is built once per backend join. Within one join, a `removeFeature(existing)` call followed by another lookup for the same osm_id — possible if the incoming backend somehow has duplicate features for the same `osm_id` *within its own response* — would still find the removed feature in the Map. Mitigation: dedup within a single backend's response is the upstream's problem; if it ships duplicates, the second-seen wins (Map gets overwritten). Document.
-- **Selection-store invalidation.** If the user has selected feature `osm_id=X` from backend A, and backend B's refresh causes A's feature to be evicted, the selection store still holds a reference to the now-removed feature. The selection store already keys on `(osm_id, backendUrl)` per `add-federation-health-exposition`'s spec, but the displayed polygon disappears. Mitigation: surface a one-time toast / log when this happens; defer to a follow-up if the UX is observed to be confusing.
+- **Pan flicker on `last_import_at` change.** If a backend's refresh-poll arrives with a slightly different `last_import_at` than the previous cycle (importer ran between polls), a feature that was the winner might transiently swap to the other backend before the next refresh re-stabilises. In practice import cadence is on the order of hours-to-days, registry polls are every 5 minutes, and observed flicker should be effectively never. The spec's "Refresh stability" scenario asserts no winner *change* on stable inputs — not "no observable removeFeature/addFeature event", which would be unimplementable given the per-arrival fan-out architecture.
+- **URL-alphabetical bias.** When tie-breaking on equal/null/NaN ages, URL ordering is not policy — it's coincidental. If a deployment names backends `https://a-fulda.example/api` and `https://z-hessen.example/api`, the city backend wins ties; rename to `https://z-fulda.example/api` and the state backend wins. Document in `docs/reference/federation.md` so operators understand. Case sensitivity matters: `https://A.example/api` < `https://a.example/api` (uppercase ASCII has lower code points than lowercase).
+- **OL `Map` snapshot vs duplicate within one backend response.** The per-`orchestrate()` `Map<osm_id, Feature>` is updated by every winning incoming. If the incoming backend somehow has duplicate features for the same `osm_id` within its own single response (multipolygon-tagged-as-leisure-playground relations exploded by osm2pgsql — see issue #299), the second-seen wins (Map gets overwritten). Mitigation: track this as a server-side concern in #299; it is not a property the dedup loop can detect from a single backend's payload.
+- **Selection-store invalidation.** If the user has selected feature `osm_id=X` from backend A, and backend B's later arrival in the same `orchestrate()` call wins, A's feature is removed before the new winner is added — the selection store still holds a reference to the now-removed feature. The selection store keys on `(osm_id, backendUrl)`, so the user's selection no longer matches anything on the map. Mitigation: out of scope for this change — reconciling the selection on winner flip is its own UX concern. Documented as an Open Question.
 
 ## Migration Plan
 

--- a/openspec/changes/add-cross-backend-osm-id-dedup/proposal.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/proposal.md
@@ -6,25 +6,35 @@ Issue #202 named this and pointed at an `openspec/changes/add-import-timestamps-
 
 ## What Changes
 
-- **Frontend (`app/src/hub/registry.js`)**: introduce a per-`VectorSource` deterministic merge rule applied at backend-arrival time. After removing the current backend's prior features (the existing stale-removal step), pre-index the remaining features as `Map<osm_id, feature>`. For each incoming feature, look up by `osm_id`:
-    - If absent → push to `toAdd`.
-    - If present → compare `last_import_at` (numeric `Date.parse`) with the existing feature's frozen-at-insertion `_lastImportAt`. Newer wins; null always loses; ties broken by URL alphabetical for absolute determinism.
-    - If incoming wins → `vectorSource.removeFeature(existing)` + `toAdd.push(incoming)`. If existing wins → drop incoming.
-- **Feature property contract**: every kept feature carries
-    - `_backendUrl` (already shipped by the federation work) — which backend the feature came from
-    - `_lastImportAt` (new) — frozen value of that backend's `last_import_at` *at the time this feature was inserted*, NOT a live read from the backends store. This is load-bearing: the live backends-store entry is mutated mid-cycle when a backend refreshes, so a live read produces the silent-drop bug PR #295 hit.
-    - `_relationId` (new — but conditional on `add-federation-health-exposition` shipping `relation_id` in `get_meta`) — kept as an opaque sentinel for any future cross-backend disambiguation; consumers in this change SHALL NOT read it.
-- **Single `addFeatures(toAdd)`** after the per-backend loop completes — no incremental adds inside the loop, to keep the source's `change` event cycle predictable.
-- **Tests**: Playwright fixture exercising two backends with overlapping `osm_id`; deterministic winner-by-`last_import_at`; refresh stability (no flicker across polls); URL-alphabetical tie-break.
-- **Docs**: `docs/reference/federation.md` gains a "Cross-backend dedup" subsection naming the contract.
+- **Frontend (`app/src/hub/hubOrchestrator.js`)** — the polygon-tier fan-out is the load-bearing edit point. `registry.js` does **not** own the polygon `VectorSource` on current `main` (the federation-clustering refactor moved all source mutation into the orchestrator); polygon-tier merge therefore lives next to `parsePolygonFeatures` + the polygon-tier `onResult` handler, not in `registry.js`.
+    - `parsePolygonFeatures(geojson, backendUrl, backend)` stamps every emitted feature with `_lastImportAt = backend.lastImportAt`. The value is **frozen at parse time**: subsequent dedup cycles read this from the *feature*, never from the live `backends` store entry.
+    - Polygon-tier `onResult` maintains a per-`orchestrate()`-call `Map<osm_id, Feature>` (`polyByOsmId`). For each incoming feature, look up by `osm_id`:
+        - If absent → add the incoming feature to the source and to the map.
+        - If present → compare via the merge rule below. Incoming wins → `polygonSource.removeFeature(existing)` then add incoming and update the map. Existing wins → drop incoming.
+    - The map is per-`orchestrate()` (not session-wide) — every new moveend / fan-out starts a fresh map. Progressive rendering is preserved; in the common case (no overlap) every arrival adds with zero removals.
+- **Frontend (`app/src/hub/registry.js`)** — the only edit is to consume the new `last_import_at` field from `get_meta`:
+    - Add `lastImportAt: null` to the initial backend shape.
+    - In `loadBackend()`, write `patch.lastImportAt = meta.last_import_at ?? null` next to the existing completeness extraction. No source mutation, no orchestrator coupling.
+- **Merge rule** (applied in `pickWinner(existing, incoming)`):
+    1. Both have a parseable `last_import_at` → newer wins (`Date.parse(a) - Date.parse(b)`, numeric).
+    2. Exactly one has a parseable value → the non-null/non-NaN wins.
+    3. Both null OR both `NaN` OR both equal → URL alphabetical, raw JavaScript `<` compare on the unmodified `_backendUrl` string (no case-folding, no scheme/trailing-slash normalisation — registry URLs are byte-stable across the session).
+- **Feature property contract**: every polygon feature in the shared source carries:
+    - `_backendUrl` (already set today by `parsePolygonFeatures`) — which backend the feature came from.
+    - `_lastImportAt` (new) — frozen value of that backend's `last_import_at` at parse time. ISO-8601 string per `add-federation-health-exposition`, or `null` on pre-FHE backends. Readers MUST treat `undefined` (never set) and `null` (set to null) and any value where `Date.parse(v)` returns `NaN` identically as "no timestamp".
+- **Tests**: Playwright fixtures exercising (a) two backends with overlapping `osm_id` + deterministic newer-import winner, (b) degraded mode (both backends report `null` `last_import_at`) → URL-alphabetical winner, (c) refresh stability (winner unchanged on stable inputs), (d) refresh transition (winner flips when one backend's `last_import_at` advances).
+- **Docs**: `docs/reference/federation.md` gains a "Cross-backend dedup" subsection naming the contract, including the URL-canonicalisation note.
 
 Out of scope (explicit non-goals):
 
 - Server-side aggregation or de-duplication. Backends still ship their full feature sets; the merge is purely client-side.
 - Region-of-truth assignment (e.g. "Fulda always wins for Fulda playgrounds"). That requires per-osm_id metadata that doesn't exist today; track separately if a use case appears.
-- Cluster-tier dedup. The cluster tier already merges via Supercluster's kd-tree on `[lon, lat]` — see archived `add-federated-playground-clustering` D-section. This change is polygon-tier only.
-- Modifications to `get_meta` shape. The `last_import_at` field is provided by `add-federation-health-exposition`; this change consumes it.
-- The implementation in PR #295. That PR is rejected for review in its current form; re-author against the contract here.
+- Cluster-tier dedup. The cluster tier already merges via Supercluster's kd-tree on `[lon, lat]` (see archived `add-federated-playground-clustering`). The cluster pipeline does not surface `osm_id`, so an "osm_id dedup" question doesn't apply at that tier — overlap manifests as cluster-count inflation when two backends report cluster buckets at different `[lon, lat]`. Out of scope here.
+- **Issue #202's `osm_data_age` (PBF replication timestamp)** as the merge key. #202's original acceptance named `osm_data_age` (the PBF's `osmosis_replication_timestamp`) as the authoritative dedup signal alongside `imported_at`. This change uses only `last_import_at` (the import-run timestamp). Rationale: `add-federation-health-exposition` ships `last_import_at` and `data_age_seconds` but not the PBF replication timestamp. Adopting the dual-timestamp model would require extending FHE; punted to a follow-up if operators report the divergence (importer ran against an old PBF) is observable.
+- Per-backend "last reachable" / "import age" rendering in `InstancePanelDrawer`. That belongs in `add-federation-health-exposition`'s `hub-ui-parity` delta, not here.
+- Selection-store reconciliation when a winner flip evicts a currently-selected feature. Documented as a Risk in `design.md`; see Open Questions for follow-up.
+- `_relationId` feature tagging. Originally proposed as speculative state for a future cross-backend disambiguation; dropped because (a) `relation_id` is already shipped by `get_meta` today (not new from FHE), and (b) no consumer in this change reads it.
+- The implementation in PR #295. That PR is rejected in code review; re-author against the contract here.
 
 ## Capabilities
 
@@ -34,13 +44,14 @@ Out of scope (explicit non-goals):
 
 ## Impact
 
-- `app/src/hub/registry.js` — `loadBackend()` gains the index-and-compare loop after the stale-removal step.
-- Each polygon feature gains `_lastImportAt` and (conditionally) `_relationId` properties.
-- `tests/hub-multi-backend.spec.js` (or a new `tests/hub-dedup.spec.js`) — Playwright coverage for the new contract.
+- `app/src/hub/hubOrchestrator.js` — `parsePolygonFeatures` stamps `_lastImportAt`; polygon-tier `onResult` gains the `Map<osm_id, Feature>` index-and-compare. (PR #302 already implements this shape using a separate `app/src/hub/osmIdDedup.js` module — that's a clean factoring; the contract here doesn't mandate the helper module's existence, just the behaviour.)
+- `app/src/hub/registry.js` — initial backend shape gains `lastImportAt: null`; `loadBackend()` adds one line to write `patch.lastImportAt = meta.last_import_at ?? null`. No source mutation.
+- Each polygon feature gains the `_lastImportAt` property at parse time.
+- `tests/hub-osm-id-dedup.spec.js` (new) or extension of `tests/hub-multi-backend.spec.js` — Playwright coverage for overlap + degraded-mode + refresh-flip.
 - `docs/reference/federation.md` — new "Cross-backend dedup" subsection.
-- No changes to: `importer/api.sql`, `importer/import.sh`, `oci/app/`, `compose.yml`, the OL VectorSource subclass, the cluster tier, the polygon-tier RPC contract, or any non-hub frontend code.
+- No changes to: `importer/api.sql`, `importer/import.sh`, `oci/app/`, `compose.yml`, the OL `VectorSource` subclass, the cluster tier, the polygon-tier RPC contract, or any non-hub frontend code.
 
 ## Dependencies
 
-- **`add-federation-health-exposition`** (in flight, issue #194) provides the `last_import_at` field on `get_meta` that this change's merge rule consumes. If the federation-health change is delayed, this change's tasks document a degraded-mode fallback (URL-alphabetical only — deterministic but not freshness-aware) so the dedup contract still holds; the freshness-tiebreak adds value as soon as the upstream lands.
-- **`add-federated-playground-clustering`** (archived 2026-04-26) provides the per-feature `_backendUrl` tagging that the merge rule reads. No new dependency surfaces here.
+- **`add-federation-health-exposition`** (in flight, issue #194; implementation in PR #301) provides the `last_import_at` field on `get_meta` that this change's merge rule consumes. **Soft dependency**: if the federation-health change is delayed, this change runs in degraded mode (URL-alphabetical only — deterministic but not freshness-aware) so the dedup contract still holds; the freshness-tiebreak activates as soon as the upstream lands. Either order is acceptable; if FHE ships second, the only conflict is in `registry.js` (both PRs add fields to the initial backend shape — keep both, they don't overlap on field names).
+- **`add-federated-playground-clustering`** (archived 2026-04-26) provides the per-feature `_backendUrl` tagging at `hubOrchestrator.js` `parsePolygonFeatures` that the merge rule reads. The archived proposal stated polygons from different backends "never overlap geographically (relations are disjoint)" — this change explicitly **supersedes** that disjoint-relations assumption: overlap is now a supported topology and the merge rule is what handles it.

--- a/openspec/changes/add-cross-backend-osm-id-dedup/proposal.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Hub mode supports overlapping backend coverage as a deliberate topology — a Fulda city backend can run alongside a Hessen state backend, and both contain the Fulda playgrounds. After fan-out, the OL `VectorSource` ends up with multiple polygon features carrying the same `osm_id`. Today's behaviour is undefined: the OL click handler picks "the first match", deep-link restore logs `[deeplink] osm_id X matched 2 backends` and proceeds non-deterministically, and which backend's polygon "wins" depends on response-arrival ordering across moveends.
+
+Issue #202 named this and pointed at an `openspec/changes/add-import-timestamps-and-dedup/` directory that was never drafted. PR #295 attempted an implementation and was rejected for (a) coordinating with the wrong names against `add-federation-health-exposition` and (b) shipping multiple correctness bugs in the dedup loop itself (lexicographic ISO compare, O(N²) lookup, stale-removal-then-compare race, missing branches). This change sets the contract that any clean re-implementation must satisfy — independent of where the implementation lands.
+
+## What Changes
+
+- **Frontend (`app/src/hub/registry.js`)**: introduce a per-`VectorSource` deterministic merge rule applied at backend-arrival time. After removing the current backend's prior features (the existing stale-removal step), pre-index the remaining features as `Map<osm_id, feature>`. For each incoming feature, look up by `osm_id`:
+    - If absent → push to `toAdd`.
+    - If present → compare `last_import_at` (numeric `Date.parse`) with the existing feature's frozen-at-insertion `_lastImportAt`. Newer wins; null always loses; ties broken by URL alphabetical for absolute determinism.
+    - If incoming wins → `vectorSource.removeFeature(existing)` + `toAdd.push(incoming)`. If existing wins → drop incoming.
+- **Feature property contract**: every kept feature carries
+    - `_backendUrl` (already shipped by the federation work) — which backend the feature came from
+    - `_lastImportAt` (new) — frozen value of that backend's `last_import_at` *at the time this feature was inserted*, NOT a live read from the backends store. This is load-bearing: the live backends-store entry is mutated mid-cycle when a backend refreshes, so a live read produces the silent-drop bug PR #295 hit.
+    - `_relationId` (new — but conditional on `add-federation-health-exposition` shipping `relation_id` in `get_meta`) — kept as an opaque sentinel for any future cross-backend disambiguation; consumers in this change SHALL NOT read it.
+- **Single `addFeatures(toAdd)`** after the per-backend loop completes — no incremental adds inside the loop, to keep the source's `change` event cycle predictable.
+- **Tests**: Playwright fixture exercising two backends with overlapping `osm_id`; deterministic winner-by-`last_import_at`; refresh stability (no flicker across polls); URL-alphabetical tie-break.
+- **Docs**: `docs/reference/federation.md` gains a "Cross-backend dedup" subsection naming the contract.
+
+Out of scope (explicit non-goals):
+
+- Server-side aggregation or de-duplication. Backends still ship their full feature sets; the merge is purely client-side.
+- Region-of-truth assignment (e.g. "Fulda always wins for Fulda playgrounds"). That requires per-osm_id metadata that doesn't exist today; track separately if a use case appears.
+- Cluster-tier dedup. The cluster tier already merges via Supercluster's kd-tree on `[lon, lat]` — see archived `add-federated-playground-clustering` D-section. This change is polygon-tier only.
+- Modifications to `get_meta` shape. The `last_import_at` field is provided by `add-federation-health-exposition`; this change consumes it.
+- The implementation in PR #295. That PR is rejected for review in its current form; re-author against the contract here.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `federated-playground-clustering`: gains a new Requirement "Hub deduplicates overlapping playgrounds by `osm_id` at VectorSource insertion".
+
+## Impact
+
+- `app/src/hub/registry.js` — `loadBackend()` gains the index-and-compare loop after the stale-removal step.
+- Each polygon feature gains `_lastImportAt` and (conditionally) `_relationId` properties.
+- `tests/hub-multi-backend.spec.js` (or a new `tests/hub-dedup.spec.js`) — Playwright coverage for the new contract.
+- `docs/reference/federation.md` — new "Cross-backend dedup" subsection.
+- No changes to: `importer/api.sql`, `importer/import.sh`, `oci/app/`, `compose.yml`, the OL VectorSource subclass, the cluster tier, the polygon-tier RPC contract, or any non-hub frontend code.
+
+## Dependencies
+
+- **`add-federation-health-exposition`** (in flight, issue #194) provides the `last_import_at` field on `get_meta` that this change's merge rule consumes. If the federation-health change is delayed, this change's tasks document a degraded-mode fallback (URL-alphabetical only — deterministic but not freshness-aware) so the dedup contract still holds; the freshness-tiebreak adds value as soon as the upstream lands.
+- **`add-federated-playground-clustering`** (archived 2026-04-26) provides the per-feature `_backendUrl` tagging that the merge rule reads. No new dependency surfaces here.

--- a/openspec/changes/add-cross-backend-osm-id-dedup/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/specs/federated-playground-clustering/spec.md
@@ -1,61 +1,74 @@
 ## ADDED Requirements
 
-### Requirement: Hub deduplicates overlapping playgrounds by `osm_id` at VectorSource insertion
+### Requirement: Hub deduplicates overlapping playgrounds by `osm_id` in the polygon tier
 
-In hub mode, when two or more registered backends serve the same playground (overlapping coverage — e.g. a city backend inside a state backend, both shipping that city's playgrounds), the hub SHALL render exactly one feature per `osm_id` in each shared `VectorSource`. The merge rule is deterministic: prefer the feature whose backend reports the freshest `last_import_at`, with `null` always losing and ties broken by URL alphabetical so the outcome is stable across refresh cycles and arrival orderings.
+In hub mode, when two or more registered backends serve the same playground (overlapping coverage — e.g. a city backend inside a state backend, both shipping that city's playgrounds), the hub SHALL render exactly one feature per `osm_id` in the shared polygon `VectorSource`. The merge runs in `app/src/hub/hubOrchestrator.js` per-`orchestrate()` call, against a `Map<osm_id, Feature>` populated as backend arrivals progress through the polygon-tier `onResult` handler. The merge rule is deterministic: prefer the feature whose backend reports the freshest `last_import_at`, with `null` and unparseable timestamps always losing, and ties broken by raw-string URL alphabetical for absolute determinism across registry edits and arrival orderings.
 
 #### Scenario: Two backends share an `osm_id`, fresher `last_import_at` wins
 
-- **WHEN** backend A and backend B both return a feature with `osm_id = 12345`, A's `get_meta` reported `last_import_at = 2026-04-25T03:00Z` and B's reported `2026-04-26T03:00Z`
-- **THEN** the hub's polygon `VectorSource` contains exactly one feature with `osm_id = 12345`
+- **WHEN** backend A and backend B both return a feature with `osm_id = 12345` in the polygon tier, A's `get_meta` reported `last_import_at = "2026-04-25T03:00:00Z"` and B's reported `"2026-04-26T03:00:00Z"`
+- **THEN** the polygon `VectorSource` contains exactly one feature with `osm_id = 12345` after both arrivals settle
 - **AND** that feature's `_backendUrl` property equals B's URL (B is fresher)
-- **AND** that feature's `_lastImportAt` property equals `2026-04-26T03:00Z` (frozen at insertion time)
+- **AND** that feature's `_lastImportAt` property equals `"2026-04-26T03:00:00Z"` (frozen at parse time, read from the feature in subsequent cycles — never from the live `backends` store)
 
-#### Scenario: Null `last_import_at` always loses
+#### Scenario: Null or unparseable `last_import_at` always loses
 
-- **WHEN** backend A reports `last_import_at = null` (e.g. pre-`add-federation-health-exposition` backend, or first-import not yet completed) and backend B reports any non-null timestamp
+- **WHEN** backend A reports `last_import_at = null` (or `undefined`, or any string for which `Date.parse(value)` returns `NaN`) and backend B reports any value where `Date.parse(value)` is finite
 - **THEN** the kept feature comes from backend B
-- **AND** the rule applies symmetrically — non-null beats null in either arrival order
+- **AND** the rule applies symmetrically — non-null/parseable beats null/unparseable in either arrival order
 
-#### Scenario: Equal or both-null timestamps tie-break by URL alphabetical
+#### Scenario: Equal or both-missing timestamps tie-break by URL alphabetical
 
-- **WHEN** backends A and B both report identical `last_import_at`, OR both report `null`
-- **THEN** the kept feature comes from whichever backend's URL sorts first lexicographically
-- **AND** swapping the order in `registry.json` does NOT change the winner — the URL string itself is the load-bearing key, not registry position
+- **WHEN** backends A and B both report identical numeric `Date.parse(last_import_at)`, OR both report values that are absent / null / unparseable
+- **THEN** the kept feature comes from whichever backend's `_backendUrl` string sorts first under JavaScript's raw `<` operator — code-unit-wise, no case-folding, no scheme/trailing-slash normalisation
+- **AND** swapping the order of entries in `registry.json` does NOT change the winner — the URL string itself is the load-bearing key, not registry position
+
+#### Scenario: Same instant emitted in different ISO TZ formats counts as a tie
+
+- **WHEN** two backends return `last_import_at = "2026-04-25T12:00:00Z"` and `"2026-04-25T14:00:00+02:00"` respectively (the same instant, different TZ format)
+- **THEN** `Date.parse(a) === Date.parse(b)` evaluates true, the timestamps are treated as equal, and the rule falls through to URL alphabetical
+- **AND** the comparison MUST NOT use lexicographic string compare on the raw values — that would flip the winner non-deterministically based on the chosen TZ format, which is the bug PR #295 was rejected for
 
 #### Scenario: Refresh cycle does not flip the winner on stable inputs
 
-- **WHEN** the registry-poll refresh fires and re-fetches `get_meta` and the bbox-tier features from both backends, with neither backend's `last_import_at` having changed
+- **WHEN** the registry-poll refresh fires and re-fetches `get_meta` and the polygon-tier features from both backends, with neither backend's `last_import_at` having changed
 - **THEN** the same backend remains the winner for every shared `osm_id`
-- **AND** no transient swap is observable in the rendered polygon source
+- **AND** the rendered polygon source's content does not change (the orchestrator may issue intermediate `removeFeature`/`addFeatures` calls per backend arrival as a consequence of the per-`orchestrate()` map being rebuilt — the contract is on *winner identity*, not on event-count silence)
 
 #### Scenario: Refresh cycle flips the winner when one backend imports newer data
 
-- **WHEN** the previously-losing backend's `last_import_at` advances past the previously-winning backend's `last_import_at` between two refresh cycles
+- **WHEN** the previously-losing backend's `last_import_at` advances past the previously-winning backend's `last_import_at` between two registry-poll cycles
 - **THEN** at the next refresh, the winner flips to the now-fresher backend for every shared `osm_id`
-- **AND** the previously-winning feature is removed from the source by `removeFeature` before the new feature is added
+- **AND** the previously-winning feature is removed from the source via `removeFeature(s)` before the new feature is added via `addFeatures`
 
-#### Scenario: Comparison treats ISO timestamps numerically
+#### Scenario: Existing-feature timestamp is read from the feature, not the live `backends` store
 
-- **WHEN** the two competing `last_import_at` values represent the same instant but are serialised in different timezone formats (e.g. `2026-04-25T12:00:00Z` from one backend and `2026-04-25T14:00:00+02:00` from another)
-- **THEN** the comparison declares them equal (as `Date.parse(a) === Date.parse(b)`) and falls through to URL alphabetical
-- **AND** the comparison MUST NOT use lexicographic string compare — that flips the winner non-deterministically based on the chosen TZ format
-
-#### Scenario: Existing-feature age is read from the feature, not the live backends store
-
-- **WHEN** the hub is mid-refresh on backend A — A's `backends`-store entry has *already* been updated to A's new `last_import_at` — and the dedup loop compares A's incoming feature against an existing feature owned by A from the previous cycle
-- **THEN** the existing feature's `_lastImportAt` (frozen at insertion time on the previous cycle) is used as the comparator, NOT the live `backends.find(b => b.url === url)?.lastImportAt` value
-- **AND** the dedup outcome is independent of the order in which the backends-store update and the dedup loop run within a single refresh
+- **WHEN** the dedup loop runs and an existing feature owned by backend B is in the source from a previous `orchestrate()` call (or a previous arrival in the same call), and the incoming feature is from backend A or B
+- **THEN** the existing feature's `_lastImportAt` is read via `existing.get('_lastImportAt')` — a value that was frozen at the feature's parse time
+- **AND** the comparison value is independent of any subsequent mutation of `backends.find(b => b.url === existingBackendUrl).lastImportAt`
+- **AND** this contract holds even if a future refactor reintroduces in-place mutation of the `backends` store
 
 #### Scenario: Single backend per `osm_id` is a no-op
 
-- **WHEN** backend A returns a feature with `osm_id = 12345` and no other backend covers that playground
+- **WHEN** backend A returns a feature with `osm_id = 12345` and no other backend covers that playground in the same `orchestrate()` call
 - **THEN** the feature is added to the source as-is
 - **AND** no compare or remove is performed
-- **AND** the feature carries `_backendUrl` and `_lastImportAt` from backend A
+- **AND** the feature carries `_backendUrl = A.url` and `_lastImportAt = A.lastImportAt ?? null`
 
-#### Scenario: Cluster tier is not affected
+#### Scenario: `_lastImportAt` storage and read symmetry
 
-- **WHEN** the dedup runs at the polygon tier (zoom > `clusterMaxZoom`)
-- **THEN** the cluster tier's Supercluster kd-tree merge (existing behaviour from this same capability) operates independently — it merges by spatial proximity on `[lon, lat]`, not by `osm_id`
-- **AND** the polygon-tier dedup does NOT touch the cluster tier's `VectorSource`
+- **WHEN** a feature is parsed by `parsePolygonFeatures` from a backend whose `lastImportAt` is null or missing
+- **THEN** the feature's `_lastImportAt` is set to JSON `null` (not omitted)
+- **AND** readers of `existing.get('_lastImportAt')` MUST treat the returned `null`, `undefined` (legacy features without the property), and any string value where `Date.parse(value)` returns `NaN` identically — all three fall into the "no parseable timestamp" branch of the merge rule
+
+#### Scenario: Source mutations are batched per arrival
+
+- **WHEN** a polygon-tier arrival from backend X yields N losers (existing features evicted by the merge) and M winners (incoming features added)
+- **THEN** the orchestrator calls `polygonSource.removeFeatures(toRemove)` once with all N losers, then `polygonSource.addFeatures(toAdd)` once with all M winners
+- **AND** per-feature `removeFeature`/`addFeature` calls inside the loop are forbidden — they each fire a synchronous `change` event that triggers a renderer repaint
+
+#### Scenario: Cluster tier is not affected by this change
+
+- **WHEN** the active tier is the cluster tier (`zoom <= clusterMaxZoom`)
+- **THEN** the dedup behaviour above does not run — the cluster tier merges by spatial proximity via Supercluster's existing kd-tree pipeline (a separate mechanism that does not surface `osm_id`)
+- **AND** the polygon-tier dedup module does not touch `clusterSource` or `macroSource`

--- a/openspec/changes/add-cross-backend-osm-id-dedup/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/specs/federated-playground-clustering/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Hub deduplicates overlapping playgrounds by `osm_id` at VectorSource insertion
+
+In hub mode, when two or more registered backends serve the same playground (overlapping coverage — e.g. a city backend inside a state backend, both shipping that city's playgrounds), the hub SHALL render exactly one feature per `osm_id` in each shared `VectorSource`. The merge rule is deterministic: prefer the feature whose backend reports the freshest `last_import_at`, with `null` always losing and ties broken by URL alphabetical so the outcome is stable across refresh cycles and arrival orderings.
+
+#### Scenario: Two backends share an `osm_id`, fresher `last_import_at` wins
+
+- **WHEN** backend A and backend B both return a feature with `osm_id = 12345`, A's `get_meta` reported `last_import_at = 2026-04-25T03:00Z` and B's reported `2026-04-26T03:00Z`
+- **THEN** the hub's polygon `VectorSource` contains exactly one feature with `osm_id = 12345`
+- **AND** that feature's `_backendUrl` property equals B's URL (B is fresher)
+- **AND** that feature's `_lastImportAt` property equals `2026-04-26T03:00Z` (frozen at insertion time)
+
+#### Scenario: Null `last_import_at` always loses
+
+- **WHEN** backend A reports `last_import_at = null` (e.g. pre-`add-federation-health-exposition` backend, or first-import not yet completed) and backend B reports any non-null timestamp
+- **THEN** the kept feature comes from backend B
+- **AND** the rule applies symmetrically — non-null beats null in either arrival order
+
+#### Scenario: Equal or both-null timestamps tie-break by URL alphabetical
+
+- **WHEN** backends A and B both report identical `last_import_at`, OR both report `null`
+- **THEN** the kept feature comes from whichever backend's URL sorts first lexicographically
+- **AND** swapping the order in `registry.json` does NOT change the winner — the URL string itself is the load-bearing key, not registry position
+
+#### Scenario: Refresh cycle does not flip the winner on stable inputs
+
+- **WHEN** the registry-poll refresh fires and re-fetches `get_meta` and the bbox-tier features from both backends, with neither backend's `last_import_at` having changed
+- **THEN** the same backend remains the winner for every shared `osm_id`
+- **AND** no transient swap is observable in the rendered polygon source
+
+#### Scenario: Refresh cycle flips the winner when one backend imports newer data
+
+- **WHEN** the previously-losing backend's `last_import_at` advances past the previously-winning backend's `last_import_at` between two refresh cycles
+- **THEN** at the next refresh, the winner flips to the now-fresher backend for every shared `osm_id`
+- **AND** the previously-winning feature is removed from the source by `removeFeature` before the new feature is added
+
+#### Scenario: Comparison treats ISO timestamps numerically
+
+- **WHEN** the two competing `last_import_at` values represent the same instant but are serialised in different timezone formats (e.g. `2026-04-25T12:00:00Z` from one backend and `2026-04-25T14:00:00+02:00` from another)
+- **THEN** the comparison declares them equal (as `Date.parse(a) === Date.parse(b)`) and falls through to URL alphabetical
+- **AND** the comparison MUST NOT use lexicographic string compare — that flips the winner non-deterministically based on the chosen TZ format
+
+#### Scenario: Existing-feature age is read from the feature, not the live backends store
+
+- **WHEN** the hub is mid-refresh on backend A — A's `backends`-store entry has *already* been updated to A's new `last_import_at` — and the dedup loop compares A's incoming feature against an existing feature owned by A from the previous cycle
+- **THEN** the existing feature's `_lastImportAt` (frozen at insertion time on the previous cycle) is used as the comparator, NOT the live `backends.find(b => b.url === url)?.lastImportAt` value
+- **AND** the dedup outcome is independent of the order in which the backends-store update and the dedup loop run within a single refresh
+
+#### Scenario: Single backend per `osm_id` is a no-op
+
+- **WHEN** backend A returns a feature with `osm_id = 12345` and no other backend covers that playground
+- **THEN** the feature is added to the source as-is
+- **AND** no compare or remove is performed
+- **AND** the feature carries `_backendUrl` and `_lastImportAt` from backend A
+
+#### Scenario: Cluster tier is not affected
+
+- **WHEN** the dedup runs at the polygon tier (zoom > `clusterMaxZoom`)
+- **THEN** the cluster tier's Supercluster kd-tree merge (existing behaviour from this same capability) operates independently — it merges by spatial proximity on `[lon, lat]`, not by `osm_id`
+- **AND** the polygon-tier dedup does NOT touch the cluster tier's `VectorSource`

--- a/openspec/changes/add-cross-backend-osm-id-dedup/tasks.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/tasks.md
@@ -1,0 +1,51 @@
+## 1. Frontend — dedup at VectorSource insertion time
+
+- [ ] 1.1 In `app/src/hub/registry.js` `loadBackend()`, after the existing `vectorSource.removeFeatures(stale)` step, build a `Map<osm_id, feature>` over the source's remaining features. Do this **once** per backend join, not per incoming feature — the rejected PR #295's per-feature `vectorSource.getFeatures().find(...)` was O(N × M).
+- [ ] 1.2 Iterate the incoming features. For each, look up by `osm_id` in the map:
+    - **Absent** → push to `toAdd`.
+    - **Present** → invoke a pure `pickWinner(existingFeature, incomingFeature, incomingBackendUrl, incomingLastImportAt)` helper that returns `{ winner: 'existing' | 'incoming' }`. Implementation rules per design D2:
+        1. Both have `last_import_at` → newer wins (compare via `Date.parse(a) - Date.parse(b)`, NOT lexicographic string compare).
+        2. Exactly one is null → the non-null wins.
+        3. Both null OR equal → URL alphabetical (lower string wins).
+    - If `pickWinner` returns `'incoming'` → `vectorSource.removeFeature(existing)` and push incoming to `toAdd`. If it returns `'existing'` → drop incoming silently.
+- [ ] 1.3 Stamp every kept feature with three properties at insertion time:
+    - `_backendUrl` — the backend the feature came from (already present from `add-federated-playground-clustering`).
+    - `_lastImportAt` — **frozen value** of `backend.lastImportAt` at the time of insertion. Subsequent dedup cycles read this from the *feature*, NOT from the live backends store. This is the load-bearing fix for PR #295's silent-drop bug (see design D3).
+    - `_relationId` — `backend.relationId` if present, omit otherwise. No consumer in this change; reserved for future cross-backend disambiguation.
+- [ ] 1.4 After the per-incoming loop completes, call `vectorSource.addFeatures(toAdd)` **once**. Do not addFeature inside the loop — per-feature inserts cause N repaints per backend join (design D7).
+- [ ] 1.5 Log a single `[hub] dedup: replaced osm_id=X (backend=… newer than backend=…)` line per replacement, using the existing console-warning de-dup pattern (`Set` of seen `osm_id`s per session) so a chronic overlap doesn't flood the console.
+- [ ] 1.6 Extract `pickWinner` into a sibling `app/src/hub/dedup.js` module (or inline section) with full JSDoc covering all four `(existingAge, incomingAge)` corner cases — the rejected PR's helper was inline and missed the `(null, present)` and `(equal, equal)` cases.
+
+## 2. Tests
+
+- [ ] 2.1 Add a `pickWinner` unit test (or in-Playwright `page.evaluate` block) covering each of the four corner cases:
+    - existingAge present + incomingAge present + incoming newer → `'incoming'`
+    - existingAge present + incomingAge present + existing newer → `'existing'`
+    - existingAge present + incomingAge null → `'existing'`
+    - existingAge null + incomingAge present → `'incoming'`
+    - both null + URL alphabetical → lower-URL backend wins
+    - equal `last_import_at` + URL alphabetical → lower-URL backend wins
+    - String-lexicographic-trap: same instant in different TZ formats (`+00:00` vs `Z` vs `+02:00`) — winner determined by `Date.parse`, not by raw string compare.
+- [ ] 2.2 Add `tests/hub-dedup.spec.js` (or extend `tests/hub-multi-backend.spec.js`) with an end-to-end Playwright fixture: two backends with overlapping `osm_id` (registry stubs both reach the same playground), assert the source contains exactly one feature with that osm_id after the cluster→polygon transition. The winning feature's `_backendUrl` matches the backend that should have won by the merge rule.
+- [ ] 2.3 Refresh stability: trigger a registry-poll refresh, assert the winner is unchanged (no flicker on stable inputs). Use Playwright route stubs to control timing.
+- [ ] 2.4 Refresh transition: change one backend's stub `last_import_at` to a fresher value, trigger refresh, assert the winner flips deterministically and the previously-winning feature is removed from the source.
+
+## 3. Docs
+
+- [ ] 3.1 In `docs/reference/federation.md`, add a "Cross-backend dedup" subsection: explains overlapping topology is supported, the merge rule (D2 in plain English), the URL-alphabetical tie-break caveat, and the consequence (operator naming choices in `registry.json` affect tie-breaks).
+- [ ] 3.2 Cross-link from `docs/ops/federated-deployment.md` "Verification" section to the new dedup subsection so an operator setting up overlap knows what to expect.
+- [ ] 3.3 If `_relationId` ends up unused after the implementation lands, drop it from the feature property contract (proposal + this tasks file) before merge — don't ship dead state.
+
+## 4. Verification
+
+- [ ] 4.1 Run `make test` — full Playwright suite passes including the new dedup spec.
+- [ ] 4.2 Manual smoke (two-backend dev fixture): `make up` with a registry pointing at both `db` and `db2` backends configured with overlapping bbox; load Hub mode; click on a playground in the overlap region; confirm exactly one popup appears, deterministic across reloads.
+- [ ] 4.3 Manual: trigger a `make import` on the backend that should win the merge (fresher `last_import_at`); verify after the next 5-minute registry poll that the winner remains the same backend (no flicker).
+- [ ] 4.4 Manual: with both backends sharing `last_import_at` (seed fixtures), verify URL-alphabetical tie-break by swapping the registry order and confirming the winner doesn't change (URL string is the load-bearing key, not registry order).
+- [ ] 4.5 Confirm the deep-link path: open a `/#W<osm_id>` link for an overlapping playground; the existing `[deeplink] osm_id X matched 2 backends` log line is replaced by a single deterministic match, or the log line still fires but the selected feature is the merge winner.
+
+## 5. OpenSpec hygiene
+
+- [ ] 5.1 Run `openspec validate add-cross-backend-osm-id-dedup --strict`.
+- [ ] 5.2 On merge, archive this change to `openspec/changes/archive/YYYY-MM-DD-add-cross-backend-osm-id-dedup` and apply the spec delta to `openspec/specs/federated-playground-clustering/spec.md`.
+- [ ] 5.3 Update issue #202: replace the dead `openspec/changes/add-import-timestamps-and-dedup/` reference with this change's path; close on archive.

--- a/openspec/changes/add-cross-backend-osm-id-dedup/tasks.md
+++ b/openspec/changes/add-cross-backend-osm-id-dedup/tasks.md
@@ -1,51 +1,53 @@
-## 1. Frontend — dedup at VectorSource insertion time
+## 1. Frontend — dedup at the polygon-tier `onResult` in `hubOrchestrator.js`
 
-- [ ] 1.1 In `app/src/hub/registry.js` `loadBackend()`, after the existing `vectorSource.removeFeatures(stale)` step, build a `Map<osm_id, feature>` over the source's remaining features. Do this **once** per backend join, not per incoming feature — the rejected PR #295's per-feature `vectorSource.getFeatures().find(...)` was O(N × M).
-- [ ] 1.2 Iterate the incoming features. For each, look up by `osm_id` in the map:
-    - **Absent** → push to `toAdd`.
-    - **Present** → invoke a pure `pickWinner(existingFeature, incomingFeature, incomingBackendUrl, incomingLastImportAt)` helper that returns `{ winner: 'existing' | 'incoming' }`. Implementation rules per design D2:
-        1. Both have `last_import_at` → newer wins (compare via `Date.parse(a) - Date.parse(b)`, NOT lexicographic string compare).
-        2. Exactly one is null → the non-null wins.
-        3. Both null OR equal → URL alphabetical (lower string wins).
-    - If `pickWinner` returns `'incoming'` → `vectorSource.removeFeature(existing)` and push incoming to `toAdd`. If it returns `'existing'` → drop incoming silently.
-- [ ] 1.3 Stamp every kept feature with three properties at insertion time:
-    - `_backendUrl` — the backend the feature came from (already present from `add-federated-playground-clustering`).
-    - `_lastImportAt` — **frozen value** of `backend.lastImportAt` at the time of insertion. Subsequent dedup cycles read this from the *feature*, NOT from the live backends store. This is the load-bearing fix for PR #295's silent-drop bug (see design D3).
-    - `_relationId` — `backend.relationId` if present, omit otherwise. No consumer in this change; reserved for future cross-backend disambiguation.
-- [ ] 1.4 After the per-incoming loop completes, call `vectorSource.addFeatures(toAdd)` **once**. Do not addFeature inside the loop — per-feature inserts cause N repaints per backend join (design D7).
-- [ ] 1.5 Log a single `[hub] dedup: replaced osm_id=X (backend=… newer than backend=…)` line per replacement, using the existing console-warning de-dup pattern (`Set` of seen `osm_id`s per session) so a chronic overlap doesn't flood the console.
-- [ ] 1.6 Extract `pickWinner` into a sibling `app/src/hub/dedup.js` module (or inline section) with full JSDoc covering all four `(existingAge, incomingAge)` corner cases — the rejected PR's helper was inline and missed the `(null, present)` and `(equal, equal)` cases.
+- [ ] 1.1 In `app/src/hub/hubOrchestrator.js` `parsePolygonFeatures(geojson, backendUrl, backend)`, alongside the existing `f.set('_backendUrl', backendUrl)` call, add `f.set('_lastImportAt', backend.lastImportAt ?? null)`. The value is **frozen at parse time** — every dedup cycle reads it from the feature via `feature.get('_lastImportAt')`, never from a live `backends`-store lookup. The frozen-value property is decoupled-from-future-store-mutations design (see design D3) — even though the current store uses immutable patches and a live read would be safe today, the contract is defensive against any future mutation refactor.
+- [ ] 1.2 In the polygon-tier `onResult` handler (currently at `hubOrchestrator.js` `polygonSource.addFeatures(features)` after `const features = parsePolygonFeatures(entry.value, entry.backendUrl, backend)`), maintain a per-`orchestrate()`-call `Map<osm_id, Feature>` (e.g. `polyByOsmId`). Reset to a fresh empty `Map` at the top of each `orchestrate()` call.
+- [ ] 1.3 Walk the incoming features once. For each, look up by `osm_id` in `polyByOsmId`:
+    - **Absent** → push to `toAdd`; set `polyByOsmId.set(osmId, incoming)`.
+    - **Present** → invoke `pickWinner(existing, incoming)` (extract into a sibling pure module, e.g. `app/src/hub/osmIdDedup.js`, exporting `pickWinner` and ideally `applyDedup({incomingFeatures, polyByOsmId})` returning `{toAdd, toRemove}`). The merge rule (verbatim from design D2):
+        - Define `parseable(v)` ≡ `v != null && Number.isFinite(Date.parse(v))`.
+        - 1. `parseable(a) && parseable(b)` → newer wins (`Date.parse(a) - Date.parse(b)`, numeric).
+        - 2. `parseable(a)` XOR `parseable(b)` → the parseable one wins.
+        - 3. Otherwise → URL alphabetical via raw JS `<` on `_backendUrl` (no case-folding, no normalisation).
+    - If `pickWinner` returns `'incoming'` → push existing to `toRemove`, push incoming to `toAdd`, update `polyByOsmId.set(osmId, incoming)`. If `'existing'` → drop incoming.
+- [ ] 1.4 After the loop, batch the source mutations: `polygonSource.removeFeatures(toRemove)` (single call) followed by `polygonSource.addFeatures(toAdd)` (single call). Per-feature `removeFeature`/`addFeature` calls each fire a synchronous `change` event — the batch form caps repaints at two per arrival regardless of dedup volume (design D7).
+- [ ] 1.5 In `app/src/hub/registry.js`, extend the initial backend shape with `lastImportAt: null` next to the existing `version`, `region`, `bbox`, `playgroundCount`, `completeness` fields. In `loadBackend()`, after the existing completeness extraction, write `patch.lastImportAt = meta.last_import_at ?? null`. Use `meta.last_import_at` (snake_case wire format from `add-federation-health-exposition`) → `lastImportAt` (camelCase JS field). This is the only `registry.js` change.
+- [ ] 1.6 Optional: log a single `[hub] dedup: replaced osm_id=X (backend=… newer than backend=…)` per replacement, de-duplicated per `osm_id` per session via a `Set` so a chronic overlap doesn't flood the console.
 
 ## 2. Tests
 
-- [ ] 2.1 Add a `pickWinner` unit test (or in-Playwright `page.evaluate` block) covering each of the four corner cases:
-    - existingAge present + incomingAge present + incoming newer → `'incoming'`
-    - existingAge present + incomingAge present + existing newer → `'existing'`
-    - existingAge present + incomingAge null → `'existing'`
-    - existingAge null + incomingAge present → `'incoming'`
-    - both null + URL alphabetical → lower-URL backend wins
-    - equal `last_import_at` + URL alphabetical → lower-URL backend wins
-    - String-lexicographic-trap: same instant in different TZ formats (`+00:00` vs `Z` vs `+02:00`) — winner determined by `Date.parse`, not by raw string compare.
-- [ ] 2.2 Add `tests/hub-dedup.spec.js` (or extend `tests/hub-multi-backend.spec.js`) with an end-to-end Playwright fixture: two backends with overlapping `osm_id` (registry stubs both reach the same playground), assert the source contains exactly one feature with that osm_id after the cluster→polygon transition. The winning feature's `_backendUrl` matches the backend that should have won by the merge rule.
-- [ ] 2.3 Refresh stability: trigger a registry-poll refresh, assert the winner is unchanged (no flicker on stable inputs). Use Playwright route stubs to control timing.
-- [ ] 2.4 Refresh transition: change one backend's stub `last_import_at` to a fresher value, trigger refresh, assert the winner flips deterministically and the previously-winning feature is removed from the source.
+- [ ] 2.1 Unit test for `pickWinner` covering the merge rule (one assertion per row):
+    - Both parseable + incoming newer → `'incoming'`.
+    - Both parseable + existing newer → `'existing'`.
+    - Both parseable + same instant in different TZ formats (`2026-04-25T12:00:00Z` vs `2026-04-25T14:00:00+02:00`) → tie → URL alphabetical.
+    - Existing parseable + incoming `null` → `'existing'`.
+    - Existing parseable + incoming `undefined` → `'existing'` (treated identically to null).
+    - Existing parseable + incoming malformed string (`Date.parse → NaN`) → `'existing'`.
+    - Existing `null` + incoming parseable → `'incoming'`.
+    - Both `null` + lower-URL existing → `'existing'`.
+    - Both `null` + lower-URL incoming → `'incoming'`.
+    - Both `null` + identical `_backendUrl` (impossible in practice, but specify) → `'existing'` (incoming dropped — first-write-wins on identity collision).
+- [ ] 2.2 Add `tests/hub-osm-id-dedup.spec.js` with an end-to-end Playwright fixture: two backends with overlapping `osm_id`, both reachable, distinct `last_import_at`. Assert the polygon source contains exactly one feature with that `osm_id` after the cluster→polygon transition, and its `_backendUrl` matches the freshness-winning backend. Use Playwright `page.evaluate` against a temporarily-exposed `window.__polygonSource` (gated behind `import.meta.env.DEV` if necessary) or a data-attribute hook on the map element.
+- [ ] 2.3 Refresh stability: trigger a registry-poll refresh with both backends' stubs unchanged, assert the winner backend is unchanged. (Subsumes the "no flip on stable inputs" spec scenario.)
+- [ ] 2.4 Refresh transition: change one backend's stub `last_import_at` to a fresher value, trigger refresh, assert the winner flips deterministically.
+- [ ] 2.5 **Degraded-mode E2E**: stub both backends with `last_import_at = null` (mimics pre-`add-federation-health-exposition` deployments). Assert URL-alphabetical winner, no console errors, no `NaN` in feature properties. This is the contract that lets this change ship before FHE.
+- [ ] 2.6 Backward compat: stub one backend without the `last_import_at` field at all (legacy `get_meta` shape). Assert the missing field is treated as `null` (defaulted in `registry.js` 1.5) and dedup still produces a deterministic winner.
 
 ## 3. Docs
 
-- [ ] 3.1 In `docs/reference/federation.md`, add a "Cross-backend dedup" subsection: explains overlapping topology is supported, the merge rule (D2 in plain English), the URL-alphabetical tie-break caveat, and the consequence (operator naming choices in `registry.json` affect tie-breaks).
+- [ ] 3.1 In `docs/reference/federation.md`, add a "Cross-backend dedup" subsection: explains overlapping topology is supported, restates the merge rule in plain English, names the URL-alphabetical caveat (case-sensitive, raw string compare — operator naming choices in `registry.json` affect ties), and notes the dependency on `add-federation-health-exposition` for freshness-aware behaviour.
 - [ ] 3.2 Cross-link from `docs/ops/federated-deployment.md` "Verification" section to the new dedup subsection so an operator setting up overlap knows what to expect.
-- [ ] 3.3 If `_relationId` ends up unused after the implementation lands, drop it from the feature property contract (proposal + this tasks file) before merge — don't ship dead state.
 
 ## 4. Verification
 
-- [ ] 4.1 Run `make test` — full Playwright suite passes including the new dedup spec.
-- [ ] 4.2 Manual smoke (two-backend dev fixture): `make up` with a registry pointing at both `db` and `db2` backends configured with overlapping bbox; load Hub mode; click on a playground in the overlap region; confirm exactly one popup appears, deterministic across reloads.
-- [ ] 4.3 Manual: trigger a `make import` on the backend that should win the merge (fresher `last_import_at`); verify after the next 5-minute registry poll that the winner remains the same backend (no flicker).
-- [ ] 4.4 Manual: with both backends sharing `last_import_at` (seed fixtures), verify URL-alphabetical tie-break by swapping the registry order and confirming the winner doesn't change (URL string is the load-bearing key, not registry order).
-- [ ] 4.5 Confirm the deep-link path: open a `/#W<osm_id>` link for an overlapping playground; the existing `[deeplink] osm_id X matched 2 backends` log line is replaced by a single deterministic match, or the log line still fires but the selected feature is the merge winner.
+- [ ] 4.1 Run `make test` — full Playwright suite passes (existing tests + new 2.2–2.6).
+- [ ] 4.2 Manual smoke (two-backend dev fixture): `make up` with a registry pointing at both `db` and `db2` backends configured with overlapping bbox; load Hub mode; click on a playground in the overlap region; confirm exactly one popup appears and the source has one feature for that `osm_id`.
+- [ ] 4.3 Manual: trigger a `make import` on the backend that should win the merge (fresher `last_import_at`); verify after the next 5-minute registry poll that the winner is now that backend.
+- [ ] 4.4 Manual: with both backends sharing `last_import_at` (seed fixtures), verify URL-alphabetical tie-break by swapping the registry-list order and confirming the winner doesn't change (URL string is the load-bearing key).
+- [ ] 4.5 Confirm the deep-link path: open a `/#W<osm_id>` link for an overlapping playground; the existing `[deeplink] osm_id X matched 2 backends` log line either disappears (dedup made the match unique) OR still fires once but the selected feature is the merge winner.
 
 ## 5. OpenSpec hygiene
 
 - [ ] 5.1 Run `openspec validate add-cross-backend-osm-id-dedup --strict`.
 - [ ] 5.2 On merge, archive this change to `openspec/changes/archive/YYYY-MM-DD-add-cross-backend-osm-id-dedup` and apply the spec delta to `openspec/specs/federated-playground-clustering/spec.md`.
-- [ ] 5.3 Update issue #202: replace the dead `openspec/changes/add-import-timestamps-and-dedup/` reference with this change's path; close on archive.
+- [ ] 5.3 Update issue #202: replace the dead `openspec/changes/add-import-timestamps-and-dedup/` reference with this change's path; close once the implementation PR (#302 or successor) lands.


### PR DESCRIPTION
## Summary

Draft the OpenSpec change that issue #202 referenced as `openspec/changes/add-import-timestamps-and-dedup/` but which was never written before PR #295 attempted an implementation. PR #295 was rejected in code review for (a) using table/field names that conflict with the in-flight `add-federation-health-exposition`, and (b) shipping multiple correctness bugs in the dedup loop (lexicographic ISO compare, O(N²) lookup, stale-removal-then-compare race, missing branches).

This is doc-only — it sets the contract that a clean re-implementation must satisfy. The timestamp half of the original issue is owned by `add-federation-health-exposition` (#194); this change is **strictly the dedup half**, renamed to reflect that.

## Key decisions

- **Polygon-tier dedup at VectorSource insertion time** (not at fetch time) — pairs with the existing per-backend stale-removal step in `loadBackend()`.
- **Numeric `Date.parse` comparison**, not lexicographic string compare on the wire-format ISO timestamp.
- **Frozen `_lastImportAt`** stamped on each kept feature — explicit fix for the silent-drop bug that surfaced in the rejected PR (reading the live, mid-mutation backends-store entry).
- **O(N+M) per backend join** via pre-indexed `Map<osm_id, feature>`.
- **URL-alphabetical tie-break** on equal/null timestamps for absolute determinism.
- **Degraded-mode fallback**: the change can ship before `add-federation-health-exposition` lands; until `last_import_at` is available everywhere, dedup falls through to URL-alphabetical (deterministic but not freshness-aware) and the contract still holds.

## Capability scope

Extends `federated-playground-clustering` (already archived 2026-04-26). Same umbrella as bbox routing, fan-out, and cluster-tier Supercluster merge — all federation-side hub behaviour.

## Test plan

- [x] `openspec validate add-cross-backend-osm-id-dedup --strict` clean.
- [ ] No code touched yet — implementation follows in a separate PR against this proposal.

## Related

- Issue #202 — the original tracking issue (replace its dead `add-import-timestamps-and-dedup` reference).
- PR #295 — rejected in code review; this proposal is the contract a re-implementation must follow.
- #194 / `add-federation-health-exposition` — the upstream that ships `last_import_at` on `get_meta`.

Refs #202

Assisted-by: ClaudeCode:claude-opus-4-7