### PR TITLE
fix(federation): close PR #301 bmad-code-review pass-2 critical findings

### DIFF
--- a/app/src/hub/federationHealth.js
+++ b/app/src/hub/federationHealth.js
@@ -5,12 +5,27 @@
 // The two exported functions preserve the signatures that hubOrchestrator.js
 // already depends on — no call-site changes required.
 
-const POLL_INTERVAL_MS = 60_000;
-// Show "stale observation" banner when generated_at is older than this.
-const STALE_THRESHOLD_SECONDS = 120;
+import { hubPollInterval } from '../lib/config.js';
 
-let _applyStatus = null;
-let _pollTimer   = null;
+// Browser-side cadence: re-fetch the federation-status snapshot at the
+// same cadence as the registry poll (default 300 s). Design D5 forbids
+// coupling UX freshness to ops freshness — the server-side cron runs at
+// its own 60 s cadence; the browser reads at the slower registry cadence
+// and the cached `generated_at` keeps aging in real time so the
+// staleness banner still surfaces within a single poll window.
+const POLL_INTERVAL_MS = hubPollInterval * 1000;
+// Show "stale observation" banner when generated_at is older than this
+// (kept as a multiplier of `data.poll_interval_seconds` from the JSON
+// payload so the threshold tracks the server's own configured cadence).
+const STALE_THRESHOLD_MULTIPLIER = 2;
+
+let _applyStatus       = null;
+let _pollTimer         = null;
+// One-time `console.warn` per session for absent/unparseable
+// federation-status.json — task 3.6 of `add-federation-health-exposition`
+// requires the warn-once + fail-open path so a deploy without FHE is
+// observable in devtools without flooding the console on every poll.
+let _absentWarned      = false;
 
 /**
  * Starts polling /federation-status.json and applies each update to the
@@ -44,14 +59,27 @@ async function _fetchAndApply() {
         const generatedAt = data.generated_at ? new Date(data.generated_at) : null;
         const pollInterval = data.poll_interval_seconds ?? 60;
         const observationStale = generatedAt
-          ? (Date.now() - generatedAt.getTime()) / 1000 > pollInterval * 2
+          ? (Date.now() - generatedAt.getTime()) / 1000 > pollInterval * STALE_THRESHOLD_MULTIPLIER
           : true;
         _applyStatus(data.backends, observationStale);
       }
+    } else if (!_absentWarned) {
+      _absentWarned = true;
+      console.warn(
+        `[federation-health] /federation-status.json returned ${res.status}; ` +
+        `degrading to per-session health (all backends optimistic).`
+      );
     }
-  } catch {
+  } catch (err) {
     // Network error — federation-status.json absent or unreachable.
     // Fail open: all backends remain as-is (no patch applied), health unknown.
+    if (!_absentWarned) {
+      _absentWarned = true;
+      console.warn(
+        `[federation-health] /federation-status.json unreachable (${err.message}); ` +
+        `degrading to per-session health (all backends optimistic).`
+      );
+    }
   }
 
   _pollTimer = setTimeout(_fetchAndApply, POLL_INTERVAL_MS);

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -16,7 +16,16 @@
 #   POSTGRES_PASSWORD      Required
 #   OSM2PGSQL_THREADS      Default: 4
 
-set -e
+# `-e` aborts on any unchecked non-zero exit. `pipefail` is the load-bearing
+# addition for the `envsubst | psql … < /api.sql` pipeline below: without it,
+# a failing envsubst (or any psql statement that errors *without* triggering
+# psql's own non-zero exit) would let the pipeline succeed overall and the
+# subsequent `api.import_status` UPSERT would record a fresh `last_import_at`
+# against a half-applied schema — exactly the silent-failure mode the
+# scheduled-importer spec scenario "Failed run does not update timestamp"
+# forbids. Pair with `psql -v ON_ERROR_STOP=1` at every `psql` callsite that
+# applies multi-statement SQL (api.sql, etc.).
+set -eo pipefail
 
 PBF_URL="${PBF_URL:-https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf}"
 PBF_FILE="/data/$(basename "$PBF_URL")"
@@ -195,8 +204,11 @@ echo "[importer] osm2pgsql finished."
 # Create PostgREST API schema (views / functions)
 # --------------------------------------------------------------------------- #
 echo "[importer] Applying API schema..."
+# ON_ERROR_STOP=1 + pipefail (set at top) guarantees a partial schema apply
+# aborts the script before the api.import_status UPSERT below runs.
 envsubst '$OSM_RELATION_ID' < /api.sql \
-    | psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+    | psql -v ON_ERROR_STOP=1 \
+        -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB"
 
 # --------------------------------------------------------------------------- #
 # Record successful import timestamp (read by get_meta / federation-status)

--- a/oci/app/docker-entrypoint.sh
+++ b/oci/app/docker-entrypoint.sh
@@ -47,17 +47,34 @@ fi
 
 # Write placeholder federation-status.json and metrics so nginx can serve
 # the endpoints immediately before the first cron tick (60 s).
+#
+# The placeholder /metrics MUST emit a valid `spielplatz_poll_generated_timestamp`
+# gauge — operators alerting on `time() - spielplatz_poll_generated_timestamp > N`
+# need a real value during the boot window, otherwise a crashed cron during
+# startup cannot be distinguished from a healthy hub before its first tick.
 WEBROOT="/usr/share/nginx/html"
-INIT_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+INIT_TS_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+INIT_TS_UNIX=$(date -u +%s)
 if [ ! -f "$WEBROOT/federation-status.json" ]; then
     printf '{"generated_at":"%s","poll_interval_seconds":60,"backends":{}}\n' \
-        "$INIT_TS" > "$WEBROOT/federation-status.json"
+        "$INIT_TS_ISO" > "$WEBROOT/federation-status.json"
 fi
 if [ ! -f "$WEBROOT/metrics" ]; then
-    printf '# spieli federation metrics — first poll pending\n' > "$WEBROOT/metrics"
+    {
+        printf '# HELP spielplatz_poll_generated_timestamp Unix timestamp when this scrape was generated.\n'
+        printf '# TYPE spielplatz_poll_generated_timestamp gauge\n'
+        printf 'spielplatz_poll_generated_timestamp %s\n' "$INIT_TS_UNIX"
+    } > "$WEBROOT/metrics"
 fi
 
-# Start crond in background (logs to stderr so Docker picks them up)
+# Start crond in background, but only when the hub is actually polling (in
+# standalone mode there's nothing to poll and the placeholder above stands
+# in as a "polling not configured" sentinel — the placeholder's
+# `spielplatz_poll_generated_timestamp` will quickly age past any sensible
+# stale-observation threshold, which is the right signal for an operator
+# scraping a non-hub container by mistake). Logs go to stderr so Docker
+# picks them up; foreground supervision is not used (single-process
+# container with a daemonised cron is the established pattern here).
 if [ "$APP_MODE" = "hub" ]; then
     crond -b -L /dev/stderr
 fi

--- a/oci/app/poll-federation.sh
+++ b/oci/app/poll-federation.sh
@@ -2,21 +2,41 @@
 # Hub federation health poll — runs every 60 s via crond.
 # Reads /usr/share/nginx/html/registry.json, fetches get_meta from each
 # backend, writes /usr/share/nginx/html/federation-status.json and
-# /usr/share/nginx/html/metrics atomically (tmp → rename).
+# /usr/share/nginx/html/metrics atomically (tmp on the SAME filesystem
+# as the webroot → rename within fs).
 set -e
+
+# Locale-independent decimals (curl's %{time_total} honours LC_NUMERIC;
+# a non-C locale produces "0,043" which breaks both JSON and Prometheus
+# parsers).
+LC_ALL=C
+export LC_ALL
 
 WEBROOT="/usr/share/nginx/html"
 REGISTRY="$WEBROOT/registry.json"
 STATUS_OUT="$WEBROOT/federation-status.json"
 METRICS_OUT="$WEBROOT/metrics"
+LOCKFILE="/var/run/poll-federation.lock"
 POLL_INTERVAL=60
 
-# Previous status for preserving last_success on transient failures
+# Single-instance guard. flock prevents concurrent runs from racing on
+# the mv calls when one cron tick takes longer than the next interval
+# (e.g. a hung backend). `-n` returns immediately if held; we exit
+# silently because the previous tick is still in progress.
+if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCKFILE"
+    flock -n 9 || exit 0
+fi
+
+# tmp dir on the SAME filesystem as the webroot so `mv` is a true atomic
+# rename rather than a cross-fs copy+unlink (which readers can observe
+# mid-stream as a partial file).
+TMP=$(mktemp -d -p "$WEBROOT" .poll.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# Previous status for preserving last_success on transient failures.
 PREV_STATUS=""
 [ -f "$STATUS_OUT" ] && PREV_STATUS=$(cat "$STATUS_OUT")
-
-TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
 
 # No registry → write an empty-but-valid status and exit
 if [ ! -f "$REGISTRY" ]; then
@@ -38,65 +58,95 @@ GENERATED_TS=$(date -u +%s)
 BACKENDS_JSON=""
 METRICS_LINES=""
 
-# jq outputs: slug<TAB>url per line
-jq -r '.backends[] | (.slug // (.url | gsub("[^a-z0-9]"; "_"))) + "\t" + .url' \
+# jq outputs: slug<TAB>url per line. Registry can be either
+# `{ "instances": [...] }` (canonical, matches `app/src/hub/registry.js:131`)
+# or a bare top-level array; `(.instances // .)[]` handles both.
+jq -r '(.instances // .)[] | (.slug // (.url | gsub("[^a-z0-9]"; "_"))) + "\t" + .url' \
     "$REGISTRY" > "$TMP/backends.tsv" 2>/dev/null || true
 
 while IFS="	" read -r SLUG URL; do
     [ -z "$URL" ] && continue
 
     META_TMP="$TMP/meta_${SLUG}.json"
-    HTTP_CODE=0
     LATENCY="0"
     UP=0
 
-    # curl: silent, fail on HTTP error, capture timing, 3 s timeout
+    # curl: silent, fail on HTTP error, capture timing, 3 s timeout.
+    # Relative URLs in registry.json (e.g. "/api") are resolved against the
+    # hub's own origin via http://localhost — needed for the dev/local
+    # stack where the hub proxies /api to a co-located data-node.
+    CURL_URL="$URL"
+    case "$URL" in
+        /*) CURL_URL="http://localhost${URL}" ;;
+    esac
     if curl -sf --max-time 3 \
             -w '%{time_total}' \
             -o "$META_TMP" \
-            "${URL}/rpc/get_meta" > "$TMP/curl_time_${SLUG}.txt" 2>/dev/null; then
+            "${CURL_URL}/rpc/get_meta" > "$TMP/curl_time_${SLUG}.txt" 2>/dev/null; then
         LATENCY=$(cat "$TMP/curl_time_${SLUG}.txt")
         UP=1
     fi
 
-    LAST_IMPORT_AT="null"
+    LAST_IMPORT_AT_JSON="null"
     DATA_AGE_SECONDS="null"
     if [ "$UP" = "1" ] && [ -f "$META_TMP" ]; then
         RAW=$(cat "$META_TMP")
-        # get_meta returns a JSON array with one element
-        LAST_IMPORT_AT=$(printf '%s' "$RAW" | jq -r '.[0].last_import_at // empty' 2>/dev/null)
-        DATA_AGE_SECONDS=$(printf '%s' "$RAW" | jq -r '.[0].data_age_seconds // empty' 2>/dev/null)
-        [ -z "$LAST_IMPORT_AT" ]   && LAST_IMPORT_AT="null"
-        [ -z "$DATA_AGE_SECONDS" ] && DATA_AGE_SECONDS="null"
+        # api.get_meta returns a JSON object directly (PostgREST scalar-RPC),
+        # not a single-element array. Read fields without `.[0]` indexing.
+        # `last_import_at` is an ISO string and MUST be re-quoted on the way
+        # into our concatenated JSON; bare ISO strings interpolate as
+        # invalid JSON (`"last_import_at":2026-04-25T03:00:00Z` — unquoted).
+        LAST_IMPORT_AT=$(printf '%s' "$RAW" | jq -r '.last_import_at // empty' 2>/dev/null)
+        DATA_AGE_SECONDS_RAW=$(printf '%s' "$RAW" | jq -r '.data_age_seconds // empty' 2>/dev/null)
+        if [ -n "$LAST_IMPORT_AT" ]; then
+            # Quote-escape via jq so a maliciously-crafted timestamp can't break
+            # the surrounding JSON. (Operator-controlled, but cheap defence.)
+            LAST_IMPORT_AT_JSON=$(printf '%s' "$LAST_IMPORT_AT" | jq -Rs .)
+        fi
+        if [ -n "$DATA_AGE_SECONDS_RAW" ]; then
+            DATA_AGE_SECONDS="$DATA_AGE_SECONDS_RAW"
+        fi
     fi
 
-    # Preserve last_success from previous run if backend is currently down
-    LAST_SUCCESS="null"
+    # Preserve last_success from previous run if backend is currently down.
+    LAST_SUCCESS_JSON="null"
     if [ -n "$PREV_STATUS" ]; then
         PREV_LAST=$(printf '%s' "$PREV_STATUS" \
             | jq -r --arg slug "$SLUG" '.backends[$slug].last_success // empty' 2>/dev/null)
-        [ -n "$PREV_LAST" ] && LAST_SUCCESS="\"$PREV_LAST\""
+        [ -n "$PREV_LAST" ] && LAST_SUCCESS_JSON=$(printf '%s' "$PREV_LAST" | jq -Rs .)
     fi
-    [ "$UP" = "1" ] && LAST_SUCCESS="\"$GENERATED_AT\""
+    [ "$UP" = "1" ] && LAST_SUCCESS_JSON=$(printf '%s' "$GENERATED_AT" | jq -Rs .)
+
+    # JSON-escape SLUG and URL (operator-controlled but cheap defence; a `"`
+    # anywhere in either string would otherwise produce malformed output).
+    SLUG_JSON=$(printf '%s' "$SLUG" | jq -Rs .)
+    URL_JSON=$(printf '%s' "$URL"  | jq -Rs .)
 
     # Append to backends JSON object
     if [ -n "$BACKENDS_JSON" ]; then BACKENDS_JSON="${BACKENDS_JSON},"; fi
-    BACKENDS_JSON="${BACKENDS_JSON}\"${SLUG}\":{"
-    BACKENDS_JSON="${BACKENDS_JSON}\"url\":\"${URL}\","
+    BACKENDS_JSON="${BACKENDS_JSON}${SLUG_JSON}:{"
+    BACKENDS_JSON="${BACKENDS_JSON}\"url\":${URL_JSON},"
     BACKENDS_JSON="${BACKENDS_JSON}\"up\":$([ "$UP" = "1" ] && echo true || echo false),"
     BACKENDS_JSON="${BACKENDS_JSON}\"latency_seconds\":${LATENCY},"
-    BACKENDS_JSON="${BACKENDS_JSON}\"last_success\":${LAST_SUCCESS},"
-    BACKENDS_JSON="${BACKENDS_JSON}\"last_import_at\":${LAST_IMPORT_AT},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"last_success\":${LAST_SUCCESS_JSON},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"last_import_at\":${LAST_IMPORT_AT_JSON},"
     BACKENDS_JSON="${BACKENDS_JSON}\"data_age_seconds\":${DATA_AGE_SECONDS}"
     BACKENDS_JSON="${BACKENDS_JSON}}"
 
-    # Append Prometheus metrics
-    LABEL="backend=\"${SLUG}\",url=\"${URL}\""
-    METRICS_LINES="${METRICS_LINES}spielplatz_backend_up{${LABEL}} ${UP}\n"
-    METRICS_LINES="${METRICS_LINES}spielplatz_backend_latency_seconds{${LABEL}} ${LATENCY}\n"
-    if [ "$DATA_AGE_SECONDS" != "null" ] && [ -n "$DATA_AGE_SECONDS" ]; then
-        METRICS_LINES="${METRICS_LINES}spielplatz_backend_data_age_seconds{${LABEL}} ${DATA_AGE_SECONDS}\n"
-    fi
+    # Append Prometheus metrics. Prometheus disallows `"` and `\` inside
+    # label values; treat URL and SLUG as already-canonical (registry
+    # operator's responsibility) and skip strings containing them.
+    case "$SLUG$URL" in
+        *\"*|*\\*) ;;  # skip — would break exposition format
+        *)
+            LABEL="backend=\"${SLUG}\",url=\"${URL}\""
+            METRICS_LINES="${METRICS_LINES}spielplatz_backend_up{${LABEL}} ${UP}\n"
+            METRICS_LINES="${METRICS_LINES}spielplatz_backend_latency_seconds{${LABEL}} ${LATENCY}\n"
+            if [ "$DATA_AGE_SECONDS" != "null" ] && [ -n "$DATA_AGE_SECONDS" ]; then
+                METRICS_LINES="${METRICS_LINES}spielplatz_backend_data_age_seconds{${LABEL}} ${DATA_AGE_SECONDS}\n"
+            fi
+            ;;
+    esac
 done < "$TMP/backends.tsv"
 
 # Write status.json
@@ -117,6 +167,6 @@ printf '{"generated_at":"%s","poll_interval_seconds":%d,"backends":{%s}}\n' \
     printf 'spielplatz_poll_generated_timestamp %s\n' "$GENERATED_TS"
 } > "$TMP/metrics"
 
-# Atomic rename
+# Atomic rename within the same filesystem (mktemp -d -p "$WEBROOT" above).
 mv "$TMP/status.json" "$STATUS_OUT"
 mv "$TMP/metrics"     "$METRICS_OUT"

--- a/openspec/changes/add-federation-health-exposition/tasks.md
+++ b/openspec/changes/add-federation-health-exposition/tasks.md
@@ -82,3 +82,35 @@ Three review layers ran over the codebase-sync diff. Edge Case Hunter verified m
 - Blind Hunter "packaging chain (busybox-suid + crond + /etc/crontabs/root) unverified" — verified: `nginx:alpine` ships busybox userland *without* crond; `busybox-suid` is the canonical Alpine package providing `crond`; `/etc/crontabs/root` is the busybox cron path; `crond -b -L /dev/stderr` matches busybox crond's flag set.
 - Blind Hunter "entrypoint filename correction unverified" — verified: file is `oci/app/docker-entrypoint.sh`, line 48 is `exec nginx -g 'daemon off;'`.
 - Blind Hunter "`postgrest2` invented" — verified earlier in conversation: `docker compose ps` shows `spielplatzkarte-postgrest2-1` and `spielplatzkarte-db2-1` in the bundled compose stack, and `compose.yml` is unchanged by this PR.
+
+### Review Findings — Pass 2 (bmad-code-review of PR #301, 2026-04-26)
+
+Re-review of the implementation diff (PR #301, post-rebase against `main`). Three review layers ran. Convergent finding across all layers: **the feature is silently non-functional on the canonical registry shape** — `poll-federation.sh` reads `.backends[]` but the registry uses `.instances[]`. Combined with three more critical defects, the cron loop never produces useful output for any backend. Playwright tests don't catch this because they stub `/federation-status.json` directly and never exercise the shell script.
+
+#### Critical
+- [x] [Review][Patch] `poll-federation.sh:42-43` reads `.backends[]` from `registry.json`, but the canonical schema (and `registry.js:131`) uses `.instances[]` (or a bare top-level array). `jq -r '.backends[] | …'` produces zero rows for every real registry, the `while read` loop never executes, and `/federation-status.json` is permanently `{"backends":{}}`. Fixed by reading `(.instances // .)[] | …`.
+- [x] [Review][Patch] `poll-federation.sh:67-68` indexes `.[0].last_import_at` against the PostgREST `get_meta` response, which is a JSON object (verified by `app/src/lib/api.js:fetchMeta` reading `meta.bbox` directly). `.[0]` errors and `// empty` swallows the result. Fixed by dropping `.[0]`.
+- [x] [Review][Patch] `poll-federation.sh:89` interpolates `${LAST_IMPORT_AT}` (a bare ISO string) unquoted into the output JSON, producing invalid `"last_import_at":2026-04-25T03:00:00Z,`. Fixed by quoting via `jq -Rs .` and emitting the resulting JSON literal.
+- [x] [Review][Patch] `app/src/hub/federationHealth.js:9` hard-codes `POLL_INTERVAL_MS = 60_000`, violating spec D5 (UX freshness must stay decoupled from ops freshness — UI poll runs at `hubPollInterval`, default 300 s) and task 3.1. Fixed by importing `hubPollInterval` from config and using `hubPollInterval * 1000`.
+
+#### High
+- [x] [Review][Patch] Relative URLs in `registry.json` (e.g. `"/api"`) break `curl ${URL}/rpc/get_meta`. Fixed by resolving relative paths against `http://localhost` inside the script.
+- [x] [Review][Patch] `import.sh` lacks `set -o pipefail` and `psql -v ON_ERROR_STOP=1`. A partial schema apply (envsubst error, individual SQL statement failure) succeeds with exit 0 and the subsequent `api.import_status` UPSERT runs — directly violating the `scheduled-importer` spec scenario "Failed run does not update timestamp". Fixed both at the top of the script and at the api.sql apply call.
+- [x] [Review][Patch] `crond` only starts when `APP_MODE=hub`, so standalone deployments serve forever-stale placeholder `/metrics` and `/federation-status.json`. Fixed by writing a valid `spielplatz_poll_generated_timestamp` gauge in the placeholder so the standard "cron died" alert (`time() - spielplatz_poll_generated_timestamp > N`) fires correctly during the boot window AND when polling is disabled (standalone mode is a "polling not configured" sentinel).
+- [x] [Review][Patch] URL/SLUG injection into JSON without escaping. Fixed by passing both through `jq -Rs .` before interpolation.
+- [x] [Review][Patch] `LATENCY` (curl's `%{time_total}`) honours `LC_NUMERIC` — a non-`C` locale produces `0,043` (comma) which breaks both JSON and Prometheus parsers. Fixed by `LC_ALL=C; export LC_ALL` at the top of `poll-federation.sh`.
+- [x] [Review][Patch] No mutual exclusion on cron runs — a hung backend lasting >60 s causes concurrent `mv` calls on `status.json` + `metrics`, producing inconsistent snapshots. Fixed by `flock -n 9 || exit 0` at the top of the script.
+- [x] [Review][Patch] `mktemp -d` defaults to `/tmp` (tmpfs), so `mv` to `/usr/share/nginx/html/` is cross-filesystem and not atomic. Defeats the "atomic rename" comment. Fixed by `mktemp -d -p "$WEBROOT" .poll.XXXXXX`.
+- [x] [Review][Patch] `federationHealth.js` swallows fetch errors silently. Task 3.6 explicitly requires "a single `console.warn(...)` fires per session" on absent-file fallback. Fixed by adding a `_absentWarned` latch and console.warn on first 404 / network error.
+
+#### Medium
+- [ ] [Review][Patch] i18n keys added only to `de.json` / `en.json` — 10 locales fall back to English. Either add the keys (placeholder English values) to all 12 locales, or wire a tooling step that surfaces missing translations. Deferred to a docs-and-locales sweep PR.
+- [ ] [Review][Patch] Stale-banner uses `Date.now()` vs server `generated_at` with no clock-skew tolerance — a browser clock 2 minutes off shows "observation stale" on a healthy hub. Mitigation: trust an HTTP `Date` header, or compute relative to client fetch time. Deferred (low real-world impact; clock skew >120 s is rare).
+- [ ] [Review][Patch] `crond -b` daemon detached from PID 1 — SIGTERM to nginx doesn't propagate to crond. Mitigation: `tini` / `dumb-init` shim, or background-trap-forward in entrypoint. Deferred (polling resumes on container restart; orphan cron during graceful shutdown is cosmetic).
+- [ ] [Review][Patch] Slug fallback regex in poll script (`gsub("[^a-z0-9]"; "_")`) desyncs with `registry.js:normaliseSlug`. Practical impact: backends without explicit slugs render with mismatched keys between `/federation-status.json` and the frontend store. Defer until either side gets a real spec for slug derivation.
+- [ ] [Review][Patch] Playwright tests stub `/federation-status.json` directly and race the first poll application — pass intermittently. Mitigation: `await expect.poll(...)` on the drawer's freshness label. Deferred to a test-hardening sweep.
+
+#### Verified clean (no patch needed)
+- D1 (cron + flat JSON), D2 (exporter pattern), D3 (`CHECK (id = 1)` singleton), D4 (Prometheus `# HELP`/`# TYPE` present), D6 (`generated_at` mandatory), D8 (built on existing `federationHealth.js` stub) — all preserved.
+- Out-of-scope items (selection store, etc.) respected.
+- Singleton schema constraint correctly enforced.


### PR DESCRIPTION
## Summary

Stacked PR on top of #301 — closes the four critical and seven high findings from the bmad-code-review pass on PR #301. **Base**: `feat/194-federation-health-exposition`.

The architecture in #301 is right (proposal/design/tasks/specs all match); the implementation has bugs concentrated in `oci/app/poll-federation.sh` and one in `federationHealth.js`. None require rework — just targeted fixes.

## Critical fixes (blockers — feature is silently non-functional without these)

| # | Defect | Fix |
|---|---|---|
| 1 | `poll-federation.sh` reads `.backends[]`; registry uses `.instances[]` (or bare array) → script silently exits with empty output every tick | `jq -r '(.instances // .)[] | …'` (handles both shapes) |
| 2 | `jq '.[0].last_import_at'` against the PostgREST scalar object → always empty | drop `.[0]` |
| 3 | ISO string interpolated unquoted into JSON → `"last_import_at":2026-04-25T...` (invalid) | `jq -Rs .` to produce a JSON literal |
| 4 | `federationHealth.js` hard-codes `POLL_INTERVAL_MS = 60_000` → violates D5 (UX freshness coupled to ops freshness) | `import { hubPollInterval } from '../lib/config.js'` |

## High fixes

- Relative URLs (`"/api"`) → `http://localhost${URL}` resolution.
- `import.sh` `set -o pipefail` + `psql -v ON_ERROR_STOP=1` so a partial schema apply doesn't mark the import successful.
- Placeholder `/metrics` now emits `spielplatz_poll_generated_timestamp` (gauge with HELP/TYPE) so the "cron died" alert fires during boot window AND in standalone mode.
- URL/SLUG `jq -Rs .` escape for JSON output.
- `LC_ALL=C` so curl's `%{time_total}` produces locale-stable decimals.
- `flock -n 9 || exit 0` for single-instance cron.
- `mktemp -d -p "$WEBROOT" .poll.XXXXXX` so the rename is on the same filesystem.
- `federationHealth.js` warns once per session on `/federation-status.json` 404 / network error (task 3.6).

## Deferred (Medium — tracked in `tasks.md` Pass-2 review findings, not blocking)

- i18n keys propagation to 10 missing locales.
- Stale-banner clock-skew tolerance.
- `crond -b` daemon SIGTERM handling.
- Slug-fallback regex divergence between poll script and `registry.js:normaliseSlug`.
- Playwright federation-health test race-on-first-poll hardening.

## Test plan

- [x] `make test` — 56/56 passing locally.
- [x] `openspec validate add-federation-health-exposition --strict` clean.
- [x] `sh -n oci/app/poll-federation.sh` — syntax OK.
- [ ] Manual: end-to-end poll on the production hub deployment (pkg.onms.eu) once #301 + this PR ship; verify `/federation-status.json` actually populates per-backend after the next cron tick.

## Merge order

Two valid orderings — same as #307 stacked on #302 (the dedup change):

1. **Stack as written**: review/merge #301 → GitHub auto-rebases this PR onto main → review/merge here.
2. **Squash into #301**: cherry-pick these commits onto `feat/194-federation-health-exposition` and force-push so #301 lands fully reviewed as one PR.

The `tasks.md` review-findings section was added to the existing in-flight openspec change (Pass 2) so the contract docs the review pass — same convention used by all archived openspec changes in this repo.

Refs #194, #301

Assisted-by: ClaudeCode:claude-opus-4-7