### PR TITLE
fix(ui): mobile glitches, routing links, zoom deselect, data quality legend

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -328,12 +328,15 @@
     checkMobile();
   }
 
-  // Center the map on the selected playground before the full-screen panel opens
+  // Center the map on the selected playground before the full-screen panel opens.
+  // Bottom padding accounts for the bottom sheet (~250 px) so the polygon
+  // isn't hidden behind it. This is the single canonical fit for all mobile
+  // selection paths (map click, nearby list, deeplink).
   $: if (isMobile && $hasSelection) {
     const feat = $selection.feature;
     if (feat && $mapStore) {
       $mapStore.getView().fit(feat.getGeometry().getExtent(), {
-        padding: [60, 60, 60, 60],
+        padding: [60, 20, 250, 20],
         maxZoom: 19,
         duration: 400,
       });

--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -411,13 +411,13 @@
           ondismiss={dismissNearby}
         />
       {/if}
-      {#if !$hasSelection}
+      {#if !isMobile && !$hasSelection}
         <CompletenessLegend />
       {/if}
     </div>
 
+    <!-- On mobile: pencil (info) on top, filter below — avoids clashing with search bar -->
     <div class="controls-top-right">
-      <FilterPanel />
       <button
         class="control-btn"
         onclick={() => dataModalOpen = true}
@@ -426,6 +426,7 @@
       >
         <Pencil class="h-5 w-5" />
       </button>
+      <FilterPanel />
     </div>
 
     <div class="controls-bottom-right">
@@ -449,6 +450,12 @@
         </button>
       </div>
     </div>
+
+    {#if isMobile && !$hasSelection}
+      <div class="legend-mobile">
+        <CompletenessLegend />
+      </div>
+    {/if}
 
     {#if instancePanel}
       <div class="instance-slot">
@@ -680,17 +687,29 @@
     .search-area {
       top: 0.75rem;
       left: 0.75rem;
-      right: 0.75rem;
+      /* Leave room for the stacked top-right buttons (40px wide + gaps). */
+      right: calc(0.75rem + 40px + 0.5rem);
     }
 
     .controls-top-right {
       top: 0.75rem;
       right: 0.75rem;
+      /* Stack vertically on mobile so they don't overlap the search bar. */
+      flex-direction: column;
     }
 
     .controls-bottom-right {
       bottom: 10rem;
       right: 0.75rem;
+    }
+
+    /* Legend moved out of the search column on mobile — sits below the
+       bottom-right control cluster, aligned to the same right edge. */
+    .legend-mobile {
+      position: absolute;
+      bottom: 2rem;
+      right: 0.75rem;
+      z-index: 100;
     }
   }
 

--- a/app/src/components/CompletenessLegend.svelte
+++ b/app/src/components/CompletenessLegend.svelte
@@ -3,6 +3,7 @@
 </script>
 
 <aside class="legend">
+  <p class="legend-title">{$_('completeness.legendTitle')}</p>
   <ul class="legend-list">
     <li class="legend-item">
       <span class="swatch swatch--complete"></span>
@@ -33,6 +34,15 @@
     font-size: 0.72rem;
     color: #374151;
     max-width: 200px;
+  }
+
+  .legend-title {
+    margin: 0 0 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
   }
 
   .legend-list {

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -1,9 +1,7 @@
 <script>
   import GeoJSON from 'ol/format/GeoJSON.js';
-  import { get } from 'svelte/store';
   import { playgroundSourceStore } from '../stores/playgroundSource.js';
   import { selection } from '../stores/selection.js';
-  import { mapStore } from '../stores/map.js';
   import { playgroundCompleteness } from '../lib/completeness.js';
   import { fetchPlaygroundByOsmId } from '../lib/api.js';
   import { _ } from 'svelte-i18n';
@@ -29,6 +27,7 @@
   let items = [];
   let loading = true;
   const geojsonFormat = new GeoJSON();
+  let selectAbort = null; // cancels any in-flight hydration when a new suggestion is tapped
 
   $: if (lat != null && lon != null) {
     load(lat, lon);
@@ -64,6 +63,10 @@
   }
 
   async function selectSuggestion(item) {
+    if (selectAbort) selectAbort.abort();
+    selectAbort = new AbortController();
+    const { signal } = selectAbort;
+
     const source = $playgroundSourceStore;
     let feature = source?.getFeatures().find(f => f.get('osm_id') === item.osm_id);
     const backendUrl = item._backendUrl ?? defaultBackendUrl;
@@ -75,7 +78,8 @@
     // feature in-source) route to the right backend in hub mode.
     if (!feature && source) {
       try {
-        const json = await fetchPlaygroundByOsmId(item.osm_id, backendUrl);
+        const json = await fetchPlaygroundByOsmId(item.osm_id, backendUrl, signal);
+        if (signal.aborted) return;
         if (json) {
           const olFeatures = geojsonFormat.readFeatures(
             { type: 'FeatureCollection', features: [json] },
@@ -86,24 +90,14 @@
           feature = olFeatures[0];
         }
       } catch (err) {
+        if (err.name === 'AbortError') return;
         console.warn('[nearby] hydration failed:', err);
       }
     }
 
+    if (signal.aborted) return;
     if (feature) {
       selection.select(feature, feature.get('_backendUrl') ?? backendUrl);
-      const map = get(mapStore);
-      if (map) {
-        const geom = feature.getGeometry();
-        if (geom) {
-          const isMobile = window.innerWidth < 1024;
-          map.getView().fit(geom.getExtent(), {
-            padding: isMobile ? [100, 20, 250, 20] : [40, 40, 40, 420],
-            maxZoom: 19,
-            duration: 400,
-          });
-        }
-      }
     }
     if (ondismiss) ondismiss();
   }

--- a/app/src/components/NearbyPlaygrounds.svelte
+++ b/app/src/components/NearbyPlaygrounds.svelte
@@ -1,7 +1,9 @@
 <script>
   import GeoJSON from 'ol/format/GeoJSON.js';
+  import { get } from 'svelte/store';
   import { playgroundSourceStore } from '../stores/playgroundSource.js';
   import { selection } from '../stores/selection.js';
+  import { mapStore } from '../stores/map.js';
   import { playgroundCompleteness } from '../lib/completeness.js';
   import { fetchPlaygroundByOsmId } from '../lib/api.js';
   import { _ } from 'svelte-i18n';
@@ -90,6 +92,18 @@
 
     if (feature) {
       selection.select(feature, feature.get('_backendUrl') ?? backendUrl);
+      const map = get(mapStore);
+      if (map) {
+        const geom = feature.getGeometry();
+        if (geom) {
+          const isMobile = window.innerWidth < 1024;
+          map.getView().fit(geom.getExtent(), {
+            padding: isMobile ? [100, 20, 250, 20] : [40, 40, 40, 420],
+            maxZoom: 19,
+            duration: 400,
+          });
+        }
+      }
     }
     if (ondismiss) ondismiss();
   }
@@ -103,7 +117,7 @@
     <div class="nearby-loading">{$_('nearby.empty')}</div>
   {:else}
     <ul class="nearby-list">
-      {#each items as item}
+      {#each items.slice(0, 5) as item}
         <li>
           <button class="nearby-item" onclick={() => selectSuggestion(item)}>
             <span class="dot {completenessClass(item.tags)}"></span>

--- a/app/src/components/POIPanel.svelte
+++ b/app/src/components/POIPanel.svelte
@@ -87,14 +87,25 @@
             {name}{#if hint}<span class="text-muted ms-1" style="font-size:0.7rem;">({hint})</span>{/if}
           </span>
           <span class="ms-2 text-nowrap">
-            <a href={geoUrl} class="text-muted text-decoration-none" style="font-size:smaller;"
-               title={$_('poi.openNavApp')}>{formatDistance(poi.dist)} ↗</a>
+            <a href={geoUrl} class="text-muted text-decoration-none link-mobile-only" style="font-size:smaller;"
+               title={$_('poi.openNavApp')}>{formatDistance(poi.dist)} 🧭</a>
             <a href={osmUrl} target="_blank" rel="noopener"
-               class="text-muted text-decoration-none ms-1" style="font-size:smaller;"
-               title={$_('poi.openInBrowser')}>🗺</a>
+               class="text-muted text-decoration-none ms-1 link-desktop-only" style="font-size:smaller;"
+               title={$_('poi.openInBrowser')}>{formatDistance(poi.dist)} 🧭</a>
           </span>
         </div>
       {/each}
     </div>
   {/each}
 {/if}
+
+<style>
+  /* geo: links open mobile nav apps (CoMaps, GMaps app) — hide on desktop */
+  .link-mobile-only  { display: inline; }
+  .link-desktop-only { display: none;   }
+
+  @media (min-width: 1024px) {
+    .link-mobile-only  { display: none;   }
+    .link-desktop-only { display: inline; }
+  }
+</style>

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -278,8 +278,8 @@
   };
   const COMPLETENESS_KEY = {
     complete: 'completeness.badgeComplete',
-    partial:  'completeness.partial',
-    missing:  'completeness.dotMissing',
+    partial:  'completeness.badgePartial',
+    missing:  'completeness.badgeMissing',
   };
   $: completenessLevel = attr ? playgroundCompleteness(attr) : null;
   $: completeness = completenessLevel

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -876,17 +876,17 @@
   }
 
   .status-pill {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 5px;
-    padding: 6px 10px;
-    border-radius: 8px;
+    padding: 3px 10px;
+    border-radius: 9999px;
     font-size: 12px;
-    font-weight: 500;
-    flex: 1;
+    font-weight: 600;
+    white-space: nowrap;
   }
-  .status-pill--open   { background: #ecfdf5; color: #065f46; }
-  .status-pill--closed { background: #fef2f2; color: #b91c1c; }
+  .status-pill--open   { background: #ecfdf5; border: 1px solid rgba(16, 185, 129, 0.4); color: #065f46; }
+  .status-pill--closed { background: #fef2f2; border: 1px solid rgba(239, 68, 68, 0.4);  color: #b91c1c; }
 
   .status-dot {
     width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -122,7 +122,7 @@
         <span class="pill__sep">·</span>
         {$_('hub.playgroundCount', { values: { count: playgroundCount } })}
       </span>
-      <span class="pill__text pill__text--compact" aria-hidden="true">{playgroundCount}</span>
+      <span class="pill__text pill__text--compact">{playgroundCount}</span>
     {/if}
   </button>
 </div>

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -116,11 +116,13 @@
       </span>
     {:else}
       <Globe class="pill__icon" aria-hidden="true" />
-      <span class="pill__text">
+      <!-- Full label on desktop, count-only on mobile to save space -->
+      <span class="pill__text pill__text--full">
         {$_('hub.regionCount', { values: { count: regionCount } })}
         <span class="pill__sep">·</span>
         {$_('hub.playgroundCount', { values: { count: playgroundCount } })}
       </span>
+      <span class="pill__text pill__text--compact" aria-hidden="true">{playgroundCount}</span>
     {/if}
   </button>
 </div>
@@ -188,5 +190,18 @@
 
   .pill__sep {
     color: #adb5bd;
+  }
+
+  .pill__text--compact {
+    display: none;
+  }
+
+  @media (max-width: 1023px) {
+    .pill__text--full {
+      display: none;
+    }
+    .pill__text--compact {
+      display: inline;
+    }
   }
 </style>

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -24,6 +24,8 @@
   import { debounce } from '../lib/utils.js';
   import { mapStore } from '../stores/map.js';
   import { filterStore } from '../stores/filters.js';
+  import { activeTierStore } from '../stores/tier.js';
+  import { selection } from '../stores/selection.js';
 
   // Standalone owns two VectorSources — one per tier. The orchestrator
   // populates the active one on every debounced moveend; Map.svelte toggles
@@ -31,6 +33,13 @@
   const playgroundSource = new VectorSource(); // polygon tier (zoom > clusterMaxZoom)
   const clusterSource    = new VectorSource(); // cluster tier (zoom ≤ clusterMaxZoom)
   let detachOrchestrator = null;
+
+  // Deselect the playground when the user zooms out past the cluster threshold.
+  let prevTier = null;
+  const detachTierDeselect = activeTierStore.subscribe(tier => {
+    if (prevTier === 'polygon' && tier === 'cluster') selection.clear();
+    prevTier = tier;
+  });
 
   // Standalone pitches (leisure=pitch outside any playground) — own layer,
   // attached to the map when it becomes available and refreshed on moveend.
@@ -179,6 +188,7 @@
   $: if (pitchLayer) pitchLayer.setVisible($filterStore.standalonePitches);
 
   onDestroy(() => {
+    detachTierDeselect();
     if (detachMapSub)      detachMapSub();
     if (detachPitchLayer)  detachPitchLayer();
     if (detachOrchestrator) detachOrchestrator();

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -30,13 +30,13 @@ More: [postgrest.org](https://postgrest.org)
 
 Each playground carries a **Data Quality** badge whose colour reflects how completely it has been mapped in OpenStreetMap:
 
-| Colour | Meaning |
-|--------|---------|
-| Green  | Photos, a name, and at least one detail (equipment, surface, …) are present |
-| Yellow | At least one of the above is present, but not all |
-| Red    | None of the above — the playground exists in OSM but has no additional data |
+| Colour | Legend label | Meaning |
+|--------|-------------|---------|
+| Green  | hoch / high   | Photos, a name, and at least one detail (equipment, surface, …) are present |
+| Yellow | mittel / medium | At least one of the above is present, but not all |
+| Red    | niedrig / low  | None of the above — the playground exists in OSM but has no additional data |
 
-The badge label is always "Datenqualität" / "Data Quality"; the colour alone communicates the state. The same three-state breakdown is used in the map legend, cluster rings, and the federation macro view.
+The map legend is headed "Datenqualität" / "Data Quality" and uses short scale labels (hoch / mittel / niedrig). The panel badge also reads "Datenqualität" / "Data Quality" in the matching colour. The same three-state breakdown is used in cluster rings and the federation macro view.
 
 Internally, the three states are referred to as `complete`, `partial`, and `missing`. These values appear in the API responses (see [`api.md`](api.md)) and in the database (`playground_stats` materialised view). The display label is intentionally kept neutral — it describes *what* is shown, not a judgement.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -26,6 +26,20 @@ More: [osm2pgsql.org](https://osm2pgsql.org)
 
 More: [postgrest.org](https://postgrest.org)
 
+## Data Quality indicator
+
+Each playground carries a **Data Quality** badge whose colour reflects how completely it has been mapped in OpenStreetMap:
+
+| Colour | Meaning |
+|--------|---------|
+| Green  | Photos, a name, and at least one detail (equipment, surface, …) are present |
+| Yellow | At least one of the above is present, but not all |
+| Red    | None of the above — the playground exists in OSM but has no additional data |
+
+The badge label is always "Datenqualität" / "Data Quality"; the colour alone communicates the state. The same three-state breakdown is used in the map legend, cluster rings, and the federation macro view.
+
+Internally, the three states are referred to as `complete`, `partial`, and `missing`. These values appear in the API responses (see [`api.md`](api.md)) and in the database (`playground_stats` materialised view). The display label is intentionally kept neutral — it describes *what* is shown, not a judgement.
+
 ## Overpass Turbo
 
 **Overpass Turbo** ([overpass-turbo.eu](https://overpass-turbo.eu)) is a web tool for running ad-hoc queries against live OpenStreetMap data. It is useful when adding support for a new device type — you can search for `playground=<tag>` to find real playgrounds that have the device mapped and use them for testing.

--- a/locales/de.json
+++ b/locales/de.json
@@ -64,9 +64,10 @@
     "backToMap": "Zurück zur Karte"
   },
   "completeness": {
-    "complete": "Fotos, Name & Details vorhanden",
-    "partial": "Teilweise erfasst",
-    "missing": "Noch keine Daten",
+    "legendTitle": "Datenqualität",
+    "complete": "hoch",
+    "partial": "mittel",
+    "missing": "niedrig",
     "dotComplete": "Daten vollständig",
     "dotPartial": "Teilweise erfasst",
     "dotMissing": "Daten fehlen",

--- a/locales/de.json
+++ b/locales/de.json
@@ -70,7 +70,9 @@
     "dotComplete": "Daten vollständig",
     "dotPartial": "Teilweise erfasst",
     "dotMissing": "Daten fehlen",
-    "badgeComplete": "Vollständig",
+    "badgeComplete": "Datenqualität",
+    "badgePartial": "Datenqualität",
+    "badgeMissing": "Datenqualität",
     "restrictedHint": "schraffiert = nicht öffentlich"
   },
   "accordion": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -74,7 +74,7 @@
     "badgeComplete": "Datenqualität",
     "badgePartial": "Datenqualität",
     "badgeMissing": "Datenqualität",
-    "restrictedHint": "schraffiert = nicht öffentlich"
+    "restrictedHint": "nicht öffentlich"
   },
   "accordion": {
     "photos": "Bilder",

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,9 +64,10 @@
     "backToMap": "Back to map"
   },
   "completeness": {
-    "complete": "Photos, name & details available",
-    "partial": "Partially mapped",
-    "missing": "No data yet",
+    "legendTitle": "Data Quality",
+    "complete": "high",
+    "partial": "medium",
+    "missing": "low",
     "dotComplete": "Data complete",
     "dotPartial": "Partially mapped",
     "dotMissing": "No data",

--- a/locales/en.json
+++ b/locales/en.json
@@ -70,7 +70,9 @@
     "dotComplete": "Data complete",
     "dotPartial": "Partially mapped",
     "dotMissing": "No data",
-    "badgeComplete": "Complete",
+    "badgeComplete": "Data Quality",
+    "badgePartial": "Data Quality",
+    "badgeMissing": "Data Quality",
     "restrictedHint": "hatched = not public"
   },
   "accordion": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -74,7 +74,7 @@
     "badgeComplete": "Data Quality",
     "badgePartial": "Data Quality",
     "badgeMissing": "Data Quality",
-    "restrictedHint": "hatched = not public"
+    "restrictedHint": "not public"
   },
   "accordion": {
     "photos": "Photos",


### PR DESCRIPTION
## Summary

- **#336** — POI routing links split by device: `geo:` link (opens CoMaps/GMaps app) shown on mobile only, OSM directions link on desktop only; both use 🧭 compass icon with distance
- **#337** — Map pans and fits to playground after selecting from the nearby list (was selected but not focused)
- **#339** — Playground is automatically deselected when zooming out past the cluster threshold (polygon → cluster tier transition)
- **#273** — Completeness badge and legend redesigned: badge always reads "Datenqualität" / "Data Quality" with colour communicating the state; legend gets a "Datenqualität" title and uses "hoch / mittel / niedrig" scale labels; opening-hours pill aligned to same pill shape as AgeChip/Badge; restricted hint shortened to "nicht öffentlich"

**Also in this branch (recovered from stash, applied on fresh main):**
- Mobile layout: legend moved to bottom-right corner; search bar shortened to avoid colliding with stacked top-right buttons; filter button stacked below info button; nearby list capped at 5 items
- InstancePanel: globe pill shows full label on desktop, count-only on mobile

## Test plan

- [ ] Open on mobile — search bar and filter/info buttons do not overlap
- [ ] Press locate — nearby list shows max 5 items, legend does not obscure map
- [ ] Select a playground from nearby list — map pans and fits to it
- [ ] Zoom out past cluster threshold while a playground is selected — panel closes automatically
- [ ] Open a playground with POIs — compass link visible on mobile (opens nav app), OSM link visible on desktop
- [ ] Check completeness badge in playground panel — reads "Datenqualität" in green/yellow/red
- [ ] Check map legend — shows "Datenqualität" header with hoch/mittel/niedrig rows
- [ ] Hub mode: instance pill shows count-only on mobile, full label on desktop

Closes #336, #337, #339, #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)