### PR TITLE
fix(hub): match federation-status entries by url, not slug (#323)

### DIFF
--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -170,10 +170,18 @@ export function createRegistry() {
 
     loadAll();
 
-    startFederationHealthPoll((statusBySlug, observationStale) => {
+    startFederationHealthPoll((status, observationStale) => {
+      // Match by `url`, not slug: slugs are optional in registry.json (only
+      // used for deep-link URLs), but every federation-status entry carries
+      // a `url` field. Matching by url avoids having two implementations of
+      // the slug-fallback algorithm (jq `gsub` server-side, `normaliseSlug`
+      // client-side) that have to stay in lockstep.
+      const entriesByUrl = new Map();
+      for (const e of Object.values(status)) {
+        if (e?.url) entriesByUrl.set(e.url, e);
+      }
       for (const b of backends) {
-        const key = b.slug ?? null;
-        const entry = key ? statusBySlug[key] : null;
+        const entry = entriesByUrl.get(b.url);
         if (!entry) continue;
         patchBackend(b.url, {
           healthUp:           entry.up ?? null,

--- a/tests/hub-federation-health.spec.js
+++ b/tests/hub-federation-health.spec.js
@@ -142,6 +142,37 @@ test.describe('Hub federation health drawer', () => {
     // Banner text matches the i18n key hub.observationStale
     await expect(drawer.locator('.drawer__stale-banner')).toBeVisible({ timeout: 5000 });
   });
+
+  // Regression for #323: when registry.json omits `slug`, poll-federation.sh
+  // falls back to a URL-sanitized key so the federation-status keys differ
+  // from any client-side slug. The patch loop must match by `entry.url`,
+  // not by the registry slug, otherwise the drawer never receives the
+  // freshness fields and silently shows only the playground count.
+  test('matches federation-status entries by url even when keys differ from registry slugs', async ({ page }) => {
+    await injectHubConfig(page);
+    await stubHubRegistry(page, { instanceA, instanceB });
+
+    const dataAgeSec = 2 * 24 * 60 * 60;
+    await stubFederationStatus(page, {
+      backends: {
+        // Server's URL-sanitized fallback key, intentionally different from
+        // `instanceA.slug`. Client must look up by `entry.url`.
+        'https___api_a_url_sanitized': {
+          url: instanceA.url,
+          up: true,
+          latency_seconds: 0.04,
+          last_success: new Date().toISOString(),
+          last_import_at: new Date(Date.now() - dataAgeSec * 1000).toISOString(),
+          data_age_seconds: dataAgeSec,
+        },
+      },
+    });
+
+    await page.goto('/');
+    const drawer = await openDrawer(page);
+
+    await expect(drawer).toContainText(/2\s*(Tage|days)/, { timeout: 5000 });
+  });
 });
 
 // TODO: filterHealthy skip-down-backend test


### PR DESCRIPTION
## Summary

Fixes #323 — the InstancePanel drawer silently dropped freshness fields whenever `registry.json` omitted the optional `slug` attribute.

`poll-federation.sh` falls back to a URL-sanitised identifier when slug is absent (`gsub("[^a-z0-9]"; "_")`), so `/federation-status.json` keys backends like `https___bawue_spieli_eu_api`. The client's `normaliseSlug` returns `null` for missing slugs with no fallback, and the patch loop skipped every backend:

```js
const key = b.slug ?? null;          // null
const entry = key ? statusBySlug[key] : null;
if (!entry) continue;                // drawer never gets osmDataAgeSec
```

Result on https://spieli.eu: drawer shows playground count only, no "OSM-Datenstand: N alt" line, even though the live federation-status JSON carries `osm_data_age_seconds` for every backend.

## Why match by url

Slugs are user-facing identifiers for deep-link URLs (`#fulda/W12345`) — they have no semantic role in federation health. `url` is always present, always unique, and already carried in every federation-status entry value. Matching by url avoids having two implementations of the slug-fallback algorithm (jq `gsub` server-side, `normaliseSlug` client-side) that have to stay in lockstep.

## Changes

- `app/src/hub/registry.js` — health-patch loop builds a `Map<url, entry>` from `Object.values(status)` and looks up by `b.url` instead of `b.slug`.
- `tests/hub-federation-health.spec.js` — adds a regression test that stubs federation-status with a key deliberately different from the registry slug and asserts the data-age label still renders.

## Test plan

- [x] `npx playwright test tests/hub-federation-health.spec.js` — all 4 tests pass (3 existing + 1 new regression).
- [ ] Deploy to https://spieli.eu and confirm the drawer shows "OSM-Datenstand: 1 Tag alt" on both rows without changing `registry.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)