### PR TITLE
fix(deeplink): skip Nominatim region fit when URL carries a deeplink hash

### DIFF
--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -18,6 +18,7 @@
     fetchStandaloneEquipment,
   } from '../lib/api.js';
   import { fetchRegionInfo } from '../lib/region.js';
+  import { parseHash } from '../lib/deeplink.js';
   import { attachTieredOrchestrator } from '../lib/tieredOrchestrator.js';
   import { equipmentLayerStyleFn } from '../lib/vectorStyles.js';
   import { debounce } from '../lib/utils.js';
@@ -80,13 +81,17 @@
       detachMapSub?.();
       detachMapSub = null;
 
-      // Region fit via Nominatim bbox.
+      // Region fit via Nominatim bbox — skipped when the URL carries a
+      // deeplink hash so that the hash-restore zoom-in is not overwritten
+      // by the (slower) Nominatim response.
       try {
         const region = await fetchRegionInfo(osmRelationId);
-        map.getView().fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
-          padding: [20, 20, 20, 380], // leave room for the side panel on desktop
-          duration: 0,
-        });
+        if (!parseHash(window.location.hash)) {
+          map.getView().fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
+            padding: [20, 20, 20, 380], // leave room for the side panel on desktop
+            duration: 0,
+          });
+        }
         document.title = `spieli ${region.name}`;
       } catch (err) {
         console.warn('Nominatim region fetch failed, using default extent:', err);

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -38,6 +38,8 @@
   let pitchLayer = null;
   let detachPitchLayer = null;
   let detachMapSub = null;
+  let regionFitTimer = null;
+  let detachRegionFitWatcher = null;
 
   // Readable store of the current map view in WGS84 for Nominatim `viewbox`.
   // Subscribes to the map's `moveend` when the map becomes available and
@@ -81,18 +83,41 @@
       detachMapSub?.();
       detachMapSub = null;
 
-      // Region fit via Nominatim bbox — skipped when the URL carries a
-      // deeplink hash so that the hash-restore zoom-in is not overwritten
-      // by the (slower) Nominatim response.
+      // Region fit via Nominatim bbox. The deeplink hash (if any) is read
+      // BEFORE the await so the decision can't be invalidated by anything
+      // that mutates window.location.hash while we're waiting on Nominatim.
+      const hadDeeplink = parseHash(window.location.hash);
       try {
         const region = await fetchRegionInfo(osmRelationId);
-        if (!parseHash(window.location.hash)) {
-          map.getView().fit(transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857'), {
+        document.title = `spieli ${region.name}`;
+        const regionExtent = transformExtent(region.extent, 'EPSG:4326', 'EPSG:3857');
+        const fitToRegion = () => {
+          map.getView().fit(regionExtent, {
             padding: [20, 20, 20, 380], // leave room for the side panel on desktop
             duration: 0,
           });
+        };
+        if (!hadDeeplink) {
+          fitToRegion();
+        } else {
+          // Deeplink hash present — the deeplink expresses explicit user
+          // intent that takes precedence over the default region framing,
+          // so we don't fit eagerly. But if AppShell.tryRestoreFromHash
+          // can't deliver (osm_id 404, hydration error, unknown slug, etc.)
+          // no fit ever happens and the user lands on the OL default view.
+          // Fall back to the region view after a short delay if no moveend
+          // has fired — the deeplink-restore success path always fires one.
+          let restored = false;
+          const onMove = () => { restored = true; };
+          map.once('moveend', onMove);
+          detachRegionFitWatcher = () => map.un('moveend', onMove);
+          regionFitTimer = setTimeout(() => {
+            regionFitTimer = null;
+            detachRegionFitWatcher?.();
+            detachRegionFitWatcher = null;
+            if (!restored) fitToRegion();
+          }, 1500);
         }
-        document.title = `spieli ${region.name}`;
       } catch (err) {
         console.warn('Nominatim region fetch failed, using default extent:', err);
       }
@@ -157,6 +182,8 @@
     if (detachMapSub)      detachMapSub();
     if (detachPitchLayer)  detachPitchLayer();
     if (detachOrchestrator) detachOrchestrator();
+    if (regionFitTimer)    clearTimeout(regionFitTimer);
+    if (detachRegionFitWatcher) detachRegionFitWatcher();
   });
 </script>
 


### PR DESCRIPTION
## Summary

Fixes a race condition on startup: opening the app via a shared deeplink URL would briefly show the correct playground, then zoom back out to the full region view.

**Root cause:** two async operations raced on mount:
1. Deeplink restore — zooms to the specific playground (fast)
2. Nominatim region fit — fetches the region bbox and calls `map.getView().fit()` (slower, fires after deeplink restore wins)

**Fix:** guard the `fit()` call with `if (!parseHash(window.location.hash))` — the Nominatim fit is skipped entirely when the URL already contains a deeplink hash.

## Test plan

- [ ] Open app with a deeplink URL (e.g. `#map=17/50.54/9.71&osm_id=37808214`) — verify map stays zoomed to the playground, not the full region
- [ ] Open app without a deeplink — verify Nominatim region fit still runs and sets the initial view correctly

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)