### PR TITLE
chore(openspec): commit local changes and archive completed specs

### DIFF
--- a/openspec/changes/add-weblate-community-translations/.openspec.yaml
+++ b/openspec/changes/add-weblate-community-translations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/add-weblate-community-translations/design.md
+++ b/openspec/changes/add-weblate-community-translations/design.md
@@ -1,0 +1,87 @@
+## Context
+
+spieli currently supports DE and EN via `svelte-i18n` with flat JSON files using ICU message format (`locales/de.json`, `locales/en.json`, ~320 keys each). Ten additional locale files exist in `locales/` from a previous attempt (cs, es, fr, it, ja, nl, pl, pt, sv, uk) but are auto-generated and not registered in `i18n.js`. There is no external translation tooling — strings are edited directly in the repo.
+
+The goal is to invite OSM community translators to contribute new languages. Translators in this context are non-developers who should not need GitHub access or knowledge of ICU syntax.
+
+**Constraint**: Setup should happen after issue #249 (project rename to "spieli") so the Weblate project name is consistent with the final repo and DNS name.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable community translation contributions via a web UI (no GitHub access required)
+- Keep translation PRs in the maintainer's review queue — no direct pushes to `main`
+- Support existing `locales/*.json` format with zero changes to file structure
+- Provide a clear threshold for when a new language goes live in the app
+
+**Non-Goals:**
+- Automated language promotion (adding to `SUPPORTED` stays a manual maintainer decision)
+- Self-hosted Weblate infrastructure
+- Changing the JSON translation format or ICU syntax
+
+## Decisions
+
+### 1. EN as Weblate source language (not DE)
+
+**Decision**: `locales/en.json` is the Weblate template; translators work from English.
+
+**Rationale**: The vast majority of community translators on hosted.weblate.org work from English. Using DE as source would require translators to know German grammar — a significant barrier, especially for e.g. Japanese or Czech contributors. The German genitive suffix in `{regionName}er spieli` (vs. `{regionName} Playground Map` in EN) illustrates the problem concretely.
+
+**Trade-off**: The maintainer must keep `locales/en.json` and `locales/de.json` in sync manually (as they do today). Weblate treats DE as a translation like any other, but the maintainer edits it directly in the repo rather than via Weblate UI.
+
+**Alternative considered**: DE as source. Rejected — see rationale above.
+
+### 2. hosted.weblate.org, free OSS tier
+
+**Decision**: Use hosted.weblate.org rather than self-hosted Weblate.
+
+**Rationale**: spieli qualifies as a libre open-source project. Zero infrastructure to maintain. Weblate handles GitHub webhook integration, translation memory, machine translation suggestions, and quality checks out of the box.
+
+**Alternative considered**: Self-hosted Weblate (Docker). Rejected — adds operational burden with no benefit for a volunteer-maintained project.
+
+### 3. `json-i18n` file format (not `json-nested`)
+
+**Decision**: Configure the Weblate component with file format `json-i18n`.
+
+**Rationale**: The locale files use ICU message format for plurals (`{count, plural, one {# Spielgerät} other {# Spielgeräte}}`). Weblate's plain `json-nested` format treats these as opaque strings, losing plural form awareness. `json-i18n` understands ICU syntax and presents plural forms as separate translation fields in the UI.
+
+**Risk**: ICU plural syntax in Weblate requires translators to understand the `{count, plural, ...}` pattern for their target language's plural rules (e.g. Slavic languages have 3–4 plural forms). Weblate surfaces this automatically in the UI, so it's manageable.
+
+### 4. Push to dedicated branch, merge via PR
+
+**Decision**: Weblate pushes translation commits to a `weblate-translations` branch. A PR from that branch to `main` is opened for maintainer review.
+
+**Rationale**: Matches the project's `Never push directly to main` policy (CLAUDE.md). Maintainer can review, squash, and merge on their own schedule. Prevents unreviewed strings landing in production.
+
+**Configuration**: In Weblate project settings, set "Push branch" to `weblate-translations`. The Weblate GitHub integration can open PRs automatically, or the maintainer creates them manually.
+
+### 5. 80% completion threshold for language graduation
+
+**Decision**: A language is added to `SUPPORTED` in `i18n.js` (and becomes visible in the app) only when it reaches ≥ 80% translated strings in Weblate.
+
+**Rationale**: A language at 30% completion produces a jarring mixed-language UI. 80% ensures most screens are fully translated before users encounter the language. The threshold is documented in the Weblate project description so translators know the bar.
+
+**Note**: The maintainer adds the language manually: add to `SUPPORTED` array in `i18n.js`, add a `register()` call, and add a `register()` call targeting `locales/<lang>.json`.
+
+### 6. Old locale files kept as starting points
+
+**Decision**: Retain `locales/cs.json`, `es.json`, `fr.json`, `it.json`, `ja.json`, `nl.json`, `pl.json`, `pt.json`, `sv.json`, `uk.json`.
+
+**Rationale**: Even auto-generated translations provide a starting point and populate Weblate's translation memory. Weblate quality checks flag suspicious strings. Community translators benefit from having something to review rather than a blank slate.
+
+## Risks / Trade-offs
+
+- **Stale EN/DE sync**: If a new string is added to `de.json` but not `en.json`, Weblate won't surface it to translators. Mitigation: treat EN as the authoritative source; add new strings to `en.json` first, then `de.json`.
+- **ICU plural complexity**: Languages with complex plural rules (Polish, Russian, Arabic) require translators to handle multiple forms. Weblate guides this but can't prevent wrong plural patterns. Mitigation: Weblate's built-in plural validation catches most errors.
+- **Weblate PR flood**: Active translation periods may produce frequent PRs. Mitigation: Weblate batches commits; "Squash commits" option in Weblate settings keeps PR history clean.
+- **`.weblate.yml` format drift**: Weblate's discovery file format may differ by version. Mitigation: verify exact YAML schema against hosted.weblate.org docs at setup time.
+
+## Migration Plan
+
+1. Wait for issue #249 (rename to "spieli") to land
+2. Register on hosted.weblate.org, create project "spieli" linked to the GitHub repo
+3. Add `.weblate.yml` to repo root (component discovery config)
+4. Configure component: file format `json-i18n`, template `locales/en.json`, push branch `weblate-translations`
+5. Weblate imports existing locale files — translators see partially-completed languages
+6. Document graduation threshold in Weblate project description
+7. As languages reach 80%: open PR to add them to `i18n.js`

--- a/openspec/changes/add-weblate-community-translations/proposal.md
+++ b/openspec/changes/add-weblate-community-translations/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+UI strings in spieli are hardcoded German with only DE and EN supported, making the app inaccessible to non-German-speaking communities who discover it through OSM. Weblate gives community translators a web UI to contribute new languages without needing GitHub access, turning translation into a self-service OSM community activity.
+
+## What Changes
+
+- Add a `.weblate.yml` component-discovery config to the repo root so hosted.weblate.org can auto-detect the translation component
+- Register the project on hosted.weblate.org (free OSS tier) as "spieli", linked to the GitHub repo via webhook
+- Configure Weblate to use EN as the source language and `locales/en.json` as the template, with `json-i18n` format (ICU plural-aware)
+- Keep existing `locales/*.json` files (cs, es, fr, it, ja, nl, pl, pt, sv, uk) as partial starting points for community translators
+- Weblate pushes translation updates to a dedicated `weblate-translations` branch; maintainer merges via PR (never direct to `main`)
+- Document language graduation threshold: when a language reaches ≥ 80% translated in Weblate, add it to `SUPPORTED` in `i18n.js` and add a `register()` call
+
+## Capabilities
+
+### New Capabilities
+
+- `weblate-integration`: Weblate component config, repo webhook, push-branch PR workflow, and language graduation process
+
+### Modified Capabilities
+
+- `i18n-language-support`: graduation threshold added — new languages go live in the app only once they reach ≥ 80% completion in Weblate
+
+## Impact
+
+- **New file**: `.weblate.yml` in repo root (Weblate component discovery)
+- **`app/src/lib/i18n.js`**: updated when new languages graduate (≥ 80% complete)
+- **`locales/`**: new language JSON files added over time via Weblate PRs
+- **External dependency**: hosted.weblate.org account and project setup (one-time manual step)
+- **Sequencing**: should be set up after issue #249 (project rename to "spieli") so the Weblate project name matches the final repo name
+- **No changes** to the JSON translation format — the existing nested ICU structure is already compatible with Weblate's `json-i18n` format

--- a/openspec/changes/add-weblate-community-translations/specs/i18n-language-support/spec.md
+++ b/openspec/changes/add-weblate-community-translations/specs/i18n-language-support/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Language graduation threshold
+
+A language SHALL only be added to the app's `SUPPORTED` array in `app/src/lib/i18n.js` when it has reached ≥ 80% translation completion in Weblate. Languages below this threshold SHALL remain in `locales/` (available in Weblate for contributor work) but SHALL NOT appear in the running application.
+
+#### Scenario: Language reaches 80% in Weblate
+
+- **WHEN** a language's completion percentage in Weblate reaches or exceeds 80%
+- **THEN** the maintainer opens a PR that adds the language code to `SUPPORTED` in `i18n.js` and adds a `register()` call pointing to `locales/<lang>.json`
+- **AND** after the PR is merged and `make docker-build` is run, the app resolves to that language for users whose browser reports it as their preferred language
+
+#### Scenario: Language below threshold
+
+- **WHEN** a locale file for a language exists in `locales/` but the language is below 80% completion
+- **THEN** the app does NOT register or resolve to that language
+- **AND** users with that browser language fall back to EN
+
+### Requirement: Graduation threshold documented for contributors
+
+The 80% graduation threshold SHALL be stated in the Weblate project description so translators understand when their work becomes visible in the production app.
+
+#### Scenario: Translator checks project description
+
+- **WHEN** a translator views the spieli project page on hosted.weblate.org
+- **THEN** they can read that their language will be enabled in the app once it reaches 80% completion
+
+### Requirement: EN is the authoritative source for new strings
+
+When new UI strings are introduced, they SHALL be added to `locales/en.json` first. `locales/de.json` SHALL be updated in the same commit. Adding only to `de.json` without an EN counterpart is not permitted, as Weblate uses `locales/en.json` as the template.
+
+#### Scenario: Developer adds a new UI string
+
+- **WHEN** a developer adds a new translatable string to a Svelte component
+- **THEN** the corresponding key is added to both `locales/en.json` and `locales/de.json` in the same commit
+- **AND** Weblate detects the new EN key and marks it as needing translation in all registered languages

