### PR TITLE
chore: OpenSpec proposal — cluster filter passthrough (fixes #305)

### DIFF
--- a/openspec/changes/fix-cluster-filter-passthrough/.openspec.yaml
+++ b/openspec/changes/fix-cluster-filter-passthrough/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/fix-cluster-filter-passthrough/design.md
+++ b/openspec/changes/fix-cluster-filter-passthrough/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The tiered playground delivery system has two data paths:
+
+- **Polygon tier** (zoom > 13): `get_playgrounds_bbox` returns full GeoJSON with all filter attributes; `playgroundStyleFn` uses `matchesFilters()` client-side to hide non-matching features — filters work correctly.
+- **Cluster tier** (zoom ≤ 13): `get_playground_clusters` returns pre-aggregated bucket rows with counts only; the aggregation runs unconditionally — filters are silently ignored.
+
+`playground_stats` (the materialized view feeding both RPCs) already carries all 11 filterable columns: `access_restricted`, `is_water`, `for_baby`, `for_toddler`, `for_wheelchair`, `bench_count`, `picnic_count`, `shelter_count`, `table_tennis_count`, `has_soccer`, `has_basketball`. The data is present; it is simply not threaded through.
+
+The orchestrator (`tieredOrchestrator.js`) currently returns a bare `() => void` detach function. `StandaloneApp.svelte` uses `filterStore` reactively only for the pitch-layer toggle; it does not re-trigger the orchestrator on filter change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cluster buckets reflect only playgrounds matching the active `filterStore` flags.
+- Bucket counts and completeness breakdowns are correct for the filtered set.
+- Buckets with zero matching members are omitted (sparse map when filters are narrow).
+- Filter changes at cluster zoom trigger a new server fetch; filter changes at polygon zoom do not (client-side re-style is sufficient).
+
+**Non-Goals:**
+- Filtering the polygon tier server-side — client-side `matchesFilters()` already handles it.
+- Changing how `standalonePitches` works — it remains a layer-visibility toggle.
+- Filtering other RPCs (`get_playgrounds_bbox`, `get_nearest_playgrounds`, etc.).
+- Performance optimisation beyond what the existing GIST index provides.
+
+## Decisions
+
+### D1: Filter ownership — orchestrator internal vs. StandaloneApp-driven
+
+**Decision**: StandaloneApp passes filters to the orchestrator; the orchestrator does not subscribe to `filterStore` internally.
+
+**Rationale**: `attachTieredOrchestrator` returns `{ detach, rerun }`. `StandaloneApp` stores `rerun` and adds:
+```js
+$: if ($filterStore && $activeTierStore === 'cluster') rerun($filterStore);
+```
+This keeps the orchestrator a plain JS module (no new Svelte store subscriptions inside it) and is consistent with the existing pattern: StandaloneApp already subscribes to both `filterStore` and `activeTierStore` for other reactive side-effects. The orchestrator reads the filters it is given at each `orchestrate()` call, no internal state needed.
+
+The `=== 'cluster'` guard avoids a spurious server fetch when filters change at polygon zoom.
+
+**Alternative considered**: Orchestrator subscribes to `filterStore` internally. Rejected — the orchestrator already writes to `activeTierStore`; adding a read subscription would tighten the coupling further and make the module harder to test in isolation.
+
+### D2: SQL filter parameters — individual booleans vs. JSON blob
+
+**Decision**: 11 individual `boolean DEFAULT false` parameters on `get_playground_clusters`.
+
+**Rationale**: PostgREST maps each URL param to a named function argument directly. Individual booleans are the natural PostgREST primitive; they appear in the OpenAPI schema automatically; inactive filters simply aren't sent in the URL (the DEFAULT handles absence). A JSON blob would require a custom parser inside the SQL function and would not benefit from the automatic schema exposure.
+
+**Filter → column mapping** (mirrors `matchesFilters()` in `filters.js`):
+
+| filterStore key | SQL param | `playground_stats` expression |
+|---|---|---|
+| `private` | `filter_private` | `NOT ps.access_restricted` |
+| `water` | `filter_water` | `ps.is_water` |
+| `baby` | `filter_baby` | `ps.for_baby` |
+| `toddler` | `filter_toddler` | `ps.for_toddler` |
+| `wheelchair` | `filter_wheelchair` | `ps.for_wheelchair` |
+| `bench` | `filter_bench` | `ps.bench_count > 0` |
+| `picnic` | `filter_picnic` | `ps.picnic_count > 0` |
+| `shelter` | `filter_shelter` | `ps.shelter_count > 0` |
+| `tableTennis` | `filter_table_tennis` | `ps.table_tennis_count > 0` |
+| `soccer` | `filter_soccer` | `ps.has_soccer` |
+| `basketball` | `filter_basketball` | `ps.has_basketball` |
+
+Each becomes an `AND (NOT <param> OR <expr>)` clause in the `buckets` CTE.
+
+### D3: API serialisation — only active flags vs. always all flags
+
+**Decision**: Only active (true) filter flags are included in the URL params.
+
+**Rationale**: Reduces URL length; the SQL `DEFAULT false` handles omitted params identically to `filter_x=false`. Simpler to reason about in network traces.
+
+Implementation in `api.js`:
+```js
+const filterMap = {
+  private: 'filter_private', water: 'filter_water', baby: 'filter_baby',
+  toddler: 'filter_toddler', wheelchair: 'filter_wheelchair',
+  bench: 'filter_bench', picnic: 'filter_picnic', shelter: 'filter_shelter',
+  tableTennis: 'filter_table_tennis', soccer: 'filter_soccer',
+  basketball: 'filter_basketball',
+};
+if (filters) {
+  for (const [key, param] of Object.entries(filterMap)) {
+    if (filters[key]) params.set(param, 'true');
+  }
+}
+```
+
+### D4: GRANT statement — update required after signature change
+
+**Decision**: The existing `GRANT EXECUTE ON FUNCTION api.get_playground_clusters(int, float8, float8, float8, float8)` must be updated to include the 11 new parameters in the type list, OR rewritten to use `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA api TO web_anon` (preferred for maintainability).
+
+**Rationale**: PostgreSQL matches grants by full signature. The old grant will not cover the new signature. The schema-level grant eliminates this class of problem for future function additions.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| DB deploy order: old frontend hits new DB function without filter params | `DEFAULT false` on all new params ensures the old call signature still works — zero-downtime safe |
+| New frontend hits old DB (`make db-apply` not yet run) | Existing 404 fallback in the orchestrator catches this; it falls back to legacy `get_playgrounds` for the session |
+| `rerun()` called while a moveend fetch is in-flight | The existing `AbortController` pattern inside `orchestrate()` cancels the superseded request — no change needed |
+| Centroid shift when filtered | Expected and correct: the geographic mean of filtered members differs from the mean of all members. Documented as correct behaviour. |
+| Empty map when filters match nothing | Expected: no buckets → empty `clusterSource` → no dots shown. Correct mental model for the user. |
+
+## Migration Plan
+
+1. Merge PR → `make db-apply` on the running stack (drops and recreates `get_playground_clusters` with new signature).
+2. `make docker-build` to deploy the new frontend.
+3. No data migration — `playground_stats` materialized view is unchanged.
+4. **Rollback**: revert the PR, `make db-apply`, `make docker-build`. The old signature is restored; the new frontend will 404 on filter params and fall back gracefully.

--- a/openspec/changes/fix-cluster-filter-passthrough/proposal.md
+++ b/openspec/changes/fix-cluster-filter-passthrough/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+When a user activates filters (e.g. "water playground"), the polygon tier (zoom > 13) correctly hides non-matching playgrounds via client-side re-styling — but the cluster tier (zoom ≤ 13) ignores all filters entirely, because `get_playground_clusters` receives no filter parameters and aggregates every playground unconditionally. The map therefore shows misleading cluster counts and ring breakdowns at low zoom whenever any filter is active.
+
+## What Changes
+
+- `get_playground_clusters` in `importer/api.sql` gains 11 optional boolean filter parameters (all `DEFAULT false`); the `buckets` CTE gains matching `AND` clauses so non-matching playgrounds are excluded before aggregation.
+- `fetchPlaygroundClusters` in `app/src/lib/api.js` accepts an optional `filters` object and serialises only the active (true) flags into the PostgREST URL params.
+- `attachTieredOrchestrator` in `app/src/lib/tieredOrchestrator.js` returns `{ detach, rerun }` instead of a bare detach function; `rerun` re-runs `orchestrate()` with freshly supplied filters.
+- `StandaloneApp.svelte` stores the `rerun` handle and adds a reactive statement: when `filterStore` changes and the active tier is `cluster`, it calls `rerun(currentFilters)`.
+
+## Capabilities
+
+### New Capabilities
+
+- `cluster-filter-passthrough`: Server-side filter application for the cluster tier — active `filterStore` flags are forwarded to `get_playground_clusters` so clusters reflect only matching playgrounds, with correct counts and completeness breakdowns.
+
+### Modified Capabilities
+
+*(none — no existing spec-level requirements change; this fixes a gap in the existing tiered-playground-delivery behaviour)*
+
+## Impact
+
+- **`importer/api.sql`**: `get_playground_clusters` signature changes; `make db-apply` required after deploy.
+- **`app/src/lib/api.js`**: `fetchPlaygroundClusters` call signature gains optional `filters` param — backwards-compatible (defaults to no filters).
+- **`app/src/lib/tieredOrchestrator.js`**: return type changes from `() => void` to `{ detach: () => void, rerun: (filters?) => void }` — callers must update destructuring.
+- **`app/src/standalone/StandaloneApp.svelte`**: update destructuring, add reactive rerun trigger.
+- **`standalonePitches`** filter key is excluded — it is a layer-visibility toggle, not a playground data filter.
+- No new dependencies. No schema migrations (the function is dropped and recreated by `make db-apply`).

--- a/openspec/changes/fix-cluster-filter-passthrough/specs/cluster-filter-passthrough/spec.md
+++ b/openspec/changes/fix-cluster-filter-passthrough/specs/cluster-filter-passthrough/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Cluster tier respects active filters
+When one or more playground filters are active in `filterStore`, the cluster tier SHALL request only matching playgrounds from the server. Cluster bucket counts and completeness breakdowns SHALL reflect only the matching set. Buckets whose matching member count is zero SHALL be omitted from the response.
+
+#### Scenario: Water filter applied at cluster zoom
+- **WHEN** the user activates the "water playground" filter at zoom ≤ 13
+- **THEN** the cluster layer SHALL show only buckets containing water playgrounds, with counts reflecting only those playgrounds
+
+#### Scenario: No filters active
+- **WHEN** no filters are active
+- **THEN** cluster behaviour SHALL be identical to the pre-change baseline — all playgrounds aggregated
+
+#### Scenario: Filter combination
+- **WHEN** multiple filters are active simultaneously (e.g. water + bench)
+- **THEN** only playgrounds matching ALL active filters SHALL be counted in clusters
+
+#### Scenario: Filter with no matches
+- **WHEN** an active filter matches zero playgrounds in the visible extent
+- **THEN** the cluster layer SHALL show no dots (empty source), not stale dots from the previous state
+
+### Requirement: Filter change triggers cluster re-fetch
+When `filterStore` changes and the active zoom tier is `cluster`, the system SHALL issue a new `get_playground_clusters` request with the updated filter params within the existing debounce window (i.e. immediately, not waiting for the next `moveend`).
+
+#### Scenario: Filter toggled at cluster zoom
+- **WHEN** the user toggles a filter while at zoom ≤ 13
+- **THEN** a new cluster fetch SHALL be issued and the cluster layer SHALL update without requiring a map pan or zoom
+
+#### Scenario: Filter toggled at polygon zoom
+- **WHEN** the user toggles a filter while at zoom > 13
+- **THEN** no new server fetch SHALL be issued; client-side re-styling via `matchesFilters()` handles the update
+
+### Requirement: `standalonePitches` excluded from cluster filter params
+The `standalonePitches` key in `filterStore` is a layer-visibility toggle and SHALL NOT be forwarded as a filter param to `get_playground_clusters`.
+
+#### Scenario: standalonePitches toggled
+- **WHEN** `standalonePitches` is toggled in any direction
+- **THEN** the cluster fetch params SHALL NOT include a `filter_standalone_pitches` param, and no cluster re-fetch SHALL be triggered by that toggle alone
+
+### Requirement: Backwards-compatible DB function signature
+All new filter parameters on `get_playground_clusters` SHALL have `DEFAULT false`. A caller omitting any filter param SHALL receive the same result as passing `false` for that param.
+
+#### Scenario: Old client hits new DB
+- **WHEN** a request arrives at the new `get_playground_clusters` without any filter params
+- **THEN** the function SHALL return the same unfiltered aggregation as before the change

--- a/openspec/changes/fix-cluster-filter-passthrough/tasks.md
+++ b/openspec/changes/fix-cluster-filter-passthrough/tasks.md
@@ -1,0 +1,44 @@
+## 1. GitHub issue & branch
+
+- [ ] 1.1 Confirm issue #305 is open and link this change to it
+- [ ] 1.2 Create branch `fix/305-cluster-filter-passthrough` from `main`
+
+## 2. Database — `get_playground_clusters`
+
+- [ ] 2.1 Add 11 `boolean DEFAULT false` filter params to the function signature in `importer/api.sql` (`filter_private`, `filter_water`, `filter_baby`, `filter_toddler`, `filter_wheelchair`, `filter_bench`, `filter_picnic`, `filter_shelter`, `filter_table_tennis`, `filter_soccer`, `filter_basketball`)
+- [ ] 2.2 Add `AND (NOT filter_x OR <expr>)` clauses to the `buckets` CTE for each param, matching the mapping in design.md D2
+- [ ] 2.3 Update the `GRANT EXECUTE` statement to cover the new function signature (or switch to schema-level grant as noted in design.md D4)
+- [ ] 2.4 Run `make db-apply` and verify the function is callable with no params (unfiltered baseline) and with individual filter flags
+
+## 3. API — `fetchPlaygroundClusters`
+
+- [ ] 3.1 Add optional `filters` parameter to `fetchPlaygroundClusters` in `app/src/lib/api.js`
+- [ ] 3.2 Implement filter serialisation: iterate the `filterMap` (see design.md D3), append only active (true) flags as URL params
+- [ ] 3.3 Ensure `standalonePitches` is absent from the filter map
+
+## 4. Orchestrator — `tieredOrchestrator.js`
+
+- [ ] 4.1 Change `attachTieredOrchestrator` to accept an optional `filters` snapshot in `orchestrate(filters)`
+- [ ] 4.2 Pass `filters` through to `fetchPlaygroundClusters` in the cluster tier branch
+- [ ] 4.3 Change the return value from `() => void` to `{ detach, rerun }` where `rerun(filters?)` calls `orchestrate(filters)` directly (not debounced)
+
+## 5. StandaloneApp integration
+
+- [ ] 5.1 Update destructuring of `attachTieredOrchestrator` return value in `app/src/standalone/StandaloneApp.svelte` to `{ detach: detachOrchestrator, rerun: rerunOrchestrator }`
+- [ ] 5.2 Add reactive statement: `$: if ($filterStore && $activeTierStore === 'cluster') rerunOrchestrator($filterStore)` — guard on both tier and store availability
+- [ ] 5.3 Verify the reactive statement fires only when tier is `cluster` (not on polygon zoom)
+
+## 6. Manual verification
+
+- [ ] 6.1 `make docker-build` and open the app at cluster zoom (zoom out to ≤ 13)
+- [ ] 6.2 Activate "water playground" filter — confirm cluster dots update without panning
+- [ ] 6.3 Activate a combination of filters — confirm counts reflect the intersection
+- [ ] 6.4 Activate a filter that matches nothing — confirm the cluster layer shows no dots
+- [ ] 6.5 Toggle back to no filters — confirm full cluster counts restore
+- [ ] 6.6 Activate a filter at polygon zoom (zoom in to > 13) — confirm no extra network request is issued
+- [ ] 6.7 Toggle `standalonePitches` — confirm no cluster re-fetch
+
+## 7. PR
+
+- [ ] 7.1 Commit with message `fix(clusters): pass active filters to get_playground_clusters — closes #305`
+- [ ] 7.2 Open PR against `main`, reference issue #305 in the description


### PR DESCRIPTION
## Summary

- Adds OpenSpec change artifacts for `fix-cluster-filter-passthrough` (proposal, design, specs, tasks)
- Documents the three-layer fix needed so active `filterStore` flags are forwarded to `get_playground_clusters` — currently the cluster tier (zoom ≤ 13) ignores all filters entirely
- No production code changes in this PR; implementation follows via `/opsx:apply`

Closes #305

## What's in the proposal

- **DB**: `get_playground_clusters` gains 11 optional `boolean DEFAULT false` filter params; non-matching playgrounds excluded before aggregation
- **API**: `fetchPlaygroundClusters` serialises active filter flags into PostgREST URL params
- **Orchestrator**: returns `{ detach, rerun }` so `StandaloneApp` can trigger a fresh cluster fetch on filter change without waiting for `moveend`
- **StandaloneApp**: one reactive statement — rerun only when `activeTierStore === 'cluster'`

## Test plan

- [ ] Review proposal/design/spec/tasks artifacts for correctness and completeness
- [ ] Confirm filter → SQL column mapping in `design.md` matches `matchesFilters()` in `filters.js`
- [ ] Confirm backwards-compat note: old callers with no filter params still work (`DEFAULT false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)