### PR TITLE
fix(importer): dedup playground_stats and get_meta counts for multipolygon relations (#299)

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -30,10 +30,31 @@ CREATE MATERIALIZED VIEW public.playground_stats AS
     WHERE osm_id = -${OSM_RELATION_ID}
   ),
   all_playgrounds AS (
-    SELECT p.osm_id, p.way, p.name, p.operator, p.access, p.surface, p.tags
+    -- osm2pgsql can emit multiple rows per relation for multipolygon
+    -- playgrounds (one row per outer ring). Without dedup, the MV would
+    -- have multiple rows per osm_id and the unique index below would
+    -- fail to create. GROUP BY osm_id with ST_Union merges fragments
+    -- back into one (multi)polygon. Non-geometry columns (name,
+    -- operator, access, surface, tags) are tied to the relation, not
+    -- the fragment, so they're identical across the rows of one
+    -- multipolygon — `MAX()` for text and `(array_agg(...))[1]` for
+    -- hstore both pick a (stable) value. The hstore case can't use
+    -- MAX() because hstore lacks a < ordering operator.
+    SELECT
+      p.osm_id,
+      ST_Union(p.way)         AS way,
+      MAX(p.name)             AS name,
+      MAX(p.operator)         AS operator,
+      MAX(p.access)           AS access,
+      MAX(p.surface)          AS surface,
+      -- tags are identical across all fragments of one relation, but
+      -- order_by-area keeps the chosen value deterministic if a future
+      -- osm2pgsql change ever introduced per-fragment tag variance.
+      (array_agg(p.tags ORDER BY ST_Area(p.way) DESC))[1] AS tags
     FROM planet_osm_polygon p
     JOIN region r ON ST_Within(p.way, r.way)
     WHERE p.leisure = 'playground'
+    GROUP BY p.osm_id
   ),
   tree_counts AS (
     SELECT
@@ -945,19 +966,25 @@ AS $$
     SELECT ST_Transform(way, 4326) AS geom FROM region
   ),
   counts AS (
-    -- INNER JOIN playground_stats so the invariant
-    --   playground_count = complete + partial + missing
-    -- holds by construction. Every playground in the configured region has
-    -- a stats row because the MV is built from the same source table.
+    -- Iterate over `playground_stats` (post-#299 dedup, exactly one row per
+    -- osm_id) and use EXISTS to constrain to the requested region. The
+    -- earlier formulation joined `planet_osm_polygon` directly, which
+    -- inflated the count by the cross-product when a relation had multiple
+    -- polygon rows (multipolygon playgrounds) — `playground_count` was
+    -- 13971 vs 13847 distinct on the BaWü production deployment. EXISTS
+    -- counts each playground_stats row at most once.
     SELECT
       COUNT(*)::int                                                        AS playground_count,
       SUM(CASE WHEN ps.completeness = 'complete' THEN 1 ELSE 0 END)::int   AS complete,
       SUM(CASE WHEN ps.completeness = 'partial'  THEN 1 ELSE 0 END)::int   AS partial,
       SUM(CASE WHEN ps.completeness = 'missing'  THEN 1 ELSE 0 END)::int   AS missing
-    FROM planet_osm_polygon p
-    JOIN region r ON ST_Within(p.way, r.way)
-    JOIN public.playground_stats ps ON ps.osm_id = p.osm_id
-    WHERE p.leisure = 'playground'
+    FROM public.playground_stats ps
+    WHERE EXISTS (
+      SELECT 1 FROM planet_osm_polygon p, region r
+      WHERE p.osm_id = ps.osm_id
+        AND p.leisure = 'playground'
+        AND ST_Within(p.way, r.way)
+    )
   ),
   import_status AS (
     -- NULL when no import has run yet (table empty); callers must handle NULL.


### PR DESCRIPTION
## Symptom (production blocker)

After PR #313 (the pipefail/POSIX-sh portability fix) landed, the BaWü importer at \`pkg.onms.eu\` runs further but now aborts at the api.sql apply step:

\`\`\`
ERROR:  could not create unique index "playground_stats_osm_id_idx"
DETAIL:  Key (osm_id)=(-19954509) is duplicated.
\`\`\`

## Root cause (#299)

osm2pgsql emits multiple polygon rows per relation when the relation is a multipolygon (one row per outer ring). The MV's \`all_playgrounds\` CTE keeps every row, producing N rows per osm_id, and the \`CREATE UNIQUE INDEX ON playground_stats(osm_id)\` then fails.

We hit this earlier (commit \`5bf9256\` in the production hotfix) and worked around it by manually recreating the MV without the unique index. That workaround was BaWü-database-local. A fresh import re-runs \`api.sql\` from the importer image, which re-introduces the unique index, which fails.

## Fix

**\`all_playgrounds\` CTE** — \`GROUP BY p.osm_id\`:

\`\`\`sql
SELECT
  p.osm_id,
  ST_Union(p.way)         AS way,
  MAX(p.name)             AS name,
  MAX(p.operator)         AS operator,
  MAX(p.access)           AS access,
  MAX(p.surface)          AS surface,
  (array_agg(p.tags ORDER BY ST_Area(p.way) DESC))[1] AS tags
FROM planet_osm_polygon p
JOIN region r ON ST_Within(p.way, r.way)
WHERE p.leisure = 'playground'
GROUP BY p.osm_id
\`\`\`

- \`ST_Union\` merges the multiple outer rings back into a single (multi)polygon — \`ST_Centroid(pl.way)\` in the MV's final SELECT then computes a sensible centroid over the whole feature.
- Non-geometry columns (name, operator, access, surface) — tied to the relation, not the fragment — \`MAX()\` picks the (stable) value.
- \`tags\` is hstore, which has no \`<\` operator → can't use \`MAX()\`. \`(array_agg(... ORDER BY ST_Area DESC))[1]\` picks the tags from the largest fragment, which is identical to the others' tags in practice but deterministic against any future osm2pgsql change that introduced per-fragment variance.

**\`get_meta\` \`counts\` CTE** — iterate over \`playground_stats\` with EXISTS:

\`\`\`sql
SELECT COUNT(*)::int AS playground_count, ...
FROM public.playground_stats ps
WHERE EXISTS (
  SELECT 1 FROM planet_osm_polygon p, region r
  WHERE p.osm_id = ps.osm_id
    AND p.leisure = 'playground'
    AND ST_Within(p.way, r.way)
)
\`\`\`

The earlier formulation joined \`planet_osm_polygon\` directly, which inflated the count by the cross-product when a relation had multiple polygon rows — observed in production as \`playground_count: 13971\` vs \`count(DISTINCT osm_id): 13847\` on BaWü.

## Backward compat

- Already-deployed databases (Fulda + BaWü) had the unique index reapplied by the earlier hotfix's manual MV recreate. Once this PR lands and the importer re-runs, the MV is rebuilt with proper dedup and the unique index reapplies cleanly.
- get_meta count change is a behaviour change visible to clients: \`playground_count\` will drop from inflated to true value (e.g. BaWü 13971 → ~13847). InstancePanel pill in the hub UI will show the lower number after the next registry-poll cycle.

## Test plan

- [x] \`make test\` 52/52 passing locally + 3 expected skips (live-API specs).
- [x] SQL syntax read end-to-end.
- [ ] Production verification on BaWü: \`make import\` succeeds, \`SELECT count(*), count(DISTINCT osm_id) FROM playground_stats\` returns identical numbers, \`api.get_meta()->>'playground_count'\` matches \`count(DISTINCT osm_id)\`.

Closes #299.

Refs #297, #298, #313 (the pipefail fix that exposed this).

Assisted-by: ClaudeCode:claude-opus-4-7