### PR TITLE
chore: bump version to 0.3.1-rc

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spieli-app",
-  "version": "0.3.0",
+  "version": "0.3.1-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spieli-app",
-      "version": "0.3.0",
+      "version": "0.3.1-rc",
       "dependencies": {
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1-rc",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Advance \`main\` to the next \`-rc\` after the [v0.3.0 release](https://github.com/mfuhrmann/spieli/releases/tag/v0.3.0). Per [\`RELEASING.md\`](https://github.com/mfuhrmann/spieli/blob/main/RELEASING.md), \`main\` always carries the next version as an \`-rc\` suffix.

## Changes

- \`app/package.json\`: \`0.3.0\` → \`0.3.1-rc\`
- \`app/package-lock.json\`: same

## Test plan

- [x] CI build (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)