--- a/openspec/changes/add-weblate-community-translations/specs/weblate-integration/spec.md
+++ b/openspec/changes/add-weblate-community-translations/specs/weblate-integration/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Weblate component discovery file
+
+The repository SHALL contain a `.weblate.yml` file in the root that configures Weblate component auto-discovery with the following settings: file format `json-i18n`, file mask `locales/*.json`, template `locales/en.json`, source language `en`, push branch `weblate-translations`.
+
+#### Scenario: Weblate reads component config on connect
+
+- **WHEN** hosted.weblate.org connects to the GitHub repository
+- **THEN** it discovers the translation component automatically from `.weblate.yml` without manual UI configuration of file paths or format
+
+### Requirement: Translation updates arrive as PRs, never direct pushes
+
+The Weblate component SHALL be configured to push translation commits to a branch named `weblate-translations` rather than directly to `main`. A pull request from `weblate-translations` to `main` SHALL be opened for maintainer review before any translation strings reach production.
+
+#### Scenario: Translator completes strings in Weblate UI
+
+- **WHEN** a translator saves one or more translated strings in the Weblate web UI
+- **THEN** Weblate eventually pushes a commit to the `weblate-translations` branch
+- **AND** a pull request from `weblate-translations` to `main` is opened (manually or via Weblate's GitHub PR integration)
+- **AND** no translation change reaches `main` without maintainer review
+
+#### Scenario: Maintainer merges translation PR
+
+- **WHEN** the maintainer merges a PR from `weblate-translations` into `main`
+- **THEN** the updated `locales/*.json` files are bundled into the next Docker build
+- **AND** the changes become visible in the live app after `make docker-build`
+
+### Requirement: Existing locale files preserved as starting points
+
+All existing locale files in `locales/` (cs, es, fr, it, ja, nl, pl, pt, sv, uk) SHALL be retained in the repository and SHALL be imported by Weblate as partially-translated starting points. They SHALL NOT be deleted or replaced with empty files.
+
+#### Scenario: Community translator opens an existing language
+
+- **WHEN** a translator opens e.g. the French component in Weblate
+- **THEN** they see partially pre-filled translations (from the existing auto-generated `fr.json`)
+- **AND** they can review, correct, and complete the strings rather than starting from blank
+
+### Requirement: ICU plural forms presented correctly in Weblate UI
+
+The `json-i18n` format MUST be used (not `json-nested`) so that Weblate presents ICU plural strings as separate form fields per plural rule, not as a single opaque string.
+
+#### Scenario: Translator handles a plural string
+
+- **WHEN** a translator opens a key containing `{count, plural, one {...} other {...}}`
+- **THEN** Weblate presents separate input fields for each plural form defined by the target language's plural rules
+- **AND** the translator does not need to write raw ICU syntax manually

--- a/openspec/changes/add-weblate-community-translations/tasks.md
+++ b/openspec/changes/add-weblate-community-translations/tasks.md
@@ -1,0 +1,29 @@
+## 1. Prerequisites
+
+- [ ] 1.1 Confirm issue #249 (project rename to "spieli") is merged before proceeding — Weblate project name must match final repo name
+- [ ] 1.2 Register on hosted.weblate.org and create project named "spieli" (libre OSS plan)
+- [ ] 1.3 Connect the GitHub repo to Weblate via deploy key and webhook (Weblate guided setup)
+
+## 2. Repository Config
+
+- [ ] 2.1 Add `.weblate.yml` to repo root: file format `json-i18n`, file mask `locales/*.json`, template `locales/en.json`, source language `en`, push branch `weblate-translations`
+- [ ] 2.2 Verify Weblate detects the component automatically from `.weblate.yml` after connecting (check Weblate component list)
+- [ ] 2.3 Confirm Weblate imports all existing `locales/*.json` files including the partial translations (cs, es, fr, it, ja, nl, pl, pt, sv, uk)
+
+## 3. Weblate Component Configuration
+
+- [ ] 3.1 Set push branch to `weblate-translations` in Weblate component settings
+- [ ] 3.2 Enable "Squash commits" in Weblate to keep PR history clean
+- [ ] 3.3 Verify ICU plural strings (e.g. `equipment.deviceCount`) appear as separate plural-form fields in the Weblate editor, not as a single raw string
+- [ ] 3.4 Add graduation threshold to Weblate project description: "Languages are enabled in the app once they reach ≥ 80% completion"
+
+## 4. PR Workflow Verification
+
+- [ ] 4.1 Make a test translation change in Weblate and confirm it pushes to `weblate-translations` branch (not `main`)
+- [ ] 4.2 Confirm a PR from `weblate-translations` → `main` can be opened and merged following the normal review workflow
+- [ ] 4.3 After merging a test PR, confirm the updated locale file is present in `main` and `make docker-build` picks it up
+
+## 5. Developer Workflow Documentation
+
+- [ ] 5.1 Add a note to the contributing guide (or docs) explaining: new strings go to `en.json` first, then `de.json` in the same commit
+- [ ] 5.2 Document language graduation process: when a language hits 80% in Weblate, open a PR adding it to `SUPPORTED` in `i18n.js` with a `register()` call

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/design.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The README is currently written for developers who already know what Docker, Vite, PostgREST, and OpenLayers are. It covers *what* to run but rarely explains *why* it works or *what to do when it doesn't*. There are no guides for the two most common contribution tasks: adding a device type and editing translations. The JS source files have minimal comments, making it hard for a newcomer to orient themselves.
+
+The target reader is someone who: knows what a terminal is, can copy-paste a command, understands roughly what a web app is, but has never used Docker, never written JavaScript beyond small scripts, and doesn't know what PostgREST or osm2pgsql mean.
+
+## Goals / Non-Goals
+
+**Goals:**
+- README becomes a self-contained onboarding document — someone with no prior context can get the stack running and understand what they're looking at
+- Two concrete how-to guides (add device, add/edit translation) written as numbered tutorials with expected output
+- Glossary that defines every technology term used in the README in one sentence
+- Troubleshooting section that lists the 5–8 most common failure modes with their fix
+- Data-flow section with an ASCII diagram showing the full request path
+- Code comments in the three most important/complex JS files that explain the *why*, not just the *what*
+
+**Non-Goals:**
+- No runtime behaviour changes
+- No new tooling, CI, or test infrastructure
+- Not a full developer guide covering every JS module — only the three entry points identified in the proposal
+- Not an API reference — PostgREST auto-generates that from the SQL schema
+
+## Decisions
+
+**Decision 1: Keep everything in README.md, not a `/docs` folder**
+A single file is easier to find, easier to read on GitHub, and requires no extra tooling (no static site generator, no link maintenance). The README is already 312 lines and can comfortably grow to 600–800 with good section headers and a table of contents. If it grows beyond that, a `/docs` split can happen in a future change.
+
+*Alternative considered:* MkDocs or Docusaurus site. Rejected — adds dependency overhead and GitHub Pages setup complexity. Out of scope for this change.
+
+**Decision 2: Write for the terminal-comfortable but Docker-naive reader**
+Every command block includes a plain-English sentence before it explaining what it does and why. Commands are never introduced without context. Error output is explained where it's expected.
+
+**Decision 3: How-to guides as numbered steps with expected output**
+Rather than prose descriptions, the device and translation guides use numbered steps with the exact file to open, the exact change to make, and what the user should see afterward. This mirrors the format of popular beginner tutorials (DigitalOcean, Netlify docs).
+
+**Decision 4: Code comments explain the "why", skip the obvious**
+Comments added to JS files do not restate what the code does (that's readable). They explain: why a module exists, what contract it maintains, what would break if you removed it, and where to look next. This keeps comments from becoming noise.
+
+## Risks / Trade-offs
+
+- [Risk] README gets too long and becomes hard to navigate → Mitigation: anchor-linked table of contents at the top; each major section has a clear header that GitHub renders as a jump link
+- [Risk] Glossary definitions become outdated as dependencies change → Mitigation: keep definitions technology-neutral ("Vite is a build tool that turns your JS files into a single optimised file the browser can load fast") rather than version-specific
+- [Risk] How-to guides fall out of sync with the code → Mitigation: guides reference the actual file names and data structures (e.g. `objDevices` in `objPlaygroundEquipment.js`) so the next maintainer notices immediately when a guide is stale
+
+## Migration Plan
+
+All changes are additive to `README.md` and add/modify comments in three JS files. No deployment, database, or API changes required. Rollback is a git revert.

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/proposal.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The project is technically solid but its documentation assumes familiarity with Docker, Node.js, Git, and OpenStreetMap concepts — meaning anyone who didn't write the code cannot realistically get it running, extend it, or maintain it. Making the docs genuinely beginner-friendly turns the project from a personal tool into something a wider community can operate and contribute to.
+
+## What Changes
+
+- Rewrite the README into a structured, beginner-oriented guide: what every tool is, why it exists, and what to do when something goes wrong
+- Add a **Glossary** section explaining Docker, Vite, PostgREST, osm2pgsql, OpenLayers, i18next, Overpass, and OSM in plain language
+- Add a **"How to add a new playground device"** guide explaining `objPlaygroundEquipment.js` and the full round-trip: OSM tag → JS object → detail panel
+- Add a **"How to change or add a UI string / translation"** guide covering the `locales/*.json` workflow
+- Add a **"How the data flows"** narrative diagram section: phone → nginx → PostgREST → PostgreSQL, and the reverse path from Overpass during dev
+- Add a **"Troubleshooting"** section covering the most common failure modes (port in use, import stuck, geolocation blocked, map blank)
+- Add inline code comments to the most complex / entry-point JS files (`main.js`, `selectPlayground.js`, `objPlaygroundEquipment.js`) to make them self-teaching
+- Add a **"Contributing"** section with a step-by-step PR walkthrough (branch → code → test locally → push → PR)
+
+## Capabilities
+
+### New Capabilities
+
+- `readme-beginner-guide`: Expanded README with glossary, data-flow narrative, troubleshooting, and contributing sections
+- `device-howto`: Step-by-step guide for adding a new playground device type (OSM tag to rendered detail panel)
+- `translation-howto`: Guide for editing existing translations and adding a new language
+- `code-comments`: Inline comments in key JS entry-point files making them self-explanatory for newcomers
+
+### Modified Capabilities
+
+## Impact
+
+- `README.md` — substantially expanded (primary deliverable)
+- `js/objPlaygroundEquipment.js` — add explanatory block comments
+- `js/main.js` — add section comments explaining module wiring
+- `js/selectPlayground.js` — add comments on the panel state machine and URL hash handling
+- No runtime behaviour changes; documentation and comments only

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/code-comments/spec.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/code-comments/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Entry-point file comments in main.js
+`js/main.js` SHALL have a top-of-file block comment explaining what this file is, why it exists as the entry point, which modules it wires together, and what order things initialise in.
+
+Each logical section within the file SHALL have a one-line comment explaining why that section exists (not what the code does — the code is readable; the comment answers "why is this here?").
+
+#### Scenario: Newcomer opens main.js first
+- **WHEN** a newcomer opens `js/main.js` to understand how the app starts
+- **THEN** the top comment gives them a mental map of the module graph and they know where to look next for each concern
+
+---
+
+### Requirement: Panel state machine comments in selectPlayground.js
+`js/selectPlayground.js` SHALL have a top-of-file block comment that explains:
+- What "selecting a playground" means (URL hash, feature highlight, panel display)
+- The three panel states on mobile (hidden / peek / open) and what triggers each
+- The `showAttributes(true/false)` contract and what calling code is expected to do
+
+Complex helper functions (drag handlers, panel state transitions) SHALL each have a short comment explaining the *why* (e.g. why `window.innerHeight` instead of `element.offsetHeight`).
+
+#### Scenario: Newcomer wants to change what happens when a playground is clicked
+- **WHEN** they open `selectPlayground.js` and read the top comment
+- **THEN** they understand the panel state model and can find the right function to modify without reading the entire 1400-line file
+
+---
+
+### Requirement: Device catalogue comments in objPlaygroundEquipment.js
+`js/objPlaygroundEquipment.js` SHALL have a top-of-file block comment explaining:
+- The purpose of `objDevices` and `objFeatures`
+- Every field in a device entry (`name_de`, `image`, `category`, `filterable`, `filter_attr`) with a one-line description of what it does and what happens if it's omitted
+- Where the `image` filename comes from (Wikimedia Commons `File:` prefix) and the fallback behaviour
+
+#### Scenario: Maintainer wants to add a new device
+- **WHEN** they open `objPlaygroundEquipment.js` for the first time
+- **THEN** the top comment alone gives them enough information to add a new entry correctly without reading the how-to guide

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/device-howto/spec.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/device-howto/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Add-a-device how-to guide
+The README SHALL include a numbered tutorial explaining how to add support for a new playground device type, covering the full journey from OSM tag to rendered detail panel.
+
+The guide MUST cover:
+1. How to find the correct OSM tag for a device (link to OSM wiki `Key:playground`)
+2. The structure of an entry in `objDevices` inside `js/objPlaygroundEquipment.js` — all fields explained (`name_de`, `image`, `category`, `filterable`, `filter_attr`)
+3. How to find a Wikimedia Commons image filename for the `image` field
+4. How to verify the change locally (run `make dev`, open a playground that has the device, expand the detail panel)
+5. What to commit and how to open a PR
+
+#### Scenario: Maintainer adds a new device type end-to-end
+- **WHEN** a maintainer follows the guide for a new OSM playground tag (e.g. `playground=balance_beam`)
+- **THEN** they can add the entry in `objPlaygroundEquipment.js`, see the device appear in the detail panel during local dev, and know exactly what to commit
+
+#### Scenario: Maintainer finds the right Wikimedia image
+- **WHEN** the guide explains the `image` field
+- **THEN** the reader knows to search `commons.wikimedia.org`, copy the `File:` filename, and understands the Commons-first + OSM-wiki-fallback behaviour

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/readme-beginner-guide/spec.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/readme-beginner-guide/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Table of contents
+The README SHALL have an anchor-linked table of contents at the top listing all major sections so a reader can jump directly to what they need.
+
+#### Scenario: Reader finds the troubleshooting section fast
+- **WHEN** a user opens the README on GitHub
+- **THEN** they can click a "Troubleshooting" link in the table of contents and land on that section without scrolling
+
+---
+
+### Requirement: Glossary section
+The README SHALL include a Glossary section that defines every technology term used in the document in one plain-English sentence, with no assumed prior knowledge.
+
+Terms that MUST be defined: Docker, Docker Compose, Vite, Node.js, PostgREST, PostgreSQL, PostGIS, osm2pgsql, OpenLayers, i18next, Overpass API, OpenStreetMap (OSM), nginx, PBF file, OSM relation ID.
+
+#### Scenario: Reader unfamiliar with Docker reads the glossary
+- **WHEN** a reader encounters "Docker" in the README
+- **THEN** they can find a one-sentence plain-English explanation in the Glossary without leaving the page
+
+---
+
+### Requirement: Data-flow section with diagram
+The README SHALL include a "How the data flows" section containing an ASCII diagram and a short narrative (3–5 sentences) that explains the full request path from the browser to the database and back, and separately explains how Overpass is used during local development without a database.
+
+#### Scenario: Reader understands why PostgREST exists
+- **WHEN** a reader follows the data-flow narrative
+- **THEN** they understand that PostgREST turns the database into an HTTP API without requiring custom server code
+
+---
+
+### Requirement: Troubleshooting section
+The README SHALL include a Troubleshooting section listing at least the following failure modes, each with its symptom and exact fix:
+
+1. Port 8080 already in use
+2. `make import` exits immediately or fails with a database error
+3. Map loads but shows no playgrounds (blank map, no markers)
+4. Geolocation button does nothing on mobile
+5. Dev server starts but changes don't appear (cache issue)
+6. `make lan-url` prints "Could not detect LAN IP"
+
+#### Scenario: Reader's map is blank
+- **WHEN** a reader follows the "Map loads but shows no playgrounds" troubleshooting entry
+- **THEN** they find the likely cause (import not run, wrong relation ID, or Overpass timeout) and the command to verify or fix it
+
+---
+
+### Requirement: Contributing section with PR walkthrough
+The README SHALL include a Contributing section with a step-by-step numbered tutorial covering: creating a branch, making a change, testing locally, pushing, and opening a PR — using concrete commands and referencing the project's naming conventions.
+
+#### Scenario: First-time contributor creates a PR
+- **WHEN** a reader follows the Contributing section step by step
+- **THEN** they produce a correctly named branch, a commit with a conventional commit message, and a PR on GitHub without needing external documentation

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/translation-howto/spec.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/specs/translation-howto/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Translation editing how-to guide
+The README SHALL include a numbered tutorial explaining how to edit an existing UI string and how to add a new language, written for someone who has never worked with JSON or i18next before.
+
+The guide MUST cover:
+1. Where all UI strings live (`locales/*.json`) and how the file structure maps to the UI
+2. How to find the key for a string they want to change (browser dev tools or search in `locales/de.json`)
+3. How to edit a value safely (valid JSON: commas, quotes)
+4. How to test the change locally (`make dev`, `?lang=xx` URL parameter)
+5. How to add a completely new language: copy `locales/en.json`, translate, register in `js/i18n.js`
+6. A note about plural forms for languages like Polish/Ukrainian
+
+#### Scenario: Non-developer fixes a typo in the German UI
+- **WHEN** a contributor follows the guide to find and fix a typo in the German translation
+- **THEN** they open `locales/de.json`, find the key, edit the value, and verify the fix in the browser without touching any other file
+
+#### Scenario: Community member adds Romanian
+- **WHEN** a Romanian speaker follows the "add a new language" steps
+- **THEN** they produce a valid `locales/ro.json` and a correct `js/i18n.js` registration without needing to understand how i18next works internally

--- a/openspec/changes/archive/2026-04-12-beginner-friendly-docs/tasks.md
+++ b/openspec/changes/archive/2026-04-12-beginner-friendly-docs/tasks.md
@@ -1,0 +1,42 @@
+## 1. README — Structure & Navigation
+
+- [x] 1.1 Add an anchor-linked table of contents at the top of README.md covering all major sections
+- [x] 1.2 Add a Glossary section defining: Docker, Docker Compose, Vite, Node.js, PostgREST, PostgreSQL, PostGIS, osm2pgsql, OpenLayers, i18next, Overpass API, OpenStreetMap, nginx, PBF file, OSM relation ID
+
+## 2. README — How It Works
+
+- [x] 2.1 Add a "How the data flows" section with an ASCII diagram showing browser → nginx → PostgREST → PostgreSQL (production) and the Overpass fallback path (local dev without a database)
+- [x] 2.2 Add a short narrative (3–5 sentences) below the diagram explaining why each component exists in plain language
+
+## 3. README — How-To: Add a Playground Device
+
+- [x] 3.1 Write a numbered guide for adding a new device type: how to find the OSM tag, how to add an entry to `objDevices` in `js/objPlaygroundEquipment.js` with all fields explained
+- [x] 3.2 Explain how to find a Wikimedia Commons image and use the `File:` filename in the `image` field
+- [x] 3.3 Explain how to verify the change locally (`make dev`, open a playground with that device, check the detail panel)
+
+## 4. README — How-To: Edit Translations / Add a Language
+
+- [x] 4.1 Write a numbered guide for finding and editing an existing UI string in `locales/*.json`, including how to use the `?lang=xx` URL parameter to test it
+- [x] 4.2 Write the steps for adding a completely new language (copy `en.json`, translate, register in `js/i18n.js`) with a note on plural forms
+
+## 5. README — Troubleshooting
+
+- [x] 5.1 Add a Troubleshooting section with symptom + fix entries for: port 8080 in use, import fails/exits immediately, map loads but shows no playgrounds, geolocation button does nothing on mobile, dev server changes don't appear, `make lan-url` can't detect IP
+
+## 6. README — Contributing
+
+- [x] 6.1 Add a Contributing section with step-by-step instructions: create branch (naming convention), make change, test locally, conventional commit message, push, open PR on GitHub
+
+## 7. Code Comments — objPlaygroundEquipment.js
+
+- [x] 7.1 Add a top-of-file block comment explaining the purpose of `objDevices` and `objFeatures`, every field in a device entry with its effect and what happens when omitted, and how the `image` field and Commons/OSM-wiki fallback work
+
+## 8. Code Comments — main.js
+
+- [x] 8.1 Add a top-of-file block comment explaining the entry-point role, which modules are wired here, and the initialisation order
+- [x] 8.2 Add section comments to each logical block within the file explaining why that section exists
+
+## 9. Code Comments — selectPlayground.js
+
+- [x] 9.1 Add a top-of-file block comment explaining what "selecting a playground" entails (URL hash, feature highlight, panel state), the three mobile panel states, and the `showAttributes` contract
+- [x] 9.2 Add inline comments to the drag handler functions explaining the non-obvious choices (e.g. why `window.innerHeight` is used instead of `element.offsetHeight`)

--- a/openspec/changes/archive/2026-04-12-local-mobile-testing/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-12-local-mobile-testing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/archive/2026-04-12-local-mobile-testing/design.md
+++ b/openspec/changes/archive/2026-04-12-local-mobile-testing/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The app runs in two modes locally:
+
+1. **Vite dev server** (`make dev` / `npm start`) — hot-reload frontend, Overpass fallback for data. Currently binds to `localhost:5173` only, unreachable from other devices.
+2. **Docker Compose stack** (`make up`) — full production-like stack: nginx/app on `${APP_PORT:-8080}:80`. Docker's default port-binding already uses `0.0.0.0`, so the stack is *already* reachable at `<host-ip>:8080` from any device on the same network.
+
+The gap is exclusively in the Vite dev server path. A secondary gap is discoverability: no target or output tells the developer what address to open on the phone.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Vite dev server accessible from any device on the local network
+- A single command prints the LAN URLs (both Vite and Docker stack) so the developer can copy-paste them into the phone browser
+- No security risk introduced (LAN-only, not exposed to the internet)
+
+**Non-Goals:**
+- Exposing the app to the internet / ngrok / tunnel setup
+- Changing how Docker networking works (it already works)
+- HTTPS / mDNS / hostname resolution — plain IP is sufficient
+
+## Decisions
+
+### 1. Configure Vite host via `vite.config.js` (not CLI flag)
+
+**Decision:** Add `server: { host: true }` to `vite.config.js`.
+
+**Why over adding `--host` to the npm script?** `vite.config.js` is the canonical place for Vite server config; it keeps `package.json` scripts clean and applies to both `npm start` and `make dev` without duplicating the flag.
+
+`host: true` is equivalent to `0.0.0.0` — Vite will bind on all interfaces and print both `localhost` and the LAN URL on startup automatically.
+
+### 2. Add `make lan-url` helper target
+
+**Decision:** Add a `make lan-url` Makefile target that prints the current machine's LAN IP and both URLs (Vite dev and Docker stack).
+
+**Why?** After `make dev` starts, Vite already prints the LAN URL in the terminal. But for the Docker stack (which runs detached), there is no URL output. A dedicated target gives a consistent, copy-pasteable answer regardless of which stack is running.
+
+Implementation: use `ip route get 1` or `hostname -I` to find the primary LAN IP — both are available on Linux without extra tools.
+
+## Risks / Trade-offs
+
+- [Risk] Vite dev server bound to `0.0.0.0` is reachable by anyone on the same network, not just the developer's phone → Mitigation: acceptable for a local dev workflow; the app has no auth or sensitive data. Document this clearly.
+- [Risk] `hostname -I` may return multiple IPs (VPN, Docker bridge, etc.) → Mitigation: take the first non-Docker address, or simply print all and let the user pick.
+- [Risk] Firewall rules on the host may block port 5173 → Mitigation: document this in the guide; user can temporarily open the port or use the Docker stack on 8080 instead.

--- a/openspec/changes/archive/2026-04-12-local-mobile-testing/proposal.md
+++ b/openspec/changes/archive/2026-04-12-local-mobile-testing/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+All recent mobile-facing fixes (search bar, photo modal, device images) can only be properly tested on a real phone. The app runs in Docker locally, but currently has no way for a phone on the same WiFi to reach it — the dev server binds to localhost only and there is no documented LAN access path.
+
+## What Changes
+
+- The Vite dev server is configured to bind to `0.0.0.0` so it is reachable on the local network
+- A `make` target (or npm script) exposes the LAN URL after startup so the developer knows which address to open on the phone
+- The Docker Compose setup (for production-like local testing) is configured to bind to `0.0.0.0` as well
+- A short guide is added to the README / CLAUDE.md explaining how to use LAN testing (find IP, open on phone)
+
+## Capabilities
+
+### New Capabilities
+
+- `lan-dev-server`: Vite dev server accessible from any device on the local network, with the LAN URL printed on startup
+
+### Modified Capabilities
+
+<!-- No existing spec-level requirements are changing -->
+
+## Impact
+
+- `vite.config.js` (or `package.json` scripts) — add `--host` flag to the dev server command
+- `Makefile` — update `make dev` target (and optionally add `make dev-lan`)
+- `public/config.js` / environment handling — no change needed; Overpass fallback already works without a backend
+- Docker Compose (`compose.yml` / `compose.prod.yml`) — ensure the app container port binding uses `0.0.0.0`
+- `README.md` or `CLAUDE.md` — brief note on LAN testing

--- a/openspec/changes/archive/2026-04-12-local-mobile-testing/specs/lan-dev-server/spec.md
+++ b/openspec/changes/archive/2026-04-12-local-mobile-testing/specs/lan-dev-server/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Vite dev server binds to all network interfaces
+The Vite dev server SHALL bind to `0.0.0.0` (all interfaces) so that devices on the same local network can reach it by the host machine's LAN IP address.
+
+#### Scenario: Dev server reachable from phone on same WiFi
+- **WHEN** developer runs `make dev` (or `npm start`)
+- **THEN** the server binds to `0.0.0.0:5173` and is reachable at `http://<host-lan-ip>:5173` from another device on the same network
+
+#### Scenario: LAN URL printed on startup
+- **WHEN** the Vite dev server starts
+- **THEN** the terminal output includes both the `localhost` URL and the `Network:` LAN URL so the developer can copy it to the phone
+
+### Requirement: `make lan-url` prints local access addresses
+A `make lan-url` target SHALL print the host machine's primary LAN IP and the full URLs for both the Vite dev server and the Docker Compose stack, so the developer always has a ready-to-use address regardless of which stack is running.
+
+#### Scenario: Developer runs `make lan-url`
+- **WHEN** developer runs `make lan-url` in the project directory
+- **THEN** the terminal prints the LAN IP and both access URLs (Vite on port 5173, Docker stack on port 8080 or `$APP_PORT`)
+
+### Requirement: LAN testing documented in CLAUDE.md
+CLAUDE.md SHALL include a short section explaining how to access the running app from a phone on the same WiFi network, covering both the Vite dev server and Docker Compose stack paths.
+
+#### Scenario: Developer follows documentation
+- **WHEN** developer reads the LAN testing section in CLAUDE.md
+- **THEN** they can find their LAN IP, open the correct URL on their phone, and verify the app loads without additional configuration

--- a/openspec/changes/archive/2026-04-12-local-mobile-testing/tasks.md
+++ b/openspec/changes/archive/2026-04-12-local-mobile-testing/tasks.md
@@ -1,0 +1,13 @@
+## 1. Vite dev server — bind to all interfaces
+
+- [x] 1.1 Add `server: { host: true }` to `vite.config.js` so Vite binds to `0.0.0.0` and prints the LAN URL on startup
+
+## 2. Makefile — LAN URL helper
+
+- [x] 2.1 Add `make lan-url` target that prints the host LAN IP and the full URLs for the Vite dev server (port 5173) and the Docker stack (port `$APP_PORT` / 8080)
+- [x] 2.2 Add `lan-url` to the `.PHONY` declaration and the `help` output
+
+## 3. Documentation
+
+- [x] 3.1 Add a "Testing on mobile / LAN access" section to `CLAUDE.md` explaining how to find the LAN IP (`make lan-url`), which URL to open on the phone, and a note about the Docker stack already being reachable without extra config
+- [x] 3.2 Add a "Testing on a phone / LAN access" subsection to `README.md` under "Local development"

--- a/openspec/changes/archive/2026-04-12-security-hardening/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-12-security-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/archive/2026-04-12-security-hardening/design.md
+++ b/openspec/changes/archive/2026-04-12-security-hardening/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The app fetches playground data from PostgREST (which reads PostgreSQL/PostGIS) and renders OSM tag values into the detail panel using `innerHTML`. OSM is a crowd-sourced dataset — any registered user can set a tag value to `<script>alert(1)</script>`. Currently those values are interpolated directly into HTML strings, creating stored XSS. The nginx server returns no security headers.
+
+The frontend is a Vite-built ES module bundle served by nginx. There is no server-side rendering. All OSM data arrives as JSON from the `/api/` PostgREST proxy.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate stored XSS from OSM tag values in innerHTML
+- Prevent protocol injection in `tel:` / `mailto:` link hrefs
+- Add standard HTTP security headers to nginx
+- Scope `postMessage` to a configurable trusted origin
+
+**Non-Goals:**
+- DOM-library adoption (DOMPurify or similar) — overkill for this use case; a small `escapeHtml()` helper is sufficient
+- Authentication or authorisation changes
+- PostgREST / SQL-layer hardening (PostgREST uses parameterised queries; no injection risk there)
+
+## Decisions
+
+### 1. Escape with a local helper, not a library
+
+**Decision:** Add a single `escapeHtml(str)` utility in `selectPlayground.js` (or a shared `utils.js`) that converts `&`, `<`, `>`, `"`, `'` to their HTML entities.
+
+**Rationale:** The app only needs to make text safe for innerHTML insertion. DOMPurify is designed for rich HTML (user-authored markup). Here, all OSM values are plain text — no formatting is intentionally preserved. A 5-line helper is simpler, has zero dependency surface, and is easy to audit.
+
+**Alternative considered:** Switch all assignments from `innerHTML` to `textContent`. Not universally applicable — many assignments mix escaped OSM values with trusted static HTML tags (`<span class="info-label">`, `<i>`, `<br>`), so plain `textContent` would destroy the layout.
+
+### 2. Allowlist-validate link protocols
+
+**Decision:** Before constructing `href="tel:${phone}"` or `href="mailto:${email}"`, check that the value starts with the expected protocol. If it does not match, omit the link rather than render a potentially dangerous href.
+
+**Rationale:** A `javascript:` URI in a `tel:` href is clickable on most browsers. OSM data is crowd-sourced and unvalidated at ingestion. Simple prefix checks cost nothing and eliminate the entire class.
+
+### 3. HTTP security headers in nginx
+
+**Decision:** Add a `Content-Security-Policy` that allows:
+- `default-src 'self'`
+- `script-src 'self'` (Vite bundles all JS into the same origin)
+- `style-src 'self' 'unsafe-inline'` (Bootstrap uses inline styles)
+- `img-src 'self' data: https:` (Wikimedia Commons, OpenStreetMap tile servers)
+- `frame-src https://panoramax.xyz` (Panoramax iframe)
+- `connect-src 'self' https:` (PostgREST proxy + external APIs)
+
+Also add `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN` (the app is embedded in Hub via iframe — use `ALLOW-FROM` is deprecated; Hub handles this via CSP on its end), `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: geolocation=(self)`.
+
+**Alternative considered:** Setting headers in the Vite dev server — not persistent in production. nginx is the right place.
+
+**Note on X-Frame-Options:** The app is intentionally embeddable in the spieli Hub iframe. `X-Frame-Options: SAMEORIGIN` would block this. Use `ALLOW-FROM` is deprecated. The correct solution is to omit `X-Frame-Options` and rely on CSP `frame-ancestors` instead, which supports multiple trusted origins.
+
+### 4. postMessage target origin
+
+**Decision:** Read a `PARENT_ORIGIN` value from `window.APP_CONFIG` (set by `docker-entrypoint.sh` from an env var, defaulting to `'*'` to preserve backward compatibility). Use this as the `targetOrigin` in `postMessage`.
+
+**Rationale:** Sending `postMessage` to `'*'` means any page that has embedded this app as an iframe can receive the escape event. Scoping to the Hub origin prevents information leakage to unknown embedders. The default of `'*'` ensures standalone deployments that haven't configured a Hub origin are unaffected.
+
+## Risks / Trade-offs
+
+- **Breaking legitimate HTML in OSM fields:** Some OSM contributors add basic markup in `description` fields. After escaping, this will render as literal characters (e.g. `&lt;b&gt;`). This is the correct behaviour — we do not render contributor-supplied HTML.
+- **CSP `unsafe-inline` for styles:** Bootstrap 5 relies on inline styles. Removing this would require significant refactoring. Accepted trade-off for now.
+- **CSP in nginx blocks dev server:** The Vite dev server runs on a different port. During `make dev`, headers come from Vite's dev middleware, not nginx. CSP only applies to the Docker stack. This is acceptable.
+
+## Migration Plan
+
+1. Add `escapeHtml()` utility to `js/selectPlayground.js`
+2. Apply it to all OSM tag value interpolations in that file
+3. Apply it to the toast message in `js/map.js`
+4. Validate phone/email protocol before href construction
+5. Add security headers to `nginx.conf`
+6. Add `PARENT_ORIGIN` to `public/config.js` and `docker-entrypoint.sh`; update `js/config.js` and `js/main.js`
+7. Rebuild and smoke-test the detail panel against a real playground

--- a/openspec/changes/archive/2026-04-12-security-hardening/proposal.md
+++ b/openspec/changes/archive/2026-04-12-security-hardening/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The app renders OpenStreetMap tag values (description, note, operator, phone, email, surface, etc.) directly into `innerHTML` without escaping. A malicious OSM contributor can inject arbitrary HTML/JavaScript that executes in every visitor's browser. The nginx server also sends no HTTP security headers, leaving the app without a last line of defence.
+
+## What Changes
+
+- Add an `escapeHtml()` helper and apply it to all OSM-sourced string values before they are interpolated into `innerHTML`
+- Validate `tel:` and `mailto:` href values to prevent protocol injection (e.g. `javascript:` URLs from bad OSM data)
+- Add HTTP security headers to nginx: `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`
+- Replace the `postMessage` wildcard target origin (`'*'`) with a configurable trusted origin
+
+## Capabilities
+
+### New Capabilities
+- `xss-prevention`: Escape all OSM-sourced values before innerHTML insertion and sanitize link hrefs
+- `http-security-headers`: Add defensive HTTP headers to the nginx config
+
+### Modified Capabilities
+<!-- None — no existing spec-level behavior changes -->
+
+## Impact
+
+- `js/selectPlayground.js` — all `innerHTML` assignments that include OSM tag values; href construction for phone/email/wikidata links
+- `js/main.js` — `postMessage` call; modal HTML built from i18n strings (already trusted, but reviewed for completeness)
+- `js/map.js` — `innerHTML` assignment for toast messages
+- `nginx.conf` — new response headers block
+- No API, database, or dependency changes required

--- a/openspec/changes/archive/2026-04-12-security-hardening/specs/http-security-headers/spec.md
+++ b/openspec/changes/archive/2026-04-12-security-hardening/specs/http-security-headers/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: nginx sends X-Content-Type-Options header
+The nginx server SHALL include `X-Content-Type-Options: nosniff` on all responses, preventing browsers from MIME-sniffing responses away from the declared content type.
+
+#### Scenario: Static asset response includes header
+- **WHEN** a browser requests any static file from the nginx server
+- **THEN** the response includes `X-Content-Type-Options: nosniff`
+
+### Requirement: nginx sends Referrer-Policy header
+The nginx server SHALL include `Referrer-Policy: strict-origin-when-cross-origin` on all responses, limiting the referrer information sent to third-party services.
+
+#### Scenario: Cross-origin request has limited referrer
+- **WHEN** a user navigates from the app to an external link
+- **THEN** only the origin (not the full URL including hash) is sent as the referrer
+
+### Requirement: nginx sends Permissions-Policy header
+The nginx server SHALL include `Permissions-Policy: geolocation=(self)` to restrict geolocation access to the app's own origin only.
+
+#### Scenario: Geolocation policy is declared
+- **WHEN** any response is served by nginx
+- **THEN** the response includes a `Permissions-Policy` header that permits geolocation only for `self`
+
+### Requirement: nginx sends Content-Security-Policy header
+The nginx server SHALL include a `Content-Security-Policy` header on HTML responses that:
+- Restricts `default-src` to `'self'`
+- Allows `script-src 'self'` only
+- Allows `style-src 'self' 'unsafe-inline'` (required for Bootstrap)
+- Allows `img-src 'self' data: https:`
+- Allows `frame-src https://panoramax.xyz` (for the Panoramax iframe)
+- Allows `connect-src 'self' https:` (for PostgREST proxy and external APIs)
+- Allows `font-src 'self'` (Bootstrap Icons woff2)
+
+#### Scenario: CSP header present on HTML response
+- **WHEN** a browser requests `index.html`
+- **THEN** the response includes a `Content-Security-Policy` header with the directives listed above
+
+#### Scenario: Inline script blocked by CSP
+- **WHEN** a CSP-compliant browser attempts to execute an injected inline script
+- **THEN** the browser blocks execution and logs a CSP violation
+
+### Requirement: nginx allows iframe embedding for Hub
+The nginx server SHALL NOT send `X-Frame-Options` as it is superseded by CSP `frame-ancestors`. The `Content-Security-Policy` MUST include `frame-ancestors 'self'` to permit same-origin embedding while being extendable by operators who add a Hub origin.
+
+#### Scenario: App loads in same-origin iframe
+- **WHEN** the app is embedded in an iframe on the same origin
+- **THEN** the browser permits the embedding (no framing violation)

--- a/openspec/changes/archive/2026-04-12-security-hardening/specs/xss-prevention/spec.md
+++ b/openspec/changes/archive/2026-04-12-security-hardening/specs/xss-prevention/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: OSM tag values escaped before innerHTML insertion
+All string values originating from OSM tags (fetched from PostgREST or equipment API) SHALL be HTML-escaped before being interpolated into any `innerHTML` assignment. The characters `&`, `<`, `>`, `"`, and `'` MUST be converted to their HTML entity equivalents.
+
+#### Scenario: Description with HTML characters renders safely
+- **WHEN** a playground's `description` tag contains `<script>alert(1)</script>`
+- **THEN** the detail panel displays the literal text `<script>alert(1)</script>` as visible characters, and no script executes
+
+#### Scenario: Operator name with ampersand renders correctly
+- **WHEN** a playground's `operator` tag is `Spielplatz & Freizeit GmbH`
+- **THEN** the operator field displays `Spielplatz & Freizeit GmbH` (rendered entity, not broken HTML)
+
+#### Scenario: Unknown surface value is escaped
+- **WHEN** a playground's `surface` tag is not in the known lookup and contains `<b>gravel</b>`
+- **THEN** the surface field shows the literal string `<b>gravel</b>` as text, no bold rendered
+
+#### Scenario: Note and fixme fields escaped
+- **WHEN** a playground's `note` or `fixme` tag contains `<img src=x onerror=alert(1)>`
+- **THEN** no image element is injected; the tag value appears as plain escaped text
+
+### Requirement: Link hrefs validated before use
+The `phone` and `email` OSM tag values SHALL be validated before constructing `href` attributes. A phone value MUST start with `+` or a digit (after optional whitespace). An email value MUST contain `@`. Values failing validation SHALL be displayed as plain text without a hyperlink. Neither field SHALL allow a `javascript:` scheme under any circumstances.
+
+#### Scenario: Valid phone number renders as tel: link
+- **WHEN** the `phone` tag is `+49 661 12345`
+- **THEN** a `href="tel:+49 661 12345"` link is rendered
+
+#### Scenario: Invalid phone value renders as text only
+- **WHEN** the `phone` tag is `javascript:alert(1)` or `call us!`
+- **THEN** the value is displayed as plain escaped text with no anchor element
+
+#### Scenario: Valid email renders as mailto: link
+- **WHEN** the `email` tag is `info@spielplatz.de`
+- **THEN** a `href="mailto:info@spielplatz.de"` link is rendered
+
+#### Scenario: Invalid email value renders as text only
+- **WHEN** the `email` tag contains no `@` character
+- **THEN** the value is displayed as plain escaped text with no anchor element
+
+### Requirement: postMessage uses scoped target origin
+The `window.parent.postMessage()` call for the ESC key event SHALL use a configurable target origin from `window.APP_CONFIG.parentOrigin`. When `parentOrigin` is empty or absent, it SHALL default to `'*'` to preserve backward compatibility for standalone deployments.
+
+#### Scenario: Hub origin configured
+- **WHEN** `APP_CONFIG.parentOrigin` is set to `https://hub.example.com`
+- **THEN** `postMessage` is sent with `targetOrigin` = `https://hub.example.com`
+
+#### Scenario: No origin configured
+- **WHEN** `APP_CONFIG.parentOrigin` is absent or empty
+- **THEN** `postMessage` is sent with `targetOrigin` = `'*'`

--- a/openspec/changes/archive/2026-04-12-security-hardening/tasks.md
+++ b/openspec/changes/archive/2026-04-12-security-hardening/tasks.md
@@ -1,0 +1,35 @@
+## 1. XSS Prevention — escapeHtml helper
+
+- [ ] 1.1 Add `escapeHtml(str)` utility function to `js/selectPlayground.js` that escapes `&`, `<`, `>`, `"`, `'` to HTML entities; return empty string for null/undefined input
+
+## 2. XSS Prevention — escape OSM values in detail panel
+
+- [ ] 2.1 Escape `location_str` (built from `addr:street`, `addr:suburb`, etc.) before `info-location` innerHTML assignment
+- [ ] 2.2 Escape `description`, `description_de`, `note`, `fixme` values before building `playgroundDescription`
+- [ ] 2.3 Escape `surfaceLabel` fallback (raw `surface` tag value) before `info-surface` innerHTML assignment
+- [ ] 2.4 Escape `operator` value before `info-operator` innerHTML assignments (both the linked and unlinked variants)
+- [ ] 2.5 Escape `ageStr` (built from `min_age`/`max_age` tags) before `info-age` innerHTML assignment
+- [ ] 2.6 Escape equipment device names (`name_de`, raw key fallback) and attribute values in `device_string` / `fallback_string` before `info-device-list` / `info-equipment` innerHTML assignments
+
+## 3. XSS Prevention — validate phone and email hrefs
+
+- [ ] 3.1 Validate `phone` value: only render as `href="tel:..."` if it starts with `+` or a digit; otherwise display as escaped plain text
+- [ ] 3.2 Validate `email` value: only render as `href="mailto:..."` if it contains `@`; otherwise display as escaped plain text
+
+## 4. XSS Prevention — postMessage origin
+
+- [ ] 4.1 Add `parentOrigin` key to `public/config.js` (default empty string) and to `docker-entrypoint.sh` (env var `PARENT_ORIGIN`, default empty)
+- [ ] 4.2 Export `parentOrigin` from `js/config.js`
+- [ ] 4.3 Update `js/main.js` to use `parentOrigin || '*'` as the `targetOrigin` in `window.parent.postMessage`
+
+## 5. HTTP Security Headers — nginx
+
+- [ ] 5.1 Add `X-Content-Type-Options: nosniff` to `nginx.conf` as a global response header
+- [ ] 5.2 Add `Referrer-Policy: strict-origin-when-cross-origin` to `nginx.conf`
+- [ ] 5.3 Add `Permissions-Policy: geolocation=(self)` to `nginx.conf`
+- [ ] 5.4 Add `Content-Security-Policy` header to `nginx.conf` with directives: `default-src 'self'`, `script-src 'self'`, `style-src 'self' 'unsafe-inline'`, `img-src 'self' data: https:`, `frame-src https://panoramax.xyz`, `connect-src 'self' https:`, `font-src 'self'`, `frame-ancestors 'self'`
+
+## 6. Verification
+
+- [ ] 6.1 Run `make docker-build` and open the app — verify the detail panel still renders correctly for a real playground (name, operator, surface, contact, equipment)
+- [ ] 6.2 Check response headers with `curl -I http://localhost:8080` — confirm all five security headers are present

--- a/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/design.md
+++ b/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The README was written for the original vanilla-JS version of spielplatzkarte. Since then, the frontend was fully rewritten in Svelte 5, the Hub was merged into the main repo as a dual-mode Vite app, and several new directories and env vars were added. The README now contradicts the actual codebase in multiple places.
+
+Current state of inaccuracies:
+- Tech stack table says "JavaScript (ES Modules)" and "Bootstrap 5" — reality is Svelte 5 + Bootstrap 5 + Tailwind CSS 4
+- Two how-to guides reference paths that no longer exist (`js/` directory was removed)
+- The i18n how-to references `js/i18n.js` and a language-registration step — i18next is in `package.json` but is **not imported anywhere** in the Svelte source; strings appear hardcoded in German
+- Federation section describes the Hub as a separate repository; it is now in `app/src/hub/` toggled by `APP_MODE`
+- Config table is missing `APP_MODE`, `GEOSERVER_URL`, `GEOSERVER_WORKSPACE`, `HUB_POLL_INTERVAL`
+- New directories (`processing/`, `taginfo/`, `oci/`) are unmentioned
+
+## Goals / Non-Goals
+
+**Goals:**
+- README accurately describes the current tech stack, file paths, and architecture
+- How-to guides point to files that exist
+- Config reference is complete
+- Contributors are not misled about how i18n works (or doesn't yet work) in the Svelte rewrite
+
+**Non-Goals:**
+- Re-implementing i18n in the Svelte app (that is a separate engineering task)
+- Documenting every internal file — the README is for deployers and contributors, not code archaeology
+- Updating the Hub's own `README.md` (separate repo)
+
+## Decisions
+
+### Decision: Note i18n as "not yet ported" rather than removing the how-to
+
+The existing how-to guide is invalid because `js/i18n.js` does not exist. However, the `locales/*.json` files still exist and the intent is presumably to re-integrate i18next. The clearest honest approach is to update the guide to reflect current reality: strings are currently hardcoded in German in the Svelte components; multi-language support via i18next is planned but not yet implemented. The `locales/` files are preserved for when it is.
+
+Alternative considered: Delete the "Add a language" section entirely. Rejected — it would lose useful context about the intended i18n approach and make contributions harder once it's re-implemented.
+
+### Decision: Describe `APP_MODE` in both the Config reference and the Federation section
+
+`APP_MODE` controls whether the app runs as a regional standalone or as a Hub. It belongs in the config table (with valid values `standalone` | `hub`) AND in the Federation section (which currently wrongly points to a separate repo).
+
+### Decision: Keep new-directory mentions brief
+
+`processing/`, `taginfo/`, and `oci/` don't need their own sections. A sentence in the "How the data flows" or "Contributing" section noting their existence is sufficient.
+
+## Risks / Trade-offs
+
+- **i18n status may be misrepresented** → Mitigation: Before writing the how-to update, verify in the Svelte source that i18next is genuinely unused (already confirmed: no `from 'i18next'` import anywhere in `app/src/`).
+- **Config table may have more gaps** → Mitigation: Cross-check `compose.yml` env vars, `.env.example`, and `config.js` exports before writing the updated table.
+- **README may drift again** → No mitigation in scope; this is a one-time sync.
+
+## Open Questions
+
+- Should `GEOSERVER_URL` and `GEOSERVER_WORKSPACE` appear in `.env.example` too, or only in the README config reference? (Currently in `config.js` defaults but not in `.env.example` or compose env block — may be intentionally omitted as an advanced/optional feature.)

--- a/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/proposal.md
+++ b/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The frontend was rewritten from vanilla JavaScript to Svelte 5 + Tailwind CSS 4, the Hub was merged into the main repo as a dual-mode app, and the file structure changed significantly — but the README still describes the old codebase, making it misleading for contributors and deployers.
+
+## What Changes
+
+- Update the **Tech Stack** table: language → Svelte 5, add Tailwind CSS 4 and lucide-svelte
+- Fix the **How-to: Add a playground device** guide: `js/objPlaygroundEquipment.js` → `app/src/lib/objPlaygroundEquipment.js`
+- Fix or deprecate the **How-to: Edit UI strings / add a language** guide: `js/i18n.js` no longer exists; i18next is a declared dependency but not imported anywhere in the Svelte source — the how-to is currently invalid
+- Update the **Federation** section: the Hub is no longer a separate repo; it is built into the same Svelte app and toggled via `APP_MODE=hub`
+- Update the **Configuration reference**: add `APP_MODE`, `GEOSERVER_URL`, `GEOSERVER_WORKSPACE`, `HUB_POLL_INTERVAL`; remove or annotate variables that only apply to one mode
+- Add a brief mention of new top-level directories: `processing/`, `taginfo/`, `oci/`
+- Mention `compose.prod.yml` alongside `compose.yml` in the local-dev section
+- Update the **Glossary**: add Svelte, Tailwind; update the "Language" entry
+
+## Capabilities
+
+### New Capabilities
+
+- `readme-accuracy`: The README correctly describes the current codebase — tech stack, file paths, configuration, and architecture
+
+### Modified Capabilities
+
+*(none — this is a documentation-only change; no existing spec files to delta)*
+
+## Impact
+
+- `spielplatzkarte/README.md` — primary file changed
+- No code changes; documentation only
+- The i18n how-to may need to note that multi-language support is not yet re-implemented in the Svelte rewrite (requires investigation before writing)

--- a/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/specs/readme-accuracy/spec.md
+++ b/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/specs/readme-accuracy/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Tech stack table reflects current framework
+The README tech stack table SHALL list Svelte 5 as the UI framework/language, include Tailwind CSS 4 as a styling dependency, and include lucide-svelte as an icon library.
+
+#### Scenario: Reader checks language entry
+- **WHEN** a contributor reads the Tech Stack table
+- **THEN** the Language row SHALL say "Svelte 5 (ES Modules)" or equivalent (not "JavaScript (ES Modules)")
+
+#### Scenario: Reader checks UI framework entry
+- **WHEN** a contributor reads the Tech Stack table
+- **THEN** the UI framework row SHALL mention both Bootstrap 5 and Tailwind CSS 4
+
+### Requirement: How-to device guide references correct file path
+The "How-to: Add a playground device" guide SHALL reference `app/src/lib/objPlaygroundEquipment.js` as the file to edit.
+
+#### Scenario: Reader follows the device how-to
+- **WHEN** a contributor opens the file path shown in the how-to
+- **THEN** the file SHALL exist at that path in the repository
+
+### Requirement: How-to language guide reflects i18n status
+The "How-to: Edit UI strings / add a language" section SHALL accurately describe the current state of i18n in the Svelte rewrite. Since i18next is not yet integrated into the Svelte source, the guide SHALL note that multi-language support is not yet implemented and that the `locales/` files are preserved for a future re-integration.
+
+#### Scenario: Reader wants to add a translation
+- **WHEN** a contributor reads the language how-to
+- **THEN** they SHALL understand that translations are not currently loaded by the Svelte app and that contributing a translation requires waiting for the i18n integration to be completed
+
+#### Scenario: Step referencing js/i18n.js is removed
+- **WHEN** a contributor reads the language how-to
+- **THEN** there SHALL be no instruction to edit `js/i18n.js` (that file does not exist)
+
+### Requirement: Federation section describes the merged Hub
+The Federation section SHALL describe that the Hub functionality is built into the same codebase as the standalone app, toggled by the `APP_MODE` environment variable, rather than pointing to a separate repository.
+
+#### Scenario: Reader wants to run the Hub
+- **WHEN** a reader follows the Federation section
+- **THEN** they SHALL find instructions that reference `APP_MODE=hub` and the same `compose.yml`
+
+### Requirement: Configuration reference is complete
+The configuration reference table SHALL include all variables present in `compose.yml` and `config.js`, including `APP_MODE`, and SHALL document which variables apply to which mode (standalone / hub / both).
+
+#### Scenario: Deployer looks up APP_MODE
+- **WHEN** a deployer reads the Configuration reference
+- **THEN** they SHALL find `APP_MODE` with valid values `standalone` and `hub` and a description of what each does
+
+#### Scenario: Deployer looks up GeoServer variables
+- **WHEN** a deployer reads the Configuration reference
+- **THEN** they SHALL find `GEOSERVER_URL` and `GEOSERVER_WORKSPACE` with descriptions noting they are optional and enable the shadow WMS layer

--- a/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/tasks.md
+++ b/openspec/changes/archive/2026-04-17-update-readme-svelte-rewrite/tasks.md
@@ -1,0 +1,43 @@
+## Workflow
+
+Create one GitHub issue per numbered group below, one branch per issue, and open a PR when the group is complete.
+
+## 1. Tech Stack and Glossary
+
+- [x] 1.1 Update Tech Stack table: change Language row to "Svelte 5 (ES Modules)", update UI framework row to include Tailwind CSS 4, add lucide-svelte row
+- [x] 1.2 Add Svelte and Tailwind to the Glossary table with one-line descriptions
+
+## 2. How-to: Add a Playground Device
+
+- [x] 2.1 Update every file path reference from `js/objPlaygroundEquipment.js` to `app/src/lib/objPlaygroundEquipment.js`
+- [x] 2.2 Update any other `js/` path references in the same section (e.g. commit example, verification step)
+
+## 3. How-to: Edit UI Strings / Add a Language
+
+- [x] 3.1 Remove the step that instructs editing `js/i18n.js` (file does not exist)
+- [x] 3.2 Add a note at the top of the section stating that multi-language support is not yet integrated in the Svelte rewrite; `locales/` files are preserved for future use
+- [x] 3.3 Keep the `locales/*.json` editing guidance (still valid as reference / future-ready)
+
+## 4. Federation Section
+
+- [x] 4.1 Rewrite the Federation section to describe the merged Hub: same codebase, `APP_MODE=hub` env var, same `compose.yml`
+- [x] 4.2 Remove or update the reference to the Hub as a separate repository
+- [x] 4.3 Note that the Hub's `get_playgrounds` / `get_meta` API contract between instances is unchanged
+
+## 5. Configuration Reference
+
+- [x] 5.1 Add `APP_MODE` row (values: `standalone` | `hub`, default: `standalone`)
+- [x] 5.2 Add `GEOSERVER_URL` row (optional; enables shadow WMS layer; leave empty to disable)
+- [x] 5.3 Add `GEOSERVER_WORKSPACE` row (default: `spielplatzkarte`; only used when `GEOSERVER_URL` is set)
+- [x] 5.4 Add `HUB_POLL_INTERVAL` row (seconds between Hub re-fetches; default: `300`; only used in hub mode)
+- [x] 5.5 Annotate rows with a mode indicator where relevant (e.g. "hub mode only", "standalone only")
+
+## 6. Local Development Section
+
+- [x] 6.1 Update the `make install` description to note it installs both the root (Playwright) and `app/` (Svelte) packages
+- [x] 6.2 Mention `compose.prod.yml` alongside `compose.yml` with a one-line description of when to use it
+
+## 7. New Directories
+
+- [x] 7.1 Add a brief mention of `processing/` (OSM data pipeline scripts) and `taginfo/` (taginfo metadata) in the Contributing section or project structure description
+- [x] 7.2 Add a mention of `oci/` (Docker build contexts for app and data-node containers) near the Docker/deployment section

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/design.md
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Pitch features in `EquipmentList.svelte` derive a display label by passing the raw `sport` property directly as an i18n key suffix. OSM allows semicolon-separated multi-values on any tag, so `sport=cycling;bmx;skateboard` is valid data. The current code treats the whole string as a single key, fails to find it, and falls back to rendering the raw value — which breaks the list layout.
+
+The fix is entirely within the frontend label derivation and the locale files. No API, DB, or style changes are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render multi-value `sport` tags as a readable joined string (e.g. `"BMX track / Skate park"`)
+- Add missing common sport keys to both locale files
+- Provide a contributor guide for adding new sport types in the future
+
+**Non-Goals:**
+- Changing how `equipmentAttributes.js` renders the detail panel (it already splits on `;` correctly)
+- Adding every possible OSM sport value — only the most common ones that appear in the wild on playgrounds/skate areas
+
+## Decisions
+
+**D1 — Split on `;`, translate each part, join with ` / `**
+
+In `EquipmentList.svelte`, replace the single-key lookup with:
+```js
+const parts = sport ? sport.split(';') : [];
+const label = parts.length
+  ? parts.map(s => $_('equipment.pitches.' + s.trim(),
+      { default: s.trim() })).join(' / ')
+  : $_('equipment.pitchDefault');
+```
+When a sport key is unknown the raw value is used as-is (same as current single-value fallback). This is graceful — new OSM sport values won't break the UI.
+
+Alternatives considered:
+- Generic "Multi-sport area" label when `;` is present — loses specificity; poor UX when only 2 known sports are involved
+- Look up a combined key like `skateboard_bmx` — combinatorial explosion, unmaintainable
+
+**D2 — Add sport keys for: `cycling`, `kick_scooter`, `roller_skating`, `hockey`, `athletics`, `baseball`, `cricket`, `rugby`, `archery`, `golf`, `gymnastics`**
+
+These are the most frequently mapped OSM sport values that don't yet have translations. Chosen by checking OSM tag usage stats for `leisure=pitch` combinations common in Central Europe.
+
+**D3 — New doc file `docs/contributing/add-sport-type.md`**
+
+Mirrors the existing `docs/contributing/add-device.md` structure: step-by-step, with OSM wiki links, a local verification command, and a commit/PR template. Lives alongside the existing guide for discoverability.
+
+## Risks / Trade-offs
+
+- [Risk] A sport value containing `;` in ways other than list separation → very rare in OSM; the split-and-join approach handles it gracefully (raw value shown for unrecognised segments)
+- [Trade-off] Showing raw values for unknown sports is slightly inconsistent with translated ones — acceptable until those keys are added; the contributing guide makes adding them easy

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/proposal.md
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+OSM pitches can carry multiple sport values in a single semicolon-separated tag (e.g. `sport=cycling;bmx;skateboard`). The equipment list in `EquipmentList.svelte` looks up the sport value as a single i18n key, so multi-value tags produce a raw, unformatted fallback string as the list label instead of a readable name. Additionally, several common sport values (`cycling`, `kick_scooter`, `roller_skating`, etc.) are missing from the locale files entirely, so even single-value tags for those sports fall back to the raw OSM string.
+
+## What Changes
+
+- `EquipmentList.svelte`: split `sport` on `;`, translate each value individually using existing `equipment.pitches.*` keys, join translated labels with ` / `
+- `locales/en.json` + `locales/de.json`: add missing common sport keys (`cycling`, `kick_scooter`, `roller_skating`, `hockey`, `athletics`, and others)
+- `docs/contributing/add-sport-type.md`: new guide documenting how to add support for a new sport type in the future (mirrors the existing `add-device.md` pattern)
+
+## Capabilities
+
+### New Capabilities
+
+- `multi-sport-label-rendering`: Correct rendering of pitch list labels when the `sport` tag contains multiple semicolon-separated values
+- `sport-contributing-guide`: Developer documentation for adding new sport pitch types
+
+### Modified Capabilities
+
+- none
+
+## Impact
+
+- `app/src/components/EquipmentList.svelte` — label derivation logic for `pitchFeatures`
+- `locales/en.json`, `locales/de.json` — new keys under `equipment.pitches`
+- `docs/contributing/add-sport-type.md` — new file
+- No API, DB, or breaking changes

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/specs/multi-sport-label-rendering/spec.md
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/specs/multi-sport-label-rendering/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Pitch list label handles multi-value sport tags
+The equipment list SHALL correctly render a pitch label when `sport` contains multiple semicolon-separated values by translating each value individually and joining them with ` / `.
+
+#### Scenario: Two known sports
+- **WHEN** a pitch feature has `sport = "skateboard;bmx"`
+- **THEN** the list label displays `"Skate park / BMX track"` (EN) or `"Skatepark / BMX-Bahn"` (DE)
+
+#### Scenario: Mix of known and unknown sports
+- **WHEN** a pitch feature has `sport = "cycling;kick_scooter;unknown_sport"`
+- **THEN** known sports are translated and unknown sports are shown as their raw OSM value, all joined with ` / `
+
+#### Scenario: Single known sport unchanged
+- **WHEN** a pitch feature has `sport = "soccer"`
+- **THEN** the list label displays the existing single-sport translation (no regression)
+
+#### Scenario: No sport tag
+- **WHEN** a pitch feature has no `sport` property
+- **THEN** the list label displays the generic pitch default label
+
+### Requirement: Common missing sport keys are translated
+The locale files SHALL include translations for the following sport values in both `en` and `de`: `cycling`, `kick_scooter`, `roller_skating`, `hockey`, `athletics`, `baseball`, `cricket`, `rugby`, `archery`, `golf`, `gymnastics`.
+
+#### Scenario: Previously missing sport renders translated
+- **WHEN** a pitch feature has `sport = "cycling"`
+- **THEN** the list label displays `"Cycling track"` (EN) or `"Radweg"` (DE) instead of the raw value `"cycling"`

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/specs/sport-contributing-guide/spec.md
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/specs/sport-contributing-guide/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Contributor guide for adding new sport types
+The docs SHALL include a guide at `docs/contributing/add-sport-type.md` that explains how to add support for a new OSM sport pitch type, mirroring the structure of the existing `docs/contributing/add-device.md`.
+
+#### Scenario: Guide covers all required steps
+- **WHEN** a contributor wants to add a new sport type
+- **THEN** the guide SHALL cover: finding the OSM tag value, adding the i18n key to both locale files, verifying locally, and opening a PR
+
+#### Scenario: Guide links to OSM resources
+- **WHEN** a contributor reads the guide
+- **THEN** the guide SHALL link to the relevant OSM wiki page for `leisure=pitch` and `Key:sport`
+
+#### Scenario: Guide includes translation guidance
+- **WHEN** a contributor adds a new sport key
+- **THEN** the guide SHALL explain that both `locales/en.json` and `locales/de.json` must be updated, and show the exact path of the key (`equipment.pitches.<sport_value>`)

--- a/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/tasks.md
+++ b/openspec/changes/archive/2026-04-20-fix-multi-sport-pitch-labels/tasks.md
@@ -1,0 +1,31 @@
+## 1. Create GitHub issue and branch
+
+- [x] 1.1 Create GitHub issue referencing #198 (multi-sport pitch label bug)
+- [x] 1.2 Create branch `fix/198-multi-sport-pitch-labels`
+
+## 2. Fix label rendering in EquipmentList
+
+- [x] 2.1 In `app/src/components/EquipmentList.svelte`, replace the single-key sport lookup with split-translate-join logic
+- [x] 2.2 Verify single-sport pitches still render correctly (no regression)
+- [x] 2.3 Verify multi-sport pitches (e.g. `cycling;bmx;skateboard`) render as joined translated labels
+
+## 3. Extend locale files
+
+- [x] 3.1 Add missing sport keys to `locales/en.json` under `equipment.pitches`: `cycling`, `kick_scooter`, `roller_skating`, `hockey`, `athletics`, `baseball`, `cricket`, `rugby`, `archery`, `golf`, `gymnastics`
+- [x] 3.2 Add corresponding translations to `locales/de.json`
+
+## 4. Add contributing guide
+
+- [x] 4.1 Create `docs/contributing/add-sport-type.md` following the structure of `docs/contributing/add-device.md`
+- [x] 4.2 Guide must cover: finding the OSM tag, adding both locale keys, local verification with `make dev`, and commit/PR steps
+- [x] 4.3 Guide must link to OSM wiki pages for `leisure=pitch` and `Key:sport`
+
+## 5. Build and verify
+
+- [x] 5.1 Run `make docker-build` and verify multi-sport pitch displays correctly in the equipment list
+- [x] 5.2 Check that the completeness legend and other bottom-left UI are unaffected
+
+## 6. Commit and open PR
+
+- [x] 6.1 Commit changes with message `fix(ui): render multi-value sport tags correctly in pitch list (#198)`
+- [x] 6.2 Push branch and open PR targeting `main`

--- a/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/design.md
+++ b/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The importer runs osm2pgsql against a full Geofabrik Bundesland extract (e.g. Hessen ~322 MB, ~31M nodes). Only a small fraction of that data belongs to the target region (a city or Kreis, ~50–80k objects). The osm2pgsql step takes ~60s because it reads and processes every node regardless. The PBF download is already cached by filename; the bottleneck is purely the osm2pgsql processing time.
+
+`osmium-tool` can clip a PBF to a bounding box in ~1–2s. Running osm2pgsql on the clipped file takes ~3–5s instead of ~60s.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reduce osm2pgsql processing time for city/Kreis-sized imports from ~60s to ~5s
+- Keep the full Bundesland PBF cached (reusable for multiple regions / import2)
+- Degrade gracefully when Nominatim is unavailable
+- Zero impact on import correctness — same data in the DB as before
+
+**Non-Goals:**
+- Reducing the initial PBF download time (network bound, not addressable here)
+- Switching from the default pgsql output to the Lua-based processing pipeline
+- Changing the import API (env vars, Makefile targets, Docker Compose services)
+
+## Decisions
+
+### D1: osmium over osm2pgsql `--bbox`
+
+osm2pgsql's `--bbox` flag filters what gets *written* but still reads the entire file. osmium reads the file once and writes a small output; subsequent osm2pgsql only sees the small file. osmium wins on total wall time.
+
+### D2: Nominatim for bbox lookup, with `OSM_BBOX` escape hatch
+
+Nominatim is already used by the frontend for location search — it's a known, trusted dependency. The `OSM_BBOX` env var covers air-gapped deployments and CI environments where Nominatim access isn't available. Fallback to full PBF ensures no regression.
+
+**Alternatives considered:**
+- OSM API (`/api/0.6/relation/<id>`): returns XML, harder to parse reliably in shell
+- Overpass API: heavier, slower, same network dependency
+- Hard-coded bbox in `.env`: forces user to calculate coordinates manually; not acceptable as a default
+
+### D3: `--strategy=smart` over `complete-ways`
+
+`smart` strategy ensures relation members (including the region boundary polygon ways) are fully included even when they cross the padded bbox edge. `complete-ways` handles ways but not relations. For our use case the region relation polygon is critical — `smart` is the correct choice at negligible extra cost.
+
+### D4: Cache filtered PBF, invalidate by source mtime
+
+osmium on 322 MB takes ~1–2s, so caching provides only marginal benefit on the first run. The main value is correctness: if a developer runs `make import` twice in quick succession (e.g. debugging api.sql), the second run skips osmium entirely. Cache key: `<pbf-basename>_<relation-id>.pbf`. Invalidation: source PBF newer than filtered PBF → regenerate.
+
+### D5: Skip pre-filter for small PBFs (< 20 MB)
+
+Some users may configure a city-level Geofabrik extract as `PBF_URL`. Running osmium on a 5 MB file saves nothing and adds a Nominatim round-trip. The 20 MB threshold is well above any city-level extract and well below any Bundesland extract.
+
+### D6: Padding default of 0.15°
+
+`POI_RADIUS_M` defaults to 5000 m. 0.15° ≈ 15 km at mid-latitudes — 3× the POI radius, comfortably capturing all POIs and buildings near the region edge. For the typical Hessen use case this grows the filtered PBF from ~3 MB to ~8 MB, still negligible for osm2pgsql.
+
+## Risks / Trade-offs
+
+- **Nominatim rate limit** → One request per import; well within the 1 req/s limit. Not a concern.
+- **Nominatim bbox accuracy** → For administrative relations the bbox is tight and correct. Padding handles edge cases.
+- **osmium `smart` strategy completeness** → `smart` guarantees relation members are included, but multi-polygon outer rings that extend far outside the bbox could pull in distant nodes. For admin boundary relations of city size this is not a practical problem.
+- **Filtered PBF stale after source update** → Handled by mtime comparison. Only a risk if someone manually touches the filtered PBF's timestamp — not a realistic scenario.
+- **Image size increase** → `osmium-tool` + `jq` + `curl` on Debian bookworm-slim add ~15 MB to the image. Acceptable.
+
+## Migration Plan
+
+1. Update `importer/Dockerfile` — add packages
+2. Update `importer/import.sh` — add pre-filter step
+3. Update `.env.example` — document `OSM_BBOX` and `OSM_BBOX_PADDING`
+4. Update `docs/ops/configuration.md` — new env vars
+5. Rebuild importer image (`make import` uses `--build`)
+6. Existing cached PBFs on the volume continue to work — osmium reads them, produces new filtered file
+
+No data migration required. No rollback complexity — removing the osmium step reverts to current behavior.
+
+## Open Questions
+
+- Should `OSM_BBOX_PADDING` be exposed in `.env.example` or kept as an advanced/hidden variable? Default of 0.15° should be correct for all realistic use cases.
+- Should the filtered PBF path be printed in import output so users can inspect it? Leaning yes — useful for debugging unexpected import results.

--- a/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/proposal.md
+++ b/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The osm2pgsql import processes the full Geofabrik Bundesland extract (e.g. Hessen, ~322 MB, ~31M nodes) even though the target region is a single city or Kreis containing ~50–80k objects. This makes every `make import` or `make import2` run take ~60s on the osm2pgsql step alone, purely wasted work. Pre-filtering the PBF to a padded bounding box of the target region with `osmium extract` reduces that step to ~3–5s.
+
+## What Changes
+
+- Add `osmium-tool`, `jq`, and `curl` to the importer Docker image
+- Before running osm2pgsql, query Nominatim for the bounding box of `OSM_RELATION_ID` and run `osmium extract --bbox --strategy=smart` on the cached PBF to produce a small regional slice
+- Cache the filtered PBF alongside the source PBF (key: `<pbf-basename>_<relation-id>.pbf`); invalidate when source is newer
+- Fall back gracefully to the full PBF if the Nominatim request fails
+- Accept an optional `OSM_BBOX` env var to skip the Nominatim lookup entirely (useful for air-gapped or rate-limited environments)
+- Skip the osmium step if the source PBF is already small (< 20 MB) — no net benefit for pre-filtered downloads
+
+## Capabilities
+
+### New Capabilities
+
+- `pbf-prefilter`: Pre-filter a large Geofabrik PBF to a padded bounding box before handing it to osm2pgsql, using osmium-tool and a Nominatim bbox lookup
+
+### Modified Capabilities
+
+<!-- none — no existing spec-level requirements change -->
+
+## Impact
+
+- **`importer/Dockerfile`**: adds `osmium-tool`, `jq`, `curl`
+- **`importer/import.sh`**: new pre-filter step between download and osm2pgsql
+- **`importer/` volume (`/data`)**: filtered PBFs cached alongside source PBF
+- **No API or frontend changes**
+- **Nominatim**: new outbound HTTP dependency during import (optional, with fallback)
+- **Import time**: ~60s osm2pgsql step → ~3–5s for city/Kreis-sized regions

--- a/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/specs/pbf-prefilter/spec.md
+++ b/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/specs/pbf-prefilter/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: osmium-tool available in importer image
+The importer Docker image SHALL include `osmium-tool`, `jq`, and `curl` so the pre-filter step can run without additional downloads at import time.
+
+#### Scenario: Tools present at import runtime
+- **WHEN** the importer container starts
+- **THEN** `osmium`, `jq`, and `curl` are available on `PATH`
+
+---
+
+### Requirement: Bounding box resolved from Nominatim
+Before running osm2pgsql, the importer SHALL query the Nominatim lookup API to obtain the bounding box of `OSM_RELATION_ID` and convert it to `west,south,east,north` order with a configurable padding (default 0.15°).
+
+#### Scenario: Nominatim returns bbox for known relation
+- **WHEN** `OSM_RELATION_ID` is a valid OSM relation ID
+- **THEN** the importer fetches `nominatim.openstreetmap.org/lookup?osm_ids=R<id>&format=json` and extracts the four bbox coordinates
+
+#### Scenario: Bbox padded before use
+- **WHEN** the raw Nominatim bbox is retrieved
+- **THEN** each side is expanded by `OSM_BBOX_PADDING` degrees (default `0.15`) before passing to osmium
+
+---
+
+### Requirement: OSM_BBOX env var overrides Nominatim lookup
+The importer SHALL accept an `OSM_BBOX` environment variable in `west,south,east,north` format. When set, the Nominatim lookup SHALL be skipped entirely.
+
+#### Scenario: OSM_BBOX provided
+- **WHEN** `OSM_BBOX=8.5,50.4,9.8,51.2` is set in the environment
+- **THEN** osmium uses that bbox directly, no HTTP request is made to Nominatim
+
+---
+
+### Requirement: Graceful fallback to full PBF on bbox failure
+If the Nominatim request fails (network error, HTTP error, or unparseable response) and `OSM_BBOX` is not set, the importer SHALL log a warning and pass the full cached PBF to osm2pgsql unchanged.
+
+#### Scenario: Nominatim unreachable
+- **WHEN** the Nominatim request times out or returns a non-200 status
+- **THEN** the importer logs `[importer] WARNING: bbox lookup failed, importing full PBF` and continues with the original PBF
+
+---
+
+### Requirement: Filtered PBF extracted with osmium smart strategy
+The importer SHALL run `osmium extract --bbox=<bbox> --strategy=smart` to produce a filtered PBF, ensuring that ways and relations (including the region boundary relation) that intersect the bbox are fully included.
+
+#### Scenario: osmium produces complete region slice
+- **WHEN** osmium extract runs with `--strategy=smart`
+- **THEN** the output PBF contains all nodes, ways, and relations whose geometry intersects the padded bbox, with no truncated way geometries
+
+---
+
+### Requirement: Filtered PBF cached and invalidated by source age
+The filtered PBF SHALL be written to `/data/<pbf-basename>_<relation-id>.pbf`. If this file already exists and is newer than the source PBF, the osmium step SHALL be skipped. If the source PBF is newer, the filtered PBF SHALL be regenerated.
+
+#### Scenario: Filtered PBF cache hit
+- **WHEN** `/data/hessen-latest.osm.pbf_454863.pbf` exists and is newer than `hessen-latest.osm.pbf`
+- **THEN** osmium is not re-run and the cached file is passed to osm2pgsql
+
+#### Scenario: Filtered PBF cache miss — source updated
+- **WHEN** the source PBF is newer than the cached filtered PBF
+- **THEN** osmium re-runs and overwrites the filtered PBF
+
+---
+
+### Requirement: Skip pre-filter for small source PBFs
+If the source PBF file size is less than `OSM_PREFILTER_MIN_MB` (default `20`) megabytes, the osmium pre-filter step SHALL be skipped and the source PBF passed directly to osm2pgsql.
+
+#### Scenario: Small PBF skips osmium
+- **WHEN** the source PBF is 15 MB
+- **THEN** the importer logs `[importer] Source PBF is small, skipping pre-filter` and runs osm2pgsql on the original file

--- a/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/tasks.md
+++ b/openspec/changes/archive/2026-04-24-osmium-pbf-prefilter/tasks.md
@@ -1,0 +1,35 @@
+## 1. Docker image
+
+- [ ] 1.1 Add `osmium-tool`, `jq`, and `curl` to `importer/Dockerfile`
+- [ ] 1.2 Verify tools are on PATH in a test run (`osmium --version`, `jq --version`, `curl --version`)
+
+## 2. import.sh — bbox resolution
+
+- [ ] 2.1 Add `OSM_BBOX` and `OSM_BBOX_PADDING` (default `0.15`) variable declarations at the top of `import.sh`
+- [ ] 2.2 Add `OSM_PREFILTER_MIN_MB` variable (default `20`)
+- [ ] 2.3 Implement `resolve_bbox` logic: if `OSM_BBOX` is set, use it directly; otherwise query Nominatim `lookup?osm_ids=R<id>&format=json` and parse with `jq`
+- [ ] 2.4 Apply padding to the four bbox coordinates (shell arithmetic via `awk` or `python3 -c`)
+- [ ] 2.5 Handle Nominatim failure: log warning and set `SKIP_PREFILTER=1` so the full PBF is used
+
+## 3. import.sh — osmium extract step
+
+- [ ] 3.1 After the download block, check source PBF size; if smaller than `OSM_PREFILTER_MIN_MB`, log and set `SKIP_PREFILTER=1`
+- [ ] 3.2 Derive filtered PBF path: `/data/$(basename "$PBF_FILE" .pbf)_${OSM_RELATION_ID}.pbf`
+- [ ] 3.3 Check if filtered PBF is newer than source PBF (cache hit); if so, skip osmium and log the cache hit
+- [ ] 3.4 Run `osmium extract --bbox=<west,south,east,north> --strategy=smart -o <filtered> <source> --overwrite` when pre-filter is active
+- [ ] 3.5 Set `IMPORT_PBF` to the filtered PBF path (or original if `SKIP_PREFILTER=1`) and pass `$IMPORT_PBF` to osm2pgsql
+
+## 4. Configuration
+
+- [ ] 4.1 Add `OSM_BBOX`, `OSM_BBOX_PADDING`, and `OSM_PREFILTER_MIN_MB` to `.env.example` with comments
+- [ ] 4.2 Add the three new variables to the `app` and `importer` service environments in `compose.yml` (pass-through only for importer)
+- [ ] 4.3 Add the three variables to `docs/ops/configuration.md`
+
+## 5. Verification
+
+- [ ] 5.1 Run `make import` from scratch (no cached PBF) — confirm osmium runs and filtered PBF is produced
+- [ ] 5.2 Run `make import` a second time — confirm osmium cache hit is logged, osm2pgsql runs on filtered PBF
+- [ ] 5.3 Run `make import2` — confirm second relation uses its own filtered PBF (`_454881.pbf`)
+- [ ] 5.4 Set `OSM_BBOX=8.5,50.4,9.8,51.2` and confirm Nominatim is not queried
+- [ ] 5.5 Simulate Nominatim failure (set DNS to invalid) — confirm fallback to full PBF with warning logged
+- [ ] 5.6 Verify playground data is correct after osmium-filtered import (same playgrounds as full import)

--- a/openspec/changes/multi-device-grouping/.openspec.yaml
+++ b/openspec/changes/multi-device-grouping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/multi-device-grouping/design.md
+++ b/openspec/changes/multi-device-grouping/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`get_equipment` returns a flat GeoJSON FeatureCollection containing all `playground=*` nodes, lines, and polygon ways within a playground's bounding box. This includes `playground=structure` polygon ways and their spatially-contained sub-devices, which today all render as separate list rows and separate dots on the map layer.
+
+`EquipmentList.svelte` renders devices from a flat `features[]` prop. `PlaygroundPanel.svelte` fetches equipment and writes it to `overlayFeaturesStore`, which `Map.svelte` reads to drive the equipment layer.
+
+The `PanoramaxViewer` component already accepts a `uuids[]` array and renders a thumbnail strip — it requires no changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Group devices spatially contained within a `playground=structure` polygon into a single list entry with expandable components.
+- Suppress component dots from the map layer; show only the structure polygon.
+- Aggregate component Panoramax UUIDs into one shared photo strip on the structure entry.
+- Leave flat-list behavior untouched for playgrounds with no structure polygons.
+
+**Non-Goals:**
+- Case 2 grouping (connected devices without a wrapper way) — requires OSM topology data not in the current API; deferred.
+- Backend / API changes.
+- New npm dependencies.
+
+## Decisions
+
+### Where grouping runs — PlaygroundPanel, not EquipmentList
+
+Grouping runs in `PlaygroundPanel.svelte` immediately after the equipment fetch, producing a structured `{ groups, standalone }` result. `EquipmentList` receives this pre-grouped data rather than doing the geometry math itself.
+
+**Why:** `PlaygroundPanel` is also the source of `overlayFeaturesStore`, so it has a single place to tag sub-device features with a `_groupId` before handing them to the map layer. Doing it in `EquipmentList` would require duplicating the logic or a second pass.
+
+### Containment algorithm — frontend ray-casting on GeoJSON coordinates
+
+Point-in-polygon check using standard ray-casting against the structure polygon's GeoJSON coordinate ring. For linestring/polygon sub-devices, use the feature's first coordinate (or centroid approximation).
+
+**Why over turf.js:** No new dependency. The structures involved are small convex-ish polygons; precision edge cases don't matter. If coordinates of a device fall clearly outside the ring, it's not part of the structure.
+
+**Alternative considered:** PostGIS `ST_Within` in `api.sql`. Ruled out to keep this a frontend-only prototype without DB changes.
+
+### Passing grouped data to EquipmentList — new props shape
+
+`EquipmentList` gains two new optional props: `groups` (array of `{structure, children}`) and keeps existing `features` for standalone devices. Existing callers pass only `features`; the component renders groups first, then standalones.
+
+**Why:** Avoids a breaking change to the component's existing flat-list path. Gradual enhancement.
+
+### Sub-device suppression on the map — `_groupId` flag in overlayFeaturesStore
+
+`PlaygroundPanel` tags each sub-device feature with `_groupId = <structure osm_id>` before writing to `overlayFeaturesStore`. `equipmentLayerStyleFn` in `vectorStyles.js` returns `null` style for features where `_groupId` is set.
+
+**Why null style over filtering:** OL style functions returning `null` hide features without requiring a separate filtered source. Simpler than maintaining two sources.
+
+### Photo aggregation — collect at group render time, pass to PanoramaxViewer
+
+When rendering a group in `EquipmentList`, collect `panoramax` tag values from all children into a single UUID array and pass to `PanoramaxViewer`. Structure's own `panoramax` tag is included first if present.
+
+**Why Option B (pooled) over Option A (per-device):** Not every component will have a photo; a pooled strip avoids empty rows and matches how `PanoramaxViewer` already works.
+
+## Risks / Trade-offs
+
+- **Bbox overlap false positives**: A device near a structure's bbox boundary that isn't actually inside the polygon could pass a loose check. Ray-casting on the actual polygon ring avoids this — only true geometric containment qualifies.
+- **Partial mapping**: A playground with some components inside a structure polygon and others outside will show a mixed list (some grouped, some standalone). This is intentional and correct behavior.
+- **`_groupId` is a client-side mutation** on the GeoJSON features: keeps implementation simple but means features must not be shared across renders without cloning. Currently `PlaygroundPanel` always refetches on playground change, so there's no stale mutation risk.
+
+## Open Questions
+
+- Should the structure entry show a component count badge (e.g., "Spielstruktur · 3 Teile") even when collapsed?
+- When a structure polygon is hovered on the map, should the tooltip show the structure name or the component list?

--- a/openspec/changes/multi-device-grouping/proposal.md
+++ b/openspec/changes/multi-device-grouping/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Playground constructions often consist of multiple physically connected devices (a platform, a climbing slope, a rope) that are mapped as separate OSM nodes/ways but represent a single piece of equipment. Today the app lists each component separately, producing an inflated and confusing equipment list. When a mapper wraps the structure in a `playground=structure` way, the app should recognize it as one device.
+
+## What Changes
+
+- Detect `playground=structure` polygon ways in the equipment feature list and treat them as group containers.
+- Devices spatially contained within a structure polygon are presented as components of that structure, not as standalone list items.
+- The equipment list renders a structure as one expandable entry with its components listed underneath.
+- The map layer shows only the structure itself; component dots are suppressed.
+- The photo viewer for a structure aggregates Panoramax photos from all components into a single shared strip (Option B).
+- Playgrounds not mapped with a structure wrapper are unaffected (current flat-list behavior is preserved).
+
+## Capabilities
+
+### New Capabilities
+
+- `equipment-grouping`: Detecting and grouping playground devices that belong to a `playground=structure` container, both in the equipment list and on the map layer.
+
+### Modified Capabilities
+
+<!-- none — existing flat-list behavior is unchanged for non-grouped devices -->
+
+## Impact
+
+- `app/src/components/EquipmentList.svelte` — new group rendering path
+- `app/src/components/PlaygroundPanel.svelte` — grouping logic after equipment fetch
+- `app/src/lib/vectorStyles.js` — suppress sub-device dots for grouped features
+- `app/src/stores/overlayLayer.js` — may need to carry group membership metadata
+- No backend / API changes required
+- No new npm dependencies required (plain GeoJSON ray-casting, no turf.js)

--- a/openspec/changes/multi-device-grouping/specs/equipment-grouping/spec.md
+++ b/openspec/changes/multi-device-grouping/specs/equipment-grouping/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Structure polygons group contained devices
+When the equipment feature list contains one or more `playground=structure` polygon ways, each such polygon SHALL act as a group container. Any other device feature whose representative point falls inside the structure polygon's geometry SHALL be treated as a component of that structure, not as a standalone device.
+
+#### Scenario: Device inside structure polygon is grouped
+- **WHEN** a `playground=structure` polygon and a `playground=climbing_slope` node are both present in the equipment feature list
+- **AND** the node's coordinates fall within the polygon's geometry
+- **THEN** the climbing slope is a component of the structure and does not appear as a standalone device
+
+#### Scenario: Device outside all structure polygons remains standalone
+- **WHEN** a `playground=swing` node is present alongside a `playground=structure` polygon
+- **AND** the swing node's coordinates fall outside the polygon
+- **THEN** the swing appears as a standalone device in the flat list
+
+#### Scenario: No structure polygons leaves behavior unchanged
+- **WHEN** the equipment feature list contains no `playground=structure` polygon features
+- **THEN** all devices are rendered in the flat list exactly as before this change
+
+### Requirement: Equipment list renders a structure as one expandable entry
+A `playground=structure` group SHALL be rendered as a single collapsible list item. When expanded, it SHALL list its component devices beneath it. Components SHALL NOT appear as independent rows in the equipment list.
+
+#### Scenario: Structure entry is collapsed by default
+- **WHEN** a structure group is rendered in the equipment list
+- **THEN** only the structure name is visible; components are hidden
+
+#### Scenario: Expanding reveals components
+- **WHEN** the user clicks the structure entry
+- **THEN** all component device names are shown as sub-rows beneath the structure
+
+#### Scenario: Structure with no components still renders
+- **WHEN** a `playground=structure` polygon has no other devices contained within it
+- **THEN** the structure appears as a standalone device entry (no grouping UI)
+
+### Requirement: Structure summary count
+A structure entry SHALL show the count of its components in a badge or suffix when collapsed, so users know something is grouped without expanding.
+
+#### Scenario: Component count shown while collapsed
+- **WHEN** a structure has 3 components
+- **THEN** the collapsed entry displays something like "Spielstruktur · 3 Teile" or "(3)"
+
+### Requirement: Map layer suppresses component dots within a structure
+Device features that belong to a structure group SHALL NOT render as individual dots on the equipment map layer. The structure polygon itself SHALL render normally.
+
+#### Scenario: Component dot is hidden
+- **WHEN** a device is a component of a structure group
+- **THEN** no dot or shape appears for that device on the equipment layer
+
+#### Scenario: Structure polygon is visible
+- **WHEN** a structure group exists
+- **THEN** the structure's polygon (or its centroid dot) appears on the equipment layer
+
+### Requirement: Structure photo viewer aggregates component photos
+When a structure entry is expanded, the photo viewer SHALL display a combined Panoramax photo strip containing photos from all components that have a `panoramax` tag. If the structure itself has a `panoramax` tag, that photo SHALL appear first.
+
+#### Scenario: Photos from multiple components appear in one strip
+- **WHEN** a structure has components A (with photo) and B (with photo)
+- **THEN** both photos appear in one `PanoramaxViewer` thumbnail strip on the structure entry
+
+#### Scenario: Component with no photo is silently skipped
+- **WHEN** a component has no `panoramax` tag
+- **THEN** no empty slot appears; the strip shows only photos from components that have one
+
+#### Scenario: No photos at all shows empty state
+- **WHEN** neither the structure nor any component has a `panoramax` tag
+- **THEN** the photo viewer shows the standard "no photos" empty state

--- a/openspec/changes/multi-device-grouping/tasks.md
+++ b/openspec/changes/multi-device-grouping/tasks.md
@@ -1,0 +1,29 @@
+## 1. Grouping Logic
+
+- [ ] 1.1 Write `groupEquipment(features)` utility function — separates `playground=structure` polygon features from all others, runs point-in-polygon containment check (ray-casting on GeoJSON coordinates), returns `{ groups: [{structure, children}], standalone: Feature[] }`
+- [ ] 1.2 Add unit test for `groupEquipment`: device inside polygon → grouped; device outside → standalone; no structure polygons → all standalone
+- [ ] 1.3 Call `groupEquipment` in `PlaygroundPanel.svelte` after the equipment fetch; tag each sub-device feature with `_groupId = structure.properties.osm_id` before writing to `overlayFeaturesStore`
+
+## 2. Map Layer
+
+- [ ] 2.1 In `vectorStyles.js` `equipmentLayerStyleFn`, return `null` for features where `properties._groupId` is set (suppresses sub-device dots)
+- [ ] 2.2 Verify in the browser that structure polygons still render and sub-device dots are hidden
+
+## 3. Equipment List — Group Rendering
+
+- [ ] 3.1 Add `groups` prop to `EquipmentList.svelte` (array of `{structure, children}`); render groups before standalone devices
+- [ ] 3.2 Render each group as a collapsible entry showing structure name + component count badge when collapsed (e.g., "Spielstruktur · 3 Teile")
+- [ ] 3.3 When expanded, list each child device name as a sub-row beneath the structure header
+- [ ] 3.4 Pass grouped data from `PlaygroundPanel.svelte` to `EquipmentList` via the new `groups` prop
+
+## 4. Photo Viewer Integration
+
+- [ ] 4.1 When rendering a group entry in `EquipmentList`, collect `panoramax` tag values from the structure and all children into a single UUID array (structure first, then children in order)
+- [ ] 4.2 Pass the aggregated UUID array to `PanoramaxViewer` inside the expanded group — verify multi-photo thumbnail strip works correctly
+- [ ] 4.3 Verify that components with no `panoramax` tag are silently skipped and show no empty slot
+
+## 5. Edge Cases & Polish
+
+- [ ] 5.1 Handle structure with zero contained components: render as a standalone device entry (no grouping UI, no component list)
+- [ ] 5.2 Verify flat-list behavior is fully unchanged for playgrounds with no `playground=structure` features
+- [ ] 5.3 Test with a real mapped structure from OSM (way/1498338233 or similar) via `make dev` with Overpass fallback


### PR DESCRIPTION
## Summary

Commits all local openspec change documents that were sitting outside the repo, placing them under `openspec/changes/` following the existing structure.

**Active (2 changes):**
- `add-weblate-community-translations` — issues #264–#268 still open
- `multi-device-grouping` — future work, no PR yet

**Archived (6 changes):**
- `2026-04-12-beginner-friendly-docs` — done via PR #41
- `2026-04-12-local-mobile-testing` — done via PR #29
- `2026-04-12-security-hardening` — done via PR #46
- `2026-04-17-update-readme-svelte-rewrite` — done via PRs #87–#89
- `2026-04-20-fix-multi-sport-pitch-labels` — done via PR #212
- `2026-04-24-osmium-pbf-prefilter` — done via PR #209

`.zip` distribution artifacts excluded from the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)