### PR TITLE
chore: release v0.3.0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spieli-app",
-  "version": "0.2.6-rc",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spieli-app",
-      "version": "0.2.6-rc",
+      "version": "0.3.0",
       "dependencies": {
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.2.6-rc",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Promote rc to **v0.3.0**.

After this PR merges:
1. `git tag v0.3.0 && git push origin v0.3.0` — CI publishes \`:latest\`, \`:0.3.0\`, \`:0.3\` for both \`spieli\` and \`spieli-importer\` images.
2. \`gh release create v0.3.0\` — populate the GitHub release page (separate PR follows to bump main to \`0.3.1-rc\`).

## What ships in v0.3.0

### New features
- **Federation health exposition** (#301) — \`/federation-status.json\` + \`/metrics\` exposed by the hub container's 60-second cron poll; per-backend OSM data freshness in the InstancePanel drawer.
- **Cross-backend osm_id deduplication** (#302) — uses \`last_import_at\` to pick the fresher copy when two backends serve the same OSM feature.
- **Tiered playground delivery** (#279) — server-side cluster buckets at low zoom, polygon hydration at high zoom.
- **Federated playground clustering** (#287) — macro view across backends at zoom 0–5.
- **Osmium PBF prefilter** (#209) — shrinks the working set when importing national extracts.
- **Mobile full-screen detail panel** (#318) — replaces the bottom sheet on mobile.
- **Search sorted by proximity** (#316) — Nominatim results sorted by distance from current map view.

### Fixes worth calling out
- \`fix(hub)\` — match federation-status entries by URL instead of slug, so the InstancePanel drawer freshness labels render even when \`registry.json\` omits the optional slug field (#324).

### Other
- Importer hardening (#283 PBF cache validation, #298 ST_Union for stats, #299 multipolygon dedup, #313 POSIX sh portability).
- Completeness-aware aggregation (\`playground_stats\` materialised view).
- Docs (\`RELEASING.md\`, \`docs/ops/monitoring.md\`, federation reference cross-links).

## Version skip

Bumps \`0.2.6-rc\` → \`0.3.0\` (skipping \`0.2.6\`) — minor bump justified by the federation-health, osm-id-dedup, tiered-delivery, and federated-clustering features that have accumulated since \`v0.2.0\` (2026-04-19).

## Test plan

- [x] Existing CI (build app + Playwright) passed on \`main\` for the merged work.
- [ ] After merge: tag push triggers \`:latest\`, \`:0.3.0\`, \`:0.3\` image publication.
- [ ] After tag push: verify both images visible in [GHCR](https://github.com/mfuhrmann?tab=packages&repo_name=spieli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)