### PR TITLE
feat(panel): unified MapComplete edit links across panel sections

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -3,6 +3,7 @@
   import { objColors } from '../lib/vectorStyles.js';
   import { getEquipmentAttributesFromProps } from '../lib/equipmentAttributes.js';
   import { _ } from 'svelte-i18n';
+  import MapCompleteLink from './MapCompleteLink.svelte';
 
   /** @type {Array} GeoJSON features from fetchPlaygroundEquipment */
   export let features = [];
@@ -94,6 +95,8 @@
                     <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
                     <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
+                {:else}
+                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
                 {@html detail.html}
               </div>
@@ -125,6 +128,8 @@
                     <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
                     <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
+                {:else}
+                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
                 {@html detail.html}
               </div>
@@ -159,6 +164,8 @@
                     <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
                     <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
                   </button>
+                {:else}
+                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
                 {@html detail.html}
               </div>

--- a/app/src/components/MapCompleteLink.svelte
+++ b/app/src/components/MapCompleteLink.svelte
@@ -1,13 +1,31 @@
 <script>
   import { Pencil } from 'lucide-svelte';
+  import { _ } from 'svelte-i18n';
+  /** Target URL. When falsy, the component renders nothing — callers don't
+   *  need to gate the render themselves. */
   export let href = '';
+  /** Visible label. When empty, falls back to the i18n key for an accessible
+   *  name so the icon-only link doesn't lose its affordance. */
   export let label = '';
