### PR TITLE
feat(hub): cross-backend osm_id deduplication in polygon tier (#202)

### DIFF
--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -12,6 +12,7 @@
   import { attachHubOrchestrator } from './hubOrchestrator.js';
   import { mapStore } from '../stores/map.js';
   import { clusterMaxZoom } from '../lib/config.js';
+  import * as osmIdDedup from './osmIdDedup.js';
 
   // Generic OSM wiki link for the contribution modal (hub is region-agnostic).
   const HUB_WIKI_URL = 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
@@ -25,6 +26,20 @@
   const clusterSource = new VectorSource();
   const macroSource   = new VectorSource();
   let detachOrchestrator = null;
+
+  // Test hooks. Used by the Playwright suite to make direct assertions
+  // about polygon-source contents and to unit-test the pure dedup helpers.
+  // The footprint is two property assignments + a few KB of bundled
+  // helpers — small enough to ship unconditionally rather than gate on a
+  // build-time flag. See tests/osmIdDedup.spec.js + tests/hub-osm-id-dedup.spec.js.
+  // Namespaced under `__spieli` so it does not collide with anything else.
+  if (typeof window !== 'undefined') {
+    window.__spieli = window.__spieli ?? {};
+    window.__spieli.polygonSource = polygonSource;
+    window.__spieli.clusterSource = clusterSource;
+    window.__spieli.macroSource   = macroSource;
+    window.__spieli.osmIdDedup    = osmIdDedup;
+  }
 
   const {
     backends,

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -41,6 +41,7 @@ import { activeTierStore } from '../stores/tier.js';
 import { hubLoadingStore } from '../stores/hubLoading.js';
 import { selectBackends } from './bboxRouter.js';
 import { filterHealthy } from './federationHealth.js';
+import { applyDedup } from './osmIdDedup.js';
 import { fanOut } from './fanOut.js';
 import { debounce } from '../lib/utils.js';
 
@@ -159,6 +160,10 @@ export function attachHubOrchestrator({
     // arrival re-runs the Supercluster pipeline and clears+adds the full
     // re-rendered set, so a separate latch would be dead.
     let polygonFirstArrival = true;
+    // Per-orchestrate-call dedup index: osm_id (string) → winning OL Feature.
+    // Reset on first arrival together with the source clear so stale winners
+    // from the previous moveend don't influence the new fan-out.
+    const polyByOsmId = new Map();
 
     if (tier === 'cluster') {
       const z = Math.floor(zoom);
@@ -247,11 +252,14 @@ export function attachHubOrchestrator({
           if (polygonFirstArrival) {
             polygonFirstArrival = false;
             polygonSource.clear();
+            polyByOsmId.clear();
           }
           if (entry.ok) {
             const backend = backendByUrl.get(entry.backendUrl);
             const features = parsePolygonFeatures(entry.value, entry.backendUrl, backend);
-            polygonSource.addFeatures(features);
+            const { toAdd, toRemove } = applyDedup(features, polyByOsmId);
+            for (const f of toRemove) polygonSource.removeFeature(f);
+            polygonSource.addFeatures(toAdd);
           } else if (isNotFound(entry.error)) {
             markBackendLegacy(entry.backendUrl);
           }
@@ -383,7 +391,8 @@ function parsePolygonFeatures(geojson, backendUrl, backend) {
     featureProjection: 'EPSG:3857',
   });
   features.forEach(f => {
-    f.set('_backendUrl', backendUrl);
+    f.set('_backendUrl',     backendUrl);
+    f.set('_lastImportAt',  backend?.lastImportAt ?? null);
     if (backend?.slug) f.set('_backendSlug', backend.slug);
   });
   return features;

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -258,7 +258,7 @@ export function attachHubOrchestrator({
             const backend = backendByUrl.get(entry.backendUrl);
             const features = parsePolygonFeatures(entry.value, entry.backendUrl, backend);
             const { toAdd, toRemove } = applyDedup(features, polyByOsmId);
-            for (const f of toRemove) polygonSource.removeFeature(f);
+            polygonSource.removeFeatures(toRemove);
             polygonSource.addFeatures(toAdd);
           } else if (isNotFound(entry.error)) {
             markBackendLegacy(entry.backendUrl);

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -161,8 +161,9 @@ export function attachHubOrchestrator({
     // re-rendered set, so a separate latch would be dead.
     let polygonFirstArrival = true;
     // Per-orchestrate-call dedup index: osm_id (string) → winning OL Feature.
-    // Reset on first arrival together with the source clear so stale winners
-    // from the previous moveend don't influence the new fan-out.
+    // Created fresh per orchestrate() call so winners from the previous
+    // moveend don't influence the new fan-out — no explicit .clear() needed
+    // on first arrival because the const above is already the empty Map.
     const polyByOsmId = new Map();
 
     if (tier === 'cluster') {
@@ -252,7 +253,8 @@ export function attachHubOrchestrator({
           if (polygonFirstArrival) {
             polygonFirstArrival = false;
             polygonSource.clear();
-            polyByOsmId.clear();
+            // polyByOsmId is already empty (declared `new Map()` per orchestrate()
+            // call) — no .clear() needed.
           }
           if (entry.ok) {
             const backend = backendByUrl.get(entry.backendUrl);
@@ -391,8 +393,8 @@ function parsePolygonFeatures(geojson, backendUrl, backend) {
     featureProjection: 'EPSG:3857',
   });
   features.forEach(f => {
-    f.set('_backendUrl',     backendUrl);
-    f.set('_lastImportAt',  backend?.lastImportAt ?? null);
+    f.set('_backendUrl', backendUrl);
+    f.set('_lastImportAt', backend?.lastImportAt ?? null);
     if (backend?.slug) f.set('_backendSlug', backend.slug);
   });
   return features;

--- a/app/src/hub/osmIdDedup.js
+++ b/app/src/hub/osmIdDedup.js
@@ -6,10 +6,11 @@
 // backend ran the most recent import.
 //
 // Tie-breaking rules (in order):
-//   1. Both have `_lastImportAt` → newer timestamp wins (Date.parse numeric compare).
-//   2. One has `_lastImportAt`, the other null → the one with data wins.
-//   3. Both null (pre-#301 backends, degraded mode) → URL-alphabetical, so the
-//      result is at least deterministic and doesn't depend on arrival order.
+//   1. One timestamp is parseable, the other is null or unparseable → parseable wins.
+//   2. Both parseable and strictly different → newer wins.
+//   3. Both parseable and equal (including same instant in different TZ formats),
+//      or both null/unparseable → URL-alphabetical (raw JS < on _backendUrl,
+//      no case-folding, no normalisation) so the result is deterministic.
 //
 // Features without an `osm_id` property (shouldn't happen in practice) are
 // always added — no dedup attempted.
@@ -26,16 +27,19 @@ export function dedupWinner(a, b) {
   const ta = a.get('_lastImportAt'); // ISO string | null
   const tb = b.get('_lastImportAt');
 
-  if (ta == null && tb == null) {
-    // Degraded mode: neither backend has shipped #301 yet. Fall back to
-    // URL-alphabetical so the result is consistent across moveends.
-    return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
-  }
-  if (ta == null) return b; // b has freshness data, a doesn't
-  if (tb == null) return a; // a has freshness data, b doesn't
-  // Both have timestamps — newer import wins (≥ so equal timestamps keep b,
-  // i.e. last arrival wins, matching the progressive-render append order).
-  return Date.parse(tb) >= Date.parse(ta) ? b : a;
+  const pa = ta != null && Number.isFinite(Date.parse(ta));
+  const pb = tb != null && Number.isFinite(Date.parse(tb));
+
+  if (!pa && !pb) return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
+  if (!pa) return b;
+  if (!pb) return a;
+
+  const da = Date.parse(ta);
+  const db = Date.parse(tb);
+  if (db > da) return b;
+  if (da > db) return a;
+  // tie (equal or same instant in different TZ formats) → URL alphabetical
+  return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
 }
 
 /**

--- a/app/src/hub/osmIdDedup.js
+++ b/app/src/hub/osmIdDedup.js
@@ -11,36 +11,45 @@
 //   2. Exactly one is parseable → the parseable one wins.
 //   3. Otherwise (both unparseable, or equal-numeric — e.g. same instant
 //      emitted in different ISO TZ formats) → URL alphabetical:
-//        - prefer the side with a non-empty `_backendUrl` over one missing it
-//        - identity collision (same `_backendUrl`) → existing wins (first-write)
+//        - prefer the side with a non-empty `_backendUrl` over one missing
+//          it (defensive — post-fan-out features are always stamped, but
+//          this guards against any future code path that injects features
+//          via a different code path)
+//        - identity collision (same `_backendUrl`) → existing wins
+//          (first-write — sanctioned by spec task 2.1)
 //        - else raw JS `<` compare on the unmodified URL string (no
 //          case-folding, no scheme/trailing-slash normalisation)
 //
-// "Parseable" means the value is a string matching the ISO-8601 date+time
-// shape (`YYYY-MM-DDTHH:MM…`) AND `Date.parse()` returns a finite number.
-// The shape regex rejects engine-dependent partial inputs like `"2026"` or
-// `"2026-01"` that V8's `Date.parse` happens to accept as Jan 1 of that
-// year — those are not values any well-behaved Postgres `timestamptz`
-// would emit, and accepting them risks letting a malformed timestamp
-// silently win against a valid one from a more recent date.
+// "Parseable" matches the spec's `parseable(v) ≡ v != null &&
+// Number.isFinite(Date.parse(v))` predicate exactly — no shape gate.
+// PostgreSQL `timestamptz` serialised through PostgREST always emits an
+// ISO-8601 date+time, but partial forms like `"2026"` or `"2026-04-25"`
+// (date-only) are accepted by V8's `Date.parse` and would also be treated
+// as parseable here; we trust the upstream wire format rather than gating
+// on a regex that disagrees with valid Postgres outputs (e.g. the
+// space-separated form `"2026-04-25 12:00:00+00"` that some
+// PostgREST configurations emit).
 //
 // Features without an `osm_id` property (shouldn't happen in practice) are
 // always added — no dedup attempted.
 
-const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
-
-function isParseableTimestamp(v) {
-  return typeof v === 'string'
-    && ISO_DATETIME_RE.test(v)
-    && Number.isFinite(Date.parse(v));
+/**
+ * Test whether a `_lastImportAt` value is parseable into a valid Date.
+ * Returns `{ ok, ms }` where `ms` is the parsed numeric (avoids re-parsing
+ * in `dedupWinner`).
+ */
+function parseTimestamp(v) {
+  if (v == null) return { ok: false, ms: NaN };
+  const ms = Date.parse(v);
+  return { ok: Number.isFinite(ms), ms };
 }
 
 function urlAlphaWinner(a, b) {
   const aUrl = a.get('_backendUrl') ?? '';
   const bUrl = b.get('_backendUrl') ?? '';
   // When one side has no _backendUrl (shouldn't happen post-fan-out, but
-  // could during a transient state), prefer the side with a real URL —
-  // never let an unstamped feature beat a stamped one.
+  // defensive against any future injection path), prefer the side with a
+  // real URL — never let an unstamped feature beat a stamped one.
   if (aUrl !== '' && bUrl === '') return a;
   if (aUrl === '' && bUrl !== '') return b;
   // Identity collision: same backend serving the same osm_id twice in one
@@ -59,24 +68,19 @@ function urlAlphaWinner(a, b) {
  * @returns {import('ol/Feature.js').default}
  */
 export function dedupWinner(a, b) {
-  const ta = a.get('_lastImportAt'); // ISO string | null | undefined
-  const tb = b.get('_lastImportAt');
-
-  const pa = isParseableTimestamp(ta);
-  const pb = isParseableTimestamp(tb);
+  const ta = parseTimestamp(a.get('_lastImportAt'));
+  const tb = parseTimestamp(b.get('_lastImportAt'));
 
   // Step 1: both parseable, strictly different → newer wins.
-  if (pa && pb) {
-    const da = Date.parse(ta);
-    const db = Date.parse(tb);
-    if (db > da) return b;
-    if (da > db) return a;
+  if (ta.ok && tb.ok) {
+    if (tb.ms > ta.ms) return b;
+    if (ta.ms > tb.ms) return a;
     // equal-numeric (e.g. same instant in different TZ formats) → step 3
     return urlAlphaWinner(a, b);
   }
   // Step 2: exactly one parseable → it wins.
-  if (pa) return a;
-  if (pb) return b;
+  if (ta.ok) return a;
+  if (tb.ok) return b;
   // Step 3: both unparseable → URL alphabetical.
   return urlAlphaWinner(a, b);
 }

--- a/app/src/hub/osmIdDedup.js
+++ b/app/src/hub/osmIdDedup.js
@@ -1,0 +1,79 @@
+// Cross-backend osm_id deduplication for the polygon tier.
+//
+// When two backends serve the same playground (same osm_id, e.g. a region
+// boundary runs through a park), the polygon source would otherwise contain
+// two overlapping features. This module keeps exactly one: the feature whose
+// backend ran the most recent import.
+//
+// Tie-breaking rules (in order):
+//   1. Both have `_lastImportAt` → newer timestamp wins (Date.parse numeric compare).
+//   2. One has `_lastImportAt`, the other null → the one with data wins.
+//   3. Both null (pre-#301 backends, degraded mode) → URL-alphabetical, so the
+//      result is at least deterministic and doesn't depend on arrival order.
+//
+// Features without an `osm_id` property (shouldn't happen in practice) are
+// always added — no dedup attempted.
+
+/**
+ * Given two OL Features for the same osm_id, return the one that should
+ * survive. Pure function — no side effects.
+ *
+ * @param {import('ol/Feature.js').default} a
+ * @param {import('ol/Feature.js').default} b
+ * @returns {import('ol/Feature.js').default}
+ */
+export function dedupWinner(a, b) {
+  const ta = a.get('_lastImportAt'); // ISO string | null
+  const tb = b.get('_lastImportAt');
+
+  if (ta == null && tb == null) {
+    // Degraded mode: neither backend has shipped #301 yet. Fall back to
+    // URL-alphabetical so the result is consistent across moveends.
+    return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
+  }
+  if (ta == null) return b; // b has freshness data, a doesn't
+  if (tb == null) return a; // a has freshness data, b doesn't
+  // Both have timestamps — newer import wins (≥ so equal timestamps keep b,
+  // i.e. last arrival wins, matching the progressive-render append order).
+  return Date.parse(tb) >= Date.parse(ta) ? b : a;
+}
+
+/**
+ * Merge an incoming batch of features into `dedupMap`, updating the map in
+ * place and returning which OL Features to add to / remove from the source.
+ *
+ * @param {import('ol/Feature.js').default[]} incoming
+ * @param {Map<string, import('ol/Feature.js').default>} dedupMap
+ *   Caller-owned map of osm_id (string) → current winning OL Feature.
+ *   Modified in place.
+ * @returns {{ toAdd: import('ol/Feature.js').default[], toRemove: import('ol/Feature.js').default[] }}
+ */
+export function applyDedup(incoming, dedupMap) {
+  const toAdd    = [];
+  const toRemove = [];
+
+  for (const f of incoming) {
+    const osmId = f.get('osm_id');
+    if (osmId == null) {
+      toAdd.push(f);
+      continue;
+    }
+    const key      = String(osmId);
+    const existing = dedupMap.get(key);
+    if (!existing) {
+      dedupMap.set(key, f);
+      toAdd.push(f);
+    } else {
+      const winner = dedupWinner(existing, f);
+      if (winner === f) {
+        // Incoming beats the current winner — swap
+        dedupMap.set(key, f);
+        toRemove.push(existing);
+        toAdd.push(f);
+      }
+      // else: existing still wins, incoming is silently dropped
+    }
+  }
+
+  return { toAdd, toRemove };
+}

--- a/app/src/hub/osmIdDedup.js
+++ b/app/src/hub/osmIdDedup.js
@@ -5,15 +5,50 @@
 // two overlapping features. This module keeps exactly one: the feature whose
 // backend ran the most recent import.
 //
-// Tie-breaking rules (in order):
-//   1. One timestamp is parseable, the other is null or unparseable → parseable wins.
-//   2. Both parseable and strictly different → newer wins.
-//   3. Both parseable and equal (including same instant in different TZ formats),
-//      or both null/unparseable → URL-alphabetical (raw JS < on _backendUrl,
-//      no case-folding, no normalisation) so the result is deterministic.
+// Tie-breaking rules (priority order, matching `add-cross-backend-osm-id-dedup`
+// design D2):
+//   1. Both timestamps parseable, strictly different → newer wins.
+//   2. Exactly one is parseable → the parseable one wins.
+//   3. Otherwise (both unparseable, or equal-numeric — e.g. same instant
+//      emitted in different ISO TZ formats) → URL alphabetical:
+//        - prefer the side with a non-empty `_backendUrl` over one missing it
+//        - identity collision (same `_backendUrl`) → existing wins (first-write)
+//        - else raw JS `<` compare on the unmodified URL string (no
+//          case-folding, no scheme/trailing-slash normalisation)
+//
+// "Parseable" means the value is a string matching the ISO-8601 date+time
+// shape (`YYYY-MM-DDTHH:MM…`) AND `Date.parse()` returns a finite number.
+// The shape regex rejects engine-dependent partial inputs like `"2026"` or
+// `"2026-01"` that V8's `Date.parse` happens to accept as Jan 1 of that
+// year — those are not values any well-behaved Postgres `timestamptz`
+// would emit, and accepting them risks letting a malformed timestamp
+// silently win against a valid one from a more recent date.
 //
 // Features without an `osm_id` property (shouldn't happen in practice) are
 // always added — no dedup attempted.
+
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+function isParseableTimestamp(v) {
+  return typeof v === 'string'
+    && ISO_DATETIME_RE.test(v)
+    && Number.isFinite(Date.parse(v));
+}
+
+function urlAlphaWinner(a, b) {
+  const aUrl = a.get('_backendUrl') ?? '';
+  const bUrl = b.get('_backendUrl') ?? '';
+  // When one side has no _backendUrl (shouldn't happen post-fan-out, but
+  // could during a transient state), prefer the side with a real URL —
+  // never let an unstamped feature beat a stamped one.
+  if (aUrl !== '' && bUrl === '') return a;
+  if (aUrl === '' && bUrl !== '') return b;
+  // Identity collision: same backend serving the same osm_id twice in one
+  // batch (osm2pgsql artefact for some multipolygon relations). Existing
+  // wins; the second occurrence is silently dropped.
+  if (aUrl === bUrl) return a;
+  return aUrl < bUrl ? a : b;
+}
 
 /**
  * Given two OL Features for the same osm_id, return the one that should
@@ -24,22 +59,26 @@
  * @returns {import('ol/Feature.js').default}
  */
 export function dedupWinner(a, b) {
-  const ta = a.get('_lastImportAt'); // ISO string | null
+  const ta = a.get('_lastImportAt'); // ISO string | null | undefined
   const tb = b.get('_lastImportAt');
 
-  const pa = ta != null && Number.isFinite(Date.parse(ta));
-  const pb = tb != null && Number.isFinite(Date.parse(tb));
+  const pa = isParseableTimestamp(ta);
+  const pb = isParseableTimestamp(tb);
 
-  if (!pa && !pb) return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
-  if (!pa) return b;
-  if (!pb) return a;
-
-  const da = Date.parse(ta);
-  const db = Date.parse(tb);
-  if (db > da) return b;
-  if (da > db) return a;
-  // tie (equal or same instant in different TZ formats) → URL alphabetical
-  return (a.get('_backendUrl') ?? '') <= (b.get('_backendUrl') ?? '') ? a : b;
+  // Step 1: both parseable, strictly different → newer wins.
+  if (pa && pb) {
+    const da = Date.parse(ta);
+    const db = Date.parse(tb);
+    if (db > da) return b;
+    if (da > db) return a;
+    // equal-numeric (e.g. same instant in different TZ formats) → step 3
+    return urlAlphaWinner(a, b);
+  }
+  // Step 2: exactly one parseable → it wins.
+  if (pa) return a;
+  if (pb) return b;
+  // Step 3: both unparseable → URL alphabetical.
+  return urlAlphaWinner(a, b);
 }
 
 /**
@@ -70,12 +109,12 @@ export function applyDedup(incoming, dedupMap) {
     } else {
       const winner = dedupWinner(existing, f);
       if (winner === f) {
-        // Incoming beats the current winner — swap
+        // Incoming beats the current winner — swap.
         dedupMap.set(key, f);
         toRemove.push(existing);
         toAdd.push(f);
       }
-      // else: existing still wins, incoming is silently dropped
+      // else: existing still wins, incoming is silently dropped.
     }
   }
 

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -104,6 +104,11 @@ export function createRegistry() {
           patch.completeness = hasCompleteness
             ? { complete: meta.complete, partial: meta.partial, missing: meta.missing }
             : null;
+          // ISO timestamp of the backend's last successful import. Null on
+          // pre-#301 backends that don't yet ship api.import_status. Used by
+          // the polygon-tier dedup to pick the fresher copy when two backends
+          // return the same osm_id.
+          patch.lastImportAt = meta.last_import_at ?? null;
           if (!backend.name && patch.region) patch.name = patch.region;
         }
 
@@ -134,6 +139,7 @@ export function createRegistry() {
           bbox:            null,
           playgroundCount: 0,
           completeness:    null, // populated after get_meta lands; see status-shape JSDoc
+          lastImportAt:    null, // from get_meta.last_import_at (#301); used by polygon dedup
         }));
         notify();
 

--- a/tests/hub-osm-id-dedup.spec.js
+++ b/tests/hub-osm-id-dedup.spec.js
@@ -1,26 +1,16 @@
-// Cross-backend osm_id deduplication tests — #202
+// Cross-backend osm_id deduplication — Playwright tests for #202.
 //
-// The polygon tier can receive the same osm_id from two backends when a
-// playground sits on or near a region boundary. Without dedup, two overlapping
-// features land in the polygon source and clicking on either one routes
-// equipment fetches to whichever backend "owns" the feature under the cursor —
-// non-deterministic from the user's perspective.
-//
-// This file covers:
-//   1. Smoke: both backends load and polygon fetches complete without errors
-//      even when every osm_id in the result set overlaps across backends.
-//   2. Fan-out: get_playgrounds_bbox is still issued to both backends — dedup
-//      happens client-side AFTER the data arrives, not before the request.
-//   3. Timestamp-based winner: when backend B has a newer last_import_at, the
-//      deeplink selection of the shared osm_id goes to B for equipment fetches.
-//      (Tested via slug-scoped hash deeplink + get_equipment call tracking —
-//      this exercises the winning backend's _backendUrl being set correctly
-//      on the feature in the polygon source.)
-//
-// What is NOT yet tested (see TODO at the bottom):
-//   - Direct assertion that polygonSource.getFeatures() contains exactly one
-//     entry for the shared osm_id. That needs either a canvas-click or a DOM
-//     hook exposing the source length — neither is currently in the test harness.
+// Closes the test-coverage gaps from the bmad-code-review of PR #302:
+//   - the original "winner by timestamp" test used a slug-scoped deeplink
+//     that bypassed `applyDedup` entirely; this file uses
+//     `window.__spieli.polygonSource` (exposed by `HubApp.svelte`) to
+//     assert the post-merge source contents directly.
+//   - the original smoke test attached `page.on('pageerror')` AFTER
+//     `page.goto` — those handlers are now attached BEFORE navigation.
+//   - the original degraded-mode test verified "no crash" only; this
+//     file asserts the URL-alphabetical winner.
+//   - new: refresh-stability and refresh-flip tests cover the spec
+//     scenarios the original suite did not.
 
 import { test, expect } from '@playwright/test';
 import {
@@ -31,59 +21,88 @@ import {
 
 const SHARED_OSM_ID = 5000;
 
-// Both backends return the same osm_id. Backend B has a newer import.
-function makeFixtures({ lastImportAtA, lastImportAtB } = {}) {
-  const sharedPg = makePlayground({ osmId: SHARED_OSM_ID, name: 'Border Park', lon: 9.675, lat: 50.551 });
+// Helper: count features in `polygonSource` matching an osm_id, plus the
+// winning `_backendUrl` (or null if absent). Reads the test hook attached
+// in HubApp.svelte (`window.__spieli.polygonSource`).
+async function readPolygonSourceFor(page, osmId) {
+  return page.evaluate((id) => {
+    const src = window.__spieli?.polygonSource;
+    if (!src) return { available: false };
+    const all = src.getFeatures().filter(f => String(f.get('osm_id')) === String(id));
+    return {
+      available: true,
+      count: all.length,
+      backendUrls: all.map(f => f.get('_backendUrl') ?? null),
+      lastImportAts: all.map(f => f.get('_lastImportAt') ?? null),
+    };
+  }, osmId);
+}
 
+// `clusterMaxZoom: 0` + `macroMaxZoom: -1` makes the polygon tier active
+// at every zoom — the orchestrator's `tierForZoom` checks macro first
+// (`zoom <= macroMaxZoom`) then cluster (`zoom <= clusterMaxZoom`); a
+// negative macro threshold guarantees neither branch ever matches.
+function polygonOnlyOverrides() {
+  return { clusterMaxZoom: 0, macroMaxZoom: -1 };
+}
+
+function makeFixtures({ lastImportAtA = null, lastImportAtB = null, urlA = '/api-a', urlB = '/api-b' } = {}) {
+  const sharedPg = makePlayground({ osmId: SHARED_OSM_ID, name: 'Border Park', lon: 9.675, lat: 50.551 });
   const instanceA = {
     slug: 'slug-a',
-    url: '/api-a',
+    url: urlA,
     name: 'Backend A',
     playgrounds: { type: 'FeatureCollection', features: [sharedPg] },
     meta: {
       name: 'Region A',
       bbox: [9.6, 50.5, 9.7, 50.6],
       playground_count: 1, complete: 0, partial: 1, missing: 0,
-      last_import_at: lastImportAtA ?? null,
+      last_import_at: lastImportAtA,
     },
   };
-
   const instanceB = {
     slug: 'slug-b',
-    url: '/api-b',
+    url: urlB,
     name: 'Backend B',
     playgrounds: { type: 'FeatureCollection', features: [sharedPg] },
     meta: {
       name: 'Region B',
       bbox: [9.6, 50.5, 9.7, 50.6],
       playground_count: 1, complete: 0, partial: 1, missing: 0,
-      last_import_at: lastImportAtB ?? null,
+      last_import_at: lastImportAtB,
     },
   };
-
   return { instanceA, instanceB };
 }
 
+// Wait until the polygon source has settled with at least `expectedCount`
+// features for the shared osm_id. Avoids flake-prone fixed sleeps.
+async function waitForPolygonCount(page, osmId, expectedCount, timeout = 8000) {
+  await expect.poll(
+    async () => (await readPolygonSourceFor(page, osmId)).count,
+    { timeout, message: `expected ${expectedCount} features for osm_id=${osmId}` }
+  ).toBe(expectedCount);
+}
+
 test.describe('Hub polygon dedup — cross-backend osm_id', () => {
-  test('smoke: polygon tier loads without error when both backends share an osm_id', async ({ page }) => {
+  test('smoke: polygon tier loads without page errors when both backends share an osm_id', async ({ page }) => {
+    // Attach the error listener BEFORE navigation so bootstrap-time errors
+    // (parsePolygonFeatures, applyDedup, OL plumbing) are captured.
+    const errors = [];
+    page.on('pageerror', e => errors.push(e.message));
+
     const { instanceA, instanceB } = makeFixtures();
-    // Force polygon tier by disabling cluster (clusterMaxZoom: 0)
-    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await injectHubConfig(page, polygonOnlyOverrides());
     await stubHubRegistry(page, { instanceA, instanceB });
     await page.goto('/');
 
-    // Pill settles — both backends loaded, no unhandled errors
-    const pill = page.locator('.instance-slot .pill');
-    await expect(pill).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
-
-    // No uncaught errors logged that would indicate a dedup crash
-    const errors = [];
-    page.on('pageerror', e => errors.push(e.message));
-    await page.waitForTimeout(500);
-    expect(errors).toEqual([]);
+    await expect(page.locator('.instance-slot .pill'))
+      .toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    expect(errors, `unexpected page errors: ${errors.join(', ')}`).toEqual([]);
   });
 
-  test('fan-out: get_playgrounds_bbox is called on both backends despite shared osm_id', async ({ page }) => {
+  test('fan-out: get_playgrounds_bbox is issued to both backends despite shared osm_id', async ({ page }) => {
     const { instanceA, instanceB } = makeFixtures();
     const polygonCalls = { a: 0, b: 0 };
     page.on('request', req => {
@@ -93,97 +112,140 @@ test.describe('Hub polygon dedup — cross-backend osm_id', () => {
       if (u.includes('/api-b/')) polygonCalls.b += 1;
     });
 
-    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await injectHubConfig(page, polygonOnlyOverrides());
     await stubHubRegistry(page, { instanceA, instanceB });
     await page.goto('/');
 
-    await expect(page.locator('.instance-slot .pill')).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+    await expect(page.locator('.instance-slot .pill'))
+      .toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
     await expect.poll(() => polygonCalls.a, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
     await expect.poll(() => polygonCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
   });
 
-  test('winner by timestamp: equipment fetched from newer-import backend on slug-scoped deeplink', async ({ page }) => {
-    // Backend B has a newer import → should be the winning backend.
-    // We verify via a slug-scoped deeplink (#slug-b/W5000): it calls
-    // get_playground on B, selects the feature, then fetches equipment from B.
-    // This is the deeplink path — it explicitly names the backend, so it
-    // does NOT directly test the polygon source dedup winner. However, it
-    // verifies that _lastImportAt is correctly stamped and that the winning
-    // backend's equipment endpoint is reachable, which is the user-visible
-    // outcome of the dedup.
-    //
-    // See TODO below for the direct polygon-source assertion.
-    const equipCalls = { a: 0, b: 0 };
-    page.on('request', req => {
-      const u = req.url();
-      if (!u.includes('/rpc/get_equipment')) return;
-      if (u.includes('/api-a/')) equipCalls.a += 1;
-      if (u.includes('/api-b/')) equipCalls.b += 1;
-    });
-
+  test('winner by timestamp: polygon source contains exactly one feature, owned by the fresher backend', async ({ page }) => {
     const { instanceA, instanceB } = makeFixtures({
       lastImportAtA: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), // 2 days ago
       lastImportAtB: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),      // 1 hour ago
     });
 
-    await injectHubConfig(page, { clusterMaxZoom: 0 });
-    await stubHubRegistry(page, { instanceA, instanceB });
-    await page.goto(`/#slug-b/W${SHARED_OSM_ID}`);
-
-    const panel = page.locator('aside.info-panel');
-    await expect(panel).toBeVisible({ timeout: 8000 });
-
-    // Equipment should come from backend B (the slug we navigated to)
-    await expect.poll(() => equipCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
-    expect(equipCalls.a).toBe(0);
-  });
-
-  test('degraded mode: both null last_import_at → URL-alphabetical winner, no errors', async ({ page }) => {
-    // Neither backend has shipped #301 yet → degraded mode.
-    // /api-a < /api-b alphabetically → A wins the tie-break.
-    // Test just verifies no crash and both backends are still queried.
-    const { instanceA, instanceB } = makeFixtures({ lastImportAtA: null, lastImportAtB: null });
-    const polygonCalls = { a: 0, b: 0 };
-    page.on('request', req => {
-      const u = req.url();
-      if (!u.includes('/rpc/get_playgrounds_bbox')) return;
-      if (u.includes('/api-a/')) polygonCalls.a += 1;
-      if (u.includes('/api-b/')) polygonCalls.b += 1;
-    });
-
-    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await injectHubConfig(page, polygonOnlyOverrides());
     await stubHubRegistry(page, { instanceA, instanceB });
     await page.goto('/');
 
-    await expect(page.locator('.instance-slot .pill')).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
-    await expect.poll(() => polygonCalls.a, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
-    await expect.poll(() => polygonCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+    await expect(page.locator('.instance-slot .pill'))
+      .toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+
+    const state = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(state.available).toBe(true);
+    expect(state.count).toBe(1);
+    // B is fresher (1 hour vs 2 days) → B wins.
+    expect(state.backendUrls).toEqual(['/api-b']);
+    expect(state.lastImportAts[0]).toBe(instanceB.meta.last_import_at);
+  });
+
+  test('winner by URL alphabetical when timestamps are identical', async ({ page }) => {
+    // Both backends report the same instant in different TZ formats — the
+    // spec scenario "Same instant in different ISO TZ formats counts as a
+    // tie" requires URL-alphabetical to break the tie. /api-a < /api-b.
+    const { instanceA, instanceB } = makeFixtures({
+      lastImportAtA: '2026-04-25T12:00:00Z',
+      lastImportAtB: '2026-04-25T14:00:00+02:00', // same instant
+    });
+
+    await injectHubConfig(page, polygonOnlyOverrides());
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    const state = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(state.backendUrls).toEqual(['/api-a']);
+  });
+
+  test('degraded mode: both null last_import_at → URL-alphabetical winner (/api-a)', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', e => errors.push(e.message));
+
+    const { instanceA, instanceB } = makeFixtures({ lastImportAtA: null, lastImportAtB: null });
+    await injectHubConfig(page, polygonOnlyOverrides());
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    const state = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(state.backendUrls).toEqual(['/api-a']); // /api-a < /api-b
+    expect(state.lastImportAts).toEqual([null]);   // no inferred NaN sentinel
+    expect(errors).toEqual([]);                    // no console errors during degraded path
+  });
+
+  test('legacy backend (no last_import_at field at all) defaults to null and falls back to URL-alpha', async ({ page }) => {
+    // Backend A's get_meta omits the field entirely (pre-FHE shape).
+    // Backend B is also legacy. Should still produce one feature with
+    // /api-a (lower URL) winning.
+    const { instanceA, instanceB } = makeFixtures();
+    delete instanceA.meta.last_import_at;
+    delete instanceB.meta.last_import_at;
+
+    await injectHubConfig(page, polygonOnlyOverrides());
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    const state = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(state.backendUrls).toEqual(['/api-a']);
+  });
+
+  test('refresh stability: re-poll with unchanged inputs keeps the same winner', async ({ page }) => {
+    const { instanceA, instanceB } = makeFixtures({
+      lastImportAtA: '2026-04-25T03:00:00Z',
+      lastImportAtB: '2026-04-26T03:00:00Z', // B is fresher
+    });
+    await injectHubConfig(page, { ...polygonOnlyOverrides(), hubPollInterval: 1 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    const before = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(before.backendUrls).toEqual(['/api-b']);
+
+    // Wait long enough for the 1-s registry poll cadence to fire at least
+    // twice (the orchestrator re-orchestrates on backends-store updates).
+    await page.waitForTimeout(2500);
+
+    const after = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(after.count).toBe(1);
+    expect(after.backendUrls).toEqual(['/api-b']); // B still wins on stable inputs
+  });
+
+  test('refresh transition: bumping a backend\'s last_import_at flips the winner', async ({ page }) => {
+    // Initial state: A is fresher.
+    const { instanceA, instanceB } = makeFixtures({
+      lastImportAtA: '2026-04-26T03:00:00Z',
+      lastImportAtB: '2026-04-25T03:00:00Z',
+    });
+    await injectHubConfig(page, { ...polygonOnlyOverrides(), hubPollInterval: 1 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await waitForPolygonCount(page, SHARED_OSM_ID, 1);
+    const before = await readPolygonSourceFor(page, SHARED_OSM_ID);
+    expect(before.backendUrls).toEqual(['/api-a']);
+
+    // Re-stub B's get_meta so B is now fresher than A. Existing routes
+    // from stubHubRegistry are still active; page.route's most-recently-
+    // registered handler wins, so this override takes precedence.
+    await page.route('**/api-b/rpc/get_meta**', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...instanceB.meta,
+        last_import_at: '2026-04-27T03:00:00Z',
+      }),
+    }));
+
+    await expect.poll(
+      async () => (await readPolygonSourceFor(page, SHARED_OSM_ID)).backendUrls?.[0],
+      { timeout: 10000, message: 'expected winner to flip to /api-b after B\'s last_import_at advances' }
+    ).toBe('/api-b');
   });
 });
-
-// TODO: direct polygon-source assertion
-//
-// The tests above verify behavior through observable side-effects (request
-// counts, UI state) but do not directly assert "polygonSource contains exactly
-// one feature for osm_id=5000, not two."
-//
-// To write that assertion without canvas clicks, two approaches are viable:
-//
-// Option A — DOM data attribute:
-//   In Map.svelte (or HubApp.svelte), write the polygon feature count into a
-//   data attribute after each source update:
-//     mapEl.dataset.polygonFeatureCount = polygonSource.getFeatures().length;
-//   Then the test can assert:
-//     await expect(page.locator('#map')).toHaveAttribute('data-polygon-feature-count', '1');
-//
-// Option B — window test hook:
-//   In dev/test mode, expose the polygon source on window:
-//     if (import.meta.env.DEV) window.__polygonSource = polygonSource;
-//   Then assert via page.evaluate:
-//     const count = await page.evaluate(() =>
-//       window.__polygonSource?.getFeatures().filter(f => f.get('osm_id') === 5000).length
-//     );
-//     expect(count).toBe(1);
-//
-// Once either mechanism is added, the direct assertion can replace the smoke
-// test above.

--- a/tests/hub-osm-id-dedup.spec.js
+++ b/tests/hub-osm-id-dedup.spec.js
@@ -1,0 +1,189 @@
+// Cross-backend osm_id deduplication tests — #202
+//
+// The polygon tier can receive the same osm_id from two backends when a
+// playground sits on or near a region boundary. Without dedup, two overlapping
+// features land in the polygon source and clicking on either one routes
+// equipment fetches to whichever backend "owns" the feature under the cursor —
+// non-deterministic from the user's perspective.
+//
+// This file covers:
+//   1. Smoke: both backends load and polygon fetches complete without errors
+//      even when every osm_id in the result set overlaps across backends.
+//   2. Fan-out: get_playgrounds_bbox is still issued to both backends — dedup
+//      happens client-side AFTER the data arrives, not before the request.
+//   3. Timestamp-based winner: when backend B has a newer last_import_at, the
+//      deeplink selection of the shared osm_id goes to B for equipment fetches.
+//      (Tested via slug-scoped hash deeplink + get_equipment call tracking —
+//      this exercises the winning backend's _backendUrl being set correctly
+//      on the feature in the polygon source.)
+//
+// What is NOT yet tested (see TODO at the bottom):
+//   - Direct assertion that polygonSource.getFeatures() contains exactly one
+//     entry for the shared osm_id. That needs either a canvas-click or a DOM
+//     hook exposing the source length — neither is currently in the test harness.
+
+import { test, expect } from '@playwright/test';
+import {
+  injectHubConfig,
+  stubHubRegistry,
+  makePlayground,
+} from './helpers.js';
+
+const SHARED_OSM_ID = 5000;
+
+// Both backends return the same osm_id. Backend B has a newer import.
+function makeFixtures({ lastImportAtA, lastImportAtB } = {}) {
+  const sharedPg = makePlayground({ osmId: SHARED_OSM_ID, name: 'Border Park', lon: 9.675, lat: 50.551 });
+
+  const instanceA = {
+    slug: 'slug-a',
+    url: '/api-a',
+    name: 'Backend A',
+    playgrounds: { type: 'FeatureCollection', features: [sharedPg] },
+    meta: {
+      name: 'Region A',
+      bbox: [9.6, 50.5, 9.7, 50.6],
+      playground_count: 1, complete: 0, partial: 1, missing: 0,
+      last_import_at: lastImportAtA ?? null,
+    },
+  };
+
+  const instanceB = {
+    slug: 'slug-b',
+    url: '/api-b',
+    name: 'Backend B',
+    playgrounds: { type: 'FeatureCollection', features: [sharedPg] },
+    meta: {
+      name: 'Region B',
+      bbox: [9.6, 50.5, 9.7, 50.6],
+      playground_count: 1, complete: 0, partial: 1, missing: 0,
+      last_import_at: lastImportAtB ?? null,
+    },
+  };
+
+  return { instanceA, instanceB };
+}
+
+test.describe('Hub polygon dedup — cross-backend osm_id', () => {
+  test('smoke: polygon tier loads without error when both backends share an osm_id', async ({ page }) => {
+    const { instanceA, instanceB } = makeFixtures();
+    // Force polygon tier by disabling cluster (clusterMaxZoom: 0)
+    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    // Pill settles — both backends loaded, no unhandled errors
+    const pill = page.locator('.instance-slot .pill');
+    await expect(pill).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+
+    // No uncaught errors logged that would indicate a dedup crash
+    const errors = [];
+    page.on('pageerror', e => errors.push(e.message));
+    await page.waitForTimeout(500);
+    expect(errors).toEqual([]);
+  });
+
+  test('fan-out: get_playgrounds_bbox is called on both backends despite shared osm_id', async ({ page }) => {
+    const { instanceA, instanceB } = makeFixtures();
+    const polygonCalls = { a: 0, b: 0 };
+    page.on('request', req => {
+      const u = req.url();
+      if (!u.includes('/rpc/get_playgrounds_bbox')) return;
+      if (u.includes('/api-a/')) polygonCalls.a += 1;
+      if (u.includes('/api-b/')) polygonCalls.b += 1;
+    });
+
+    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await expect(page.locator('.instance-slot .pill')).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+    await expect.poll(() => polygonCalls.a, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+    await expect.poll(() => polygonCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  test('winner by timestamp: equipment fetched from newer-import backend on slug-scoped deeplink', async ({ page }) => {
+    // Backend B has a newer import → should be the winning backend.
+    // We verify via a slug-scoped deeplink (#slug-b/W5000): it calls
+    // get_playground on B, selects the feature, then fetches equipment from B.
+    // This is the deeplink path — it explicitly names the backend, so it
+    // does NOT directly test the polygon source dedup winner. However, it
+    // verifies that _lastImportAt is correctly stamped and that the winning
+    // backend's equipment endpoint is reachable, which is the user-visible
+    // outcome of the dedup.
+    //
+    // See TODO below for the direct polygon-source assertion.
+    const equipCalls = { a: 0, b: 0 };
+    page.on('request', req => {
+      const u = req.url();
+      if (!u.includes('/rpc/get_equipment')) return;
+      if (u.includes('/api-a/')) equipCalls.a += 1;
+      if (u.includes('/api-b/')) equipCalls.b += 1;
+    });
+
+    const { instanceA, instanceB } = makeFixtures({
+      lastImportAtA: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), // 2 days ago
+      lastImportAtB: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),      // 1 hour ago
+    });
+
+    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto(`/#slug-b/W${SHARED_OSM_ID}`);
+
+    const panel = page.locator('aside.info-panel');
+    await expect(panel).toBeVisible({ timeout: 8000 });
+
+    // Equipment should come from backend B (the slug we navigated to)
+    await expect.poll(() => equipCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+    expect(equipCalls.a).toBe(0);
+  });
+
+  test('degraded mode: both null last_import_at → URL-alphabetical winner, no errors', async ({ page }) => {
+    // Neither backend has shipped #301 yet → degraded mode.
+    // /api-a < /api-b alphabetically → A wins the tie-break.
+    // Test just verifies no crash and both backends are still queried.
+    const { instanceA, instanceB } = makeFixtures({ lastImportAtA: null, lastImportAtB: null });
+    const polygonCalls = { a: 0, b: 0 };
+    page.on('request', req => {
+      const u = req.url();
+      if (!u.includes('/rpc/get_playgrounds_bbox')) return;
+      if (u.includes('/api-a/')) polygonCalls.a += 1;
+      if (u.includes('/api-b/')) polygonCalls.b += 1;
+    });
+
+    await injectHubConfig(page, { clusterMaxZoom: 0 });
+    await stubHubRegistry(page, { instanceA, instanceB });
+    await page.goto('/');
+
+    await expect(page.locator('.instance-slot .pill')).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+    await expect.poll(() => polygonCalls.a, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+    await expect.poll(() => polygonCalls.b, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// TODO: direct polygon-source assertion
+//
+// The tests above verify behavior through observable side-effects (request
+// counts, UI state) but do not directly assert "polygonSource contains exactly
+// one feature for osm_id=5000, not two."
+//
+// To write that assertion without canvas clicks, two approaches are viable:
+//
+// Option A — DOM data attribute:
+//   In Map.svelte (or HubApp.svelte), write the polygon feature count into a
+//   data attribute after each source update:
+//     mapEl.dataset.polygonFeatureCount = polygonSource.getFeatures().length;
+//   Then the test can assert:
+//     await expect(page.locator('#map')).toHaveAttribute('data-polygon-feature-count', '1');
+//
+// Option B — window test hook:
+//   In dev/test mode, expose the polygon source on window:
+//     if (import.meta.env.DEV) window.__polygonSource = polygonSource;
+//   Then assert via page.evaluate:
+//     const count = await page.evaluate(() =>
+//       window.__polygonSource?.getFeatures().filter(f => f.get('osm_id') === 5000).length
+//     );
+//     expect(count).toBe(1);
+//
+// Once either mechanism is added, the direct assertion can replace the smoke
+// test above.

--- a/tests/osmIdDedup.spec.js
+++ b/tests/osmIdDedup.spec.js
@@ -103,15 +103,10 @@ test.describe('osmIdDedup unit — dedupWinner', () => {
     expect(result).toBe('a');
   });
 
-  test('existing parseable + incoming year-only (V8 accepts but spec rejects) → existing', async ({ page }) => {
-    const result = await page.evaluate((mockSrc) => {
-      const f = new Function('return ' + mockSrc)();
-      const a = f({ _lastImportAt: '2025-04-25T03:00:00Z', _backendUrl: '/api-a' });
-      const b = f({ _lastImportAt: '2026',                 _backendUrl: '/api-b' });
-      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
-    }, MOCK_FEATURE);
-    expect(result).toBe('a');
-  });
+  // Note: per spec D2, `parseable(v) ≡ v != null && Number.isFinite(Date.parse(v))`.
+  // V8's `Date.parse('2026')` returns a finite number (Jan 1 2026 UTC) so a
+  // year-only string IS parseable per spec — not a reject case. Kept as a
+  // comment so future readers don't accidentally re-add a regex shape gate.
 
   test('existing null + incoming parseable → incoming', async ({ page }) => {
     const result = await page.evaluate((mockSrc) => {

--- a/tests/osmIdDedup.spec.js
+++ b/tests/osmIdDedup.spec.js
@@ -1,0 +1,250 @@
+// Unit tests for `app/src/hub/osmIdDedup.js` — closes Task 2.1 of the
+// `add-cross-backend-osm-id-dedup` spec.
+//
+// The module is pure (no DOM, no OL imports beyond the typed `set/get`
+// interface), but the project's test runner is Playwright against the
+// production build. Rather than introduce a separate Node unit harness,
+// we boot the hub frontend (HubApp.svelte exposes `window.__spieli.osmIdDedup`)
+// and exercise the module via `page.evaluate`. Mock features are plain
+// objects with a matching `.get(key)` shape — `dedupWinner` and `applyDedup`
+// only depend on that interface.
+//
+// The cases below match the spec's enumerated rows in Task 2.1.
+
+import { test, expect } from '@playwright/test';
+import { injectHubConfig, stubHubRegistry, makePlayground } from './helpers.js';
+
+// Boot the hub once per test — page.evaluate calls in each test reach into
+// the same `window.__spieli.osmIdDedup` namespace.
+async function bootHub({ page }) {
+  await injectHubConfig(page, { clusterMaxZoom: 0, macroMaxZoom: -1 });
+  await stubHubRegistry(page, {
+    instanceA: {
+      slug: 'slug-a', url: '/api-a', name: 'A',
+      playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 1, name: 'A' })] },
+      meta: { name: 'A', bbox: [9.6, 50.5, 9.7, 50.6], playground_count: 1, complete: 0, partial: 1, missing: 0, last_import_at: null },
+    },
+    instanceB: {
+      slug: 'slug-b', url: '/api-b', name: 'B',
+      playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 2, name: 'B' })] },
+      meta: { name: 'B', bbox: [9.6, 50.5, 9.7, 50.6], playground_count: 1, complete: 0, partial: 1, missing: 0, last_import_at: null },
+    },
+  });
+  await page.goto('/');
+  // Wait until HubApp's onMount runs and the hooks are attached.
+  await page.waitForFunction(() => window.__spieli?.osmIdDedup != null, { timeout: 8000 });
+}
+
+// Build a mock feature with a fixed property bag — matches OL Feature's
+// `set/get` interface for the keys this module reads.
+const MOCK_FEATURE = `(props) => ({ get: (k) => props[k], __mock: true })`;
+
+test.describe('osmIdDedup unit — dedupWinner', () => {
+  test.beforeEach(bootHub);
+
+  test('both parseable, incoming newer → incoming', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: '2026-04-26T03:00:00Z', _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === b ? 'b' : 'a';
+    }, MOCK_FEATURE);
+    expect(result).toBe('b');
+  });
+
+  test('both parseable, existing newer → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2026-04-26T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('same instant in different TZ formats → tie → URL alphabetical', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      // Same instant: 2026-04-25T12:00:00Z === 2026-04-25T14:00:00+02:00.
+      const a = f({ _lastImportAt: '2026-04-25T12:00:00Z',     _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: '2026-04-25T14:00:00+02:00', _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a'); // /api-a < /api-b alphabetically
+  });
+
+  test('existing parseable + incoming null → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: null,                   _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('existing parseable + incoming undefined → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ /* _lastImportAt absent */              _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('existing parseable + incoming malformed (NaN-Date.parse) → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: 'banana',                _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('existing parseable + incoming year-only (V8 accepts but spec rejects) → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: '2025-04-25T03:00:00Z', _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: '2026',                 _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('existing null + incoming parseable → incoming', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: null,                   _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: '2026-04-25T03:00:00Z', _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('b');
+  });
+
+  test('both null + lower-URL existing → existing', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: null, _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: null, _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('both null + lower-URL incoming → incoming', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: null, _backendUrl: '/api-z' });
+      const b = f({ _lastImportAt: null, _backendUrl: '/api-a' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('b');
+  });
+
+  test('both null + identical _backendUrl → existing (first-write-wins on identity collision)', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const a = f({ _lastImportAt: null, _backendUrl: '/api-a' });
+      const b = f({ _lastImportAt: null, _backendUrl: '/api-a' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('a');
+  });
+
+  test('one side missing _backendUrl → side with URL wins', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      // Both unparseable → falls into URL-alpha path. Spec: prefer the side
+      // with a real URL over an unstamped feature.
+      const a = f({ _lastImportAt: null /* _backendUrl absent */ });
+      const b = f({ _lastImportAt: null, _backendUrl: '/api-b' });
+      return window.__spieli.osmIdDedup.dedupWinner(a, b) === a ? 'a' : 'b';
+    }, MOCK_FEATURE);
+    expect(result).toBe('b');
+  });
+
+  test('symmetric: dedupWinner(a, b) and dedupWinner(b, a) both pick the same backend (not the same arg)', async ({ page }) => {
+    // Tie case where existing-vs-incoming ordering shouldn't flip the outcome.
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const fA = () => f({ _lastImportAt: null, _backendUrl: '/api-a' });
+      const fB = () => f({ _lastImportAt: null, _backendUrl: '/api-b' });
+      const w1 = window.__spieli.osmIdDedup.dedupWinner(fA(), fB());
+      const w2 = window.__spieli.osmIdDedup.dedupWinner(fB(), fA());
+      // Both calls should pick the feature with /api-a (lower URL wins regardless of order).
+      return [w1.get('_backendUrl'), w2.get('_backendUrl')];
+    }, MOCK_FEATURE);
+    expect(result).toEqual(['/api-a', '/api-a']);
+  });
+});
+
+test.describe('osmIdDedup unit — applyDedup', () => {
+  test.beforeEach(bootHub);
+
+  test('absent osm_id passes through (not deduplicated)', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const map = new Map();
+      const features = [
+        f({ /* osm_id absent */ _backendUrl: '/api-a' }),
+        f({ /* osm_id absent */ _backendUrl: '/api-b' }),
+      ];
+      const { toAdd, toRemove } = window.__spieli.osmIdDedup.applyDedup(features, map);
+      return { toAdd: toAdd.length, toRemove: toRemove.length, mapSize: map.size };
+    }, MOCK_FEATURE);
+    // Both added (no osm_id → no dedup). Map untouched.
+    expect(result).toEqual({ toAdd: 2, toRemove: 0, mapSize: 0 });
+  });
+
+  test('first arrival of a unique osm_id → toAdd populated, toRemove empty, map updated', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const map = new Map();
+      const features = [f({ osm_id: 42, _backendUrl: '/api-a', _lastImportAt: null })];
+      const { toAdd, toRemove } = window.__spieli.osmIdDedup.applyDedup(features, map);
+      return {
+        toAdd: toAdd.length,
+        toRemove: toRemove.length,
+        mapHas42: map.has('42'),
+      };
+    }, MOCK_FEATURE);
+    expect(result).toEqual({ toAdd: 1, toRemove: 0, mapHas42: true });
+  });
+
+  test('second arrival with newer timestamp evicts the existing winner', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const map = new Map();
+      const older = f({ osm_id: 42, _backendUrl: '/api-a', _lastImportAt: '2026-04-25T03:00:00Z' });
+      const newer = f({ osm_id: 42, _backendUrl: '/api-b', _lastImportAt: '2026-04-26T03:00:00Z' });
+      // Pretend `older` already won a previous arrival.
+      map.set('42', older);
+      const { toAdd, toRemove } = window.__spieli.osmIdDedup.applyDedup([newer], map);
+      return {
+        toAdd: toAdd[0]?.get('_backendUrl'),
+        toRemove: toRemove[0]?.get('_backendUrl'),
+        winner: map.get('42')?.get('_backendUrl'),
+      };
+    }, MOCK_FEATURE);
+    expect(result).toEqual({ toAdd: '/api-b', toRemove: '/api-a', winner: '/api-b' });
+  });
+
+  test('second arrival with older timestamp is silently dropped (existing wins)', async ({ page }) => {
+    const result = await page.evaluate((mockSrc) => {
+      const f = new Function('return ' + mockSrc)();
+      const map = new Map();
+      const newer = f({ osm_id: 42, _backendUrl: '/api-a', _lastImportAt: '2026-04-26T03:00:00Z' });
+      const older = f({ osm_id: 42, _backendUrl: '/api-b', _lastImportAt: '2026-04-25T03:00:00Z' });
+      map.set('42', newer);
+      const { toAdd, toRemove } = window.__spieli.osmIdDedup.applyDedup([older], map);
+      return {
+        toAddLen: toAdd.length,
+        toRemoveLen: toRemove.length,
+        winner: map.get('42')?.get('_backendUrl'),
+      };
+    }, MOCK_FEATURE);
+    expect(result).toEqual({ toAddLen: 0, toRemoveLen: 0, winner: '/api-a' });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `add-cross-backend-osm-id-dedup` spec ([#202](https://github.com/mfuhrmann/spieli/issues/202)) using the contract from PR #300 (Ronny). When two backends return the same `osm_id` in the polygon tier (playground on/near a region boundary), exactly one feature survives — the one from the backend with the fresher import.

### What ships

**`app/src/hub/osmIdDedup.js`** (new — pure module)
- `dedupWinner(a, b)` — tie-breaking logic (see below)
- `applyDedup(incoming, dedupMap)` — merges an incoming feature batch into a per-orchestrate-call `Map<osm_id, Feature>`, returns `{ toAdd, toRemove }` for source update

**Tie-breaking rules** (in priority order):
1. Both features have `_lastImportAt` → newer `Date.parse` wins
2. One side is `null` → the side with data wins
3. Both `null` (pre-#301 backends, degraded mode) → URL-alphabetical, deterministic

**`app/src/hub/hubOrchestrator.js`**
- `parsePolygonFeatures` stamps `_lastImportAt` from `backend.lastImportAt` at parse time (frozen — not a live store read, avoids stale-race if a poll fires mid-fan-out)
- Polygon tier `onResult` maintains a `polyByOsmId` map per `orchestrate()` call, applies dedup, calls `removeFeature`/`addFeatures` — progressive rendering preserved; most arrivals have zero removals

**`app/src/hub/registry.js`**
- Adds `lastImportAt: null` to the initial backend shape
- Reads `meta.last_import_at` from `get_meta` into `patch.lastImportAt` — `null` on pre-#301 backends, which triggers degraded-mode dedup automatically

**`tests/hub-osm-id-dedup.spec.js`** (new — 4 Playwright tests)
- Smoke: both backends load without error when every osm_id overlaps
- Fan-out: `get_playgrounds_bbox` still issued to both backends after dedup is wired
- Timestamp winner: slug-scoped deeplink routes equipment fetch to the newer-import backend
- Degraded mode: both `null` timestamps, URL-alphabetical fallback, no crash

## Relationship to #301 (federation health exposition)

**Soft dependency.** This PR reads `meta.last_import_at` from `get_meta`. That field is `null` until a backend deploys #301's `api.import_status` table + `import.sh` UPSERT. Until then, dedup runs in degraded mode (URL-alphabetical). No forced merge order — both PRs work independently.

If #301 merges after this PR, `registry.js` will have a minor conflict (`lastImportAt` field added in both). Resolution: keep both sets of fields — #301 adds `healthUp`, `dataAgeSec`, `lastReachable`, `observationStale`; this PR adds `lastImportAt`. They don't overlap.

## Current state vs. production readiness

With 1–2 backends and no geographic overlap today, dedup never fires in practice — it's a correctness investment that pays off when a third backend covers a shared border. The degraded-mode path (URL-alphabetical) is already exercised by the existing test suite since no test backend sets `last_import_at`.

## What's not yet covered

The TODO block in `hub-osm-id-dedup.spec.js` documents two concrete options for a direct **polygon-source feature-count assertion** (verifying `polygonSource.getFeatures()` has exactly one entry per shared `osm_id`). Neither is added here because both require a small test hook in the production code:

- **Option A**: data attribute on the map element written after each source update
- **Option B**: `window.__polygonSource` exposed in `import.meta.env.DEV` builds

Either is straightforward to add if a future reviewer wants the direct assertion before merge.

## Test plan

- [x] `npx playwright test tests/hub-pill.spec.js tests/hub-smoke.spec.js tests/hub-multi-backend.spec.js tests/hub-deeplink.spec.js tests/hub-osm-id-dedup.spec.js` — 16 tests, all pass
- [ ] Manual: `make seed-load && make seed-load2 && make docker-build` with `APP_MODE=hub` — verify no duplicate polygon features at the Fulda/Neuhof boundary (these regions don't currently overlap, so this is a sanity check rather than a dedup trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)