+
+  // Defense in depth: only allow http(s) URLs through to the rendered anchor.
+  // mcUrl is internally constructed today, but a future caller passing
+  // user-influenced input would otherwise be free to inject `javascript:`.
+  $: safeHref = (typeof href === 'string' && /^https?:\/\//i.test(href)) ? href : '';
 </script>
 
-<a {href} target="_blank" rel="noopener" class="mc-edit-link">
-  <Pencil class="h-3 w-3" />
-  {label}
-</a>
+{#if safeHref}
+  <a
+    href={safeHref}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="mc-edit-link"
+    aria-label={label || $_('popup.editInMapComplete')}
+  >
+    <Pencil class="h-3 w-3" aria-hidden="true" />
+    {label}
+  </a>
+{/if}
 
 <style>
   .mc-edit-link {
@@ -25,5 +43,10 @@
   .mc-edit-link:hover {
     color: #374151;
     text-decoration: underline;
+  }
+  .mc-edit-link:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 </style>

--- a/app/src/components/MapCompleteLink.svelte
+++ b/app/src/components/MapCompleteLink.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Pencil } from 'lucide-svelte';
+  export let href = '';
+  export let label = '';
+</script>
+
+<a {href} target="_blank" rel="noopener" class="mc-edit-link">
+  <Pencil class="h-3 w-3" />
+  {label}
+</a>
+
+<style>
+  .mc-edit-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #9ca3af;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .mc-edit-link:hover {
+    color: #374151;
+    text-decoration: underline;
+  }
+</style>

--- a/app/src/components/PanoramaxViewer.svelte
+++ b/app/src/components/PanoramaxViewer.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { _ } from 'svelte-i18n';
+  import MapCompleteLink from './MapCompleteLink.svelte';
 
   /** @type {{ uuids?: string[], mcUrl?: string }} */
   let { uuids = [], mcUrl = '' } = $props();
@@ -55,9 +56,7 @@
   <div class="text-center py-2">
     <span class="bi bi-camera" style="font-size:1.8rem; color:#d1d5db;"></span>
     <p class="text-muted mt-1 mb-2" style="font-size:smaller;">{$_('panoramax.noPhotos')}</p>
-    <a href={mcUrl} target="_blank" rel="noopener" class="mc-add-link small">
-      <span class="bi bi-camera-fill"></span> {$_('popup.addPhoto')}
-    </a>
+    <MapCompleteLink href={mcUrl} label={$_('popup.addPhoto')} />
   </div>
 {:else}
   <!-- Inline viewer: selected photo as clickable iframe -->
@@ -92,9 +91,7 @@
   {/if}
 
   <p class="mt-1 mb-0">
-    <a href={mcUrl} target="_blank" rel="noopener" class="mc-add-link small">
-      <span class="bi bi-camera-fill"></span> {$_('popup.addPhoto')}
-    </a>
+    <MapCompleteLink href={mcUrl} label={$_('popup.addPhoto')} />
   </p>
 
 {/if}
@@ -241,6 +238,4 @@
   }
   .close-btn:hover { background: #f3f4f6; color: #111827; }
 
-  .mc-add-link { color: #6c757d; text-decoration: none; }
-  .mc-add-link:hover { color: #343a40; text-decoration: underline; }
 </style>

--- a/app/src/components/PanoramaxViewer.svelte
+++ b/app/src/components/PanoramaxViewer.svelte
@@ -4,7 +4,11 @@
   import MapCompleteLink from './MapCompleteLink.svelte';
 
   /** @type {{ uuids?: string[], mcUrl?: string }} */
-  let { uuids = [], mcUrl = '' } = $props();
+  let { uuids: uuidsProp = [], mcUrl = '' } = $props();
+  // Defensive: a parent passing `uuids={null}` would bypass the destructure
+  // default (which only fires for undefined). The derived form keeps the
+  // rest of the component free of `uuids?.length` checks.
+  const uuids = $derived(uuidsProp ?? []);
 
   const thumbUrl  = uuid => `https://api.panoramax.xyz/api/pictures/${uuid}/thumb.jpg`;
   const viewerUrl = uuid => `https://api.panoramax.xyz/?pic=${uuid}&nav=none&focus=pic`;

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -11,7 +11,7 @@
   import { onMount, onDestroy } from 'svelte';
   import OpeningHours from 'opening_hours';
   import { transform } from 'ol/proj';
-  import { X, Share2, Check, ChevronDown, ChevronUp, ChevronRight, Pencil, Clock, ExternalLink, Image, Package, Navigation, Star, Info } from 'lucide-svelte';
+  import { X, Share2, Check, ChevronDown, ChevronUp, ChevronRight, Clock, Image, Package, Navigation, Star, Info } from 'lucide-svelte';
   import { _ } from 'svelte-i18n';
 
   import { selection } from '../stores/selection.js';
@@ -22,6 +22,7 @@
   import { getPlaygroundTitle, getPlaygroundLocation } from '../lib/playgroundHelpers.js';
   import { cn } from '../lib/utils.js';
   import EquipmentList from './EquipmentList.svelte';
+  import MapCompleteLink from './MapCompleteLink.svelte';
   import POIPanel from './POIPanel.svelte';
   import PanoramaxViewer from './PanoramaxViewer.svelte';
   import ReviewsPanel from './ReviewsPanel.svelte';
@@ -554,6 +555,11 @@
         </div>
       {/if}
 
+      <!-- MapComplete edit link -->
+      <div class="mb-3">
+        <MapCompleteLink href={mcUrl} label={$_('popup.editInMapComplete')} />
+      </div>
+
       <!-- Accordion Sections -->
       <div class="border-t border-border">
         <!-- Photos -->
@@ -776,24 +782,6 @@
   .section-btn:hover {
     color: #374151;
     background: #fafafa;
-  }
-
-  .panel-edit-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: 11px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: #9ca3af;
-    text-decoration: none;
-    margin-bottom: 1rem;
-    transition: color 0.15s;
-  }
-
-  .panel-edit-link:hover {
-    color: #374151;
   }
 
   .panel-icon-btn {

--- a/app/src/lib/equipmentAttributes.js
+++ b/app/src/lib/equipmentAttributes.js
@@ -126,7 +126,6 @@ export function getEquipmentAttributesFromProps(props, t) {
     const osmId    = g('osm_id');
     const mcTheme  = (leisure === 'fitness_station' || leisure === 'pitch') ? 'sports' : 'playgrounds';
     const mcUrl    = `https://mapcomplete.org/${mcTheme}.html` + (osmId ? `#${osmType}/${osmId}` : '');
-    const addPhotoLink = `<p class="mb-0 mt-1"><a href="${mcUrl}" target="_blank" rel="noopener" style="font-size:0.75rem;"><span class="bi bi-camera-fill"></span> ${escapeHtml(t('popup.addPhoto'))}</a></p>`;
 
     let html = '';
     if (content.length) {
@@ -155,6 +154,5 @@ export function getEquipmentAttributesFromProps(props, t) {
         }
     }
 
-    if (!panoramaxUuid) html += addPhotoLink;
-    return { html, panoramaxUuid: panoramaxUuid || null };
+    return { html, panoramaxUuid: panoramaxUuid || null, mcUrl };
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -467,7 +467,8 @@
     "unknownObject": "Unbekanntes Objekt",
     "devicePhoto": "Foto dieses Geräts",
     "deviceSymbol": "Symbolbild",
-    "addPhoto": "Foto hinzufügen"
+    "addPhoto": "Foto hinzufügen",
+    "editInMapComplete": "In MapComplete bearbeiten"
   },
   "reviews": {
     "loading": "Wird geladen …",

--- a/locales/en.json
+++ b/locales/en.json
@@ -467,7 +467,8 @@
     "unknownObject": "Unknown object",
     "devicePhoto": "Photo of this device",
     "deviceSymbol": "Example image",
-    "addPhoto": "Add photo"
+    "addPhoto": "Add photo",
+    "editInMapComplete": "Edit in MapComplete"
   },
   "reviews": {
     "loading": "Loading …",


### PR DESCRIPTION
## Summary

- Extracts a shared `MapCompleteLink.svelte` component (pencil icon + uppercased label, consistent hover style) to replace three different inline link implementations
- Adds "Add photo" MapComplete link to every expanded device row in `EquipmentList` when no Panoramax photo exists
- Moves the per-device `addPhotoLink` HTML out of `equipmentAttributes.js` and into the component layer; `getEquipmentAttributesFromProps` now returns `mcUrl` instead of embedding raw HTML
- Replaces the bespoke `.mc-add-link` style in `PanoramaxViewer` with the shared component
- Adds `popup.editInMapComplete` i18n key (de + en)

## Test plan

- [ ] Open a playground panel — verify "Edit in MapComplete" link appears below the header meta
- [ ] Expand a device with no photo — verify "Add photo" MapComplete link is shown
- [ ] Expand a device with a Panoramax photo — verify no duplicate link
- [ ] PanoramaxViewer empty state — verify "Add photo" link still works

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)