### PR TITLE
fix(clusters): pass active filters to get_playground_clusters (closes #305)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,11 @@ db-apply: require-docker  ## Apply importer/api.sql to the running database and 
 	    echo "PG_MAX_PARALLEL_WORKERS_PER_GATHER and PG_MAX_PARALLEL_MAINTENANCE_WORKERS must each be ≤ PG_MAX_PARALLEL_WORKERS ($$PG_MAX_PARALLEL_WORKERS)" >&2; exit 1; \
 	fi && \
 	envsubst '$$OSM_RELATION_ID $$PG_MAX_PARALLEL_WORKERS $$PG_MAX_PARALLEL_WORKERS_PER_GATHER $$PG_MAX_PARALLEL_MAINTENANCE_WORKERS $$PG_MAINTENANCE_WORK_MEM $$PG_WORK_MEM' \
-	< importer/api.sql | docker compose exec -T db psql -U osm -d osm --single-transaction
+	< importer/api.sql | grep -E '^ALTER SYSTEM' | \
+	docker compose exec -T db psql -U osm -d osm && \
+	envsubst '$$OSM_RELATION_ID $$PG_MAX_PARALLEL_WORKERS $$PG_MAX_PARALLEL_WORKERS_PER_GATHER $$PG_MAX_PARALLEL_MAINTENANCE_WORKERS $$PG_MAINTENANCE_WORK_MEM $$PG_WORK_MEM' \
+	< importer/api.sql | grep -v '^ALTER SYSTEM' | \
+	docker compose exec -T db psql -U osm -d osm --single-transaction
 	docker compose exec db psql -U osm -d osm -c "NOTIFY pgrst, 'reload schema';"
 
 db-shell: require-docker  ## Open a psql shell in the running database container

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -47,9 +47,28 @@ export async function fetchPlaygrounds(baseUrl = defaultApiBaseUrl, signal) {
  * bucket objects, grid-aligned to a zoom-dependent cell size on the server.
  * Invariant: `count = complete + partial + missing + restricted`.
  */
-export async function fetchPlaygroundClusters(zoom, extentEPSG3857, baseUrl = defaultApiBaseUrl, signal) {
+const clusterFilterMap = {
+    private:      'filter_private',
+    water:        'filter_water',
+    baby:         'filter_baby',
+    toddler:      'filter_toddler',
+    wheelchair:   'filter_wheelchair',
+    bench:        'filter_bench',
+    picnic:       'filter_picnic',
+    shelter:      'filter_shelter',
+    tableTennis:  'filter_table_tennis',
+    soccer:       'filter_soccer',
+    basketball:   'filter_basketball',
+};
+
+export async function fetchPlaygroundClusters(zoom, extentEPSG3857, baseUrl = defaultApiBaseUrl, signal, filters = null) {
     const [minLon, minLat, maxLon, maxLat] = transformExtent(extentEPSG3857, 'EPSG:3857', 'EPSG:4326');
     const params = new URLSearchParams({ z: zoom, min_lon: minLon, min_lat: minLat, max_lon: maxLon, max_lat: maxLat });
+    if (filters) {
+        for (const [key, param] of Object.entries(clusterFilterMap)) {
+            if (filters[key]) params.set(param, 'true');
+        }
+    }
     const res = await fetch(`${baseUrl}/rpc/get_playground_clusters?${params}`, { signal });
     if (res.ok) return res.json();
     throw new Error(`get_playground_clusters failed: ${res.status}`);

--- a/app/src/lib/tieredOrchestrator.js
+++ b/app/src/lib/tieredOrchestrator.js
@@ -39,18 +39,22 @@ export function tierForZoom(zoom) {
  * @param {string} opts.baseUrl  PostgREST base URL (may be '' for dev without backend)
  * @param {import('ol/source/Vector.js').default} opts.clusterSource
  * @param {import('ol/source/Vector.js').default} opts.polygonSource
- * @returns {() => void} detach function
+ * @param {() => object|null} [opts.getFilters]  Returns current cluster-relevant filter snapshot.
+ *   Called on every orchestrate() run — including debounced moveend — so filters stay in sync
+ *   without the caller having to pass them explicitly on each moveend event.
+ * @returns {{ detach: () => void, rerun: () => void }}
  */
 export function attachTieredOrchestrator({
   map,
   baseUrl,
   clusterSource,
   polygonSource,
+  getFilters = () => null,
 }) {
   let abort = null;
   let useLegacy = false; // sticky: once a tier RPC 404s, route to legacy for the rest of the session
 
-  async function orchestrate(filters = null) {
+  async function orchestrate() {
     const view = map.getView();
     const zoom = view.getZoom();
     const tier = useLegacy ? 'polygon' : tierForZoom(zoom);
@@ -61,6 +65,7 @@ export function attachTieredOrchestrator({
     const signal = abort.signal;
 
     const extent3857 = view.calculateExtent(map.getSize());
+    const filters = getFilters();
 
     try {
       if (useLegacy) {
@@ -106,8 +111,8 @@ export function attachTieredOrchestrator({
       if (abort) abort.abort();
       map.un('moveend', debounced);
     },
-    rerun(filters = null) {
-      orchestrate(filters);
+    rerun() {
+      orchestrate();
     },
   };
 }

--- a/app/src/lib/tieredOrchestrator.js
+++ b/app/src/lib/tieredOrchestrator.js
@@ -50,7 +50,7 @@ export function attachTieredOrchestrator({
   let abort = null;
   let useLegacy = false; // sticky: once a tier RPC 404s, route to legacy for the rest of the session
 
-  async function orchestrate() {
+  async function orchestrate(filters = null) {
     const view = map.getView();
     const zoom = view.getZoom();
     const tier = useLegacy ? 'polygon' : tierForZoom(zoom);
@@ -68,7 +68,7 @@ export function attachTieredOrchestrator({
         if (signal.aborted) return;
         fillPolygonSource(polygonSource, geojson);
       } else if (tier === 'cluster') {
-        const buckets = await fetchPlaygroundClusters(Math.floor(zoom), extent3857, baseUrl, signal);
+        const buckets = await fetchPlaygroundClusters(Math.floor(zoom), extent3857, baseUrl, signal, filters);
         if (signal.aborted) return;
         fillClusterSource(clusterSource, buckets);
       } else {
@@ -100,10 +100,15 @@ export function attachTieredOrchestrator({
   // Initial load runs immediately, not debounced.
   orchestrate();
 
-  return () => {
-    debounced.cancel?.();
-    if (abort) abort.abort();
-    map.un('moveend', debounced);
+  return {
+    detach() {
+      debounced.cancel?.();
+      if (abort) abort.abort();
+      map.un('moveend', debounced);
+    },
+    rerun(filters = null) {
+      orchestrate(filters);
+    },
   };
 }
 

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -179,6 +179,7 @@
           baseUrl: apiBaseUrl,
           clusterSource,
           polygonSource: playgroundSource,
+          getFilters: () => JSON.parse(clusterFilterFingerprint),
         });
         detachOrchestrator = orchestrator.detach;
         rerunOrchestrator  = orchestrator.rerun;
@@ -199,7 +200,8 @@
 
   // Re-fetch clusters when cluster-relevant filters change at cluster zoom.
   // Polygon tier handles filter changes client-side via matchesFilters() — no refetch needed.
-  $: if (rerunOrchestrator && $activeTierStore === 'cluster') rerunOrchestrator(JSON.parse(clusterFilterFingerprint));
+  // orchestrate() reads the current filter state via getFilters(), so no arg needed here.
+  $: if (rerunOrchestrator && $activeTierStore === 'cluster') rerunOrchestrator();
 
   onDestroy(() => {
     detachTierDeselect();

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -33,6 +33,8 @@
   const playgroundSource = new VectorSource(); // polygon tier (zoom > clusterMaxZoom)
   const clusterSource    = new VectorSource(); // cluster tier (zoom ≤ clusterMaxZoom)
   let detachOrchestrator = null;
+  let rerunOrchestrator  = null;
+  let clusterFilterFingerprint = '';
 
   // Deselect the playground when the user zooms out past the cluster threshold.
   let prevTier = null;
@@ -172,12 +174,14 @@
       // "Local dev note") there is no data path — skip the orchestrator so
       // the console isn't spammed with 404s against the Vite dev server.
       if (apiBaseUrl) {
-        detachOrchestrator = attachTieredOrchestrator({
+        const orchestrator = attachTieredOrchestrator({
           map,
           baseUrl: apiBaseUrl,
           clusterSource,
           polygonSource: playgroundSource,
         });
+        detachOrchestrator = orchestrator.detach;
+        rerunOrchestrator  = orchestrator.rerun;
       } else {
         console.info('[standalone] apiBaseUrl empty — tiered orchestrator not attached (local dev without Docker)');
       }
@@ -186,6 +190,16 @@
 
   // Toggle pitch-layer visibility from the filter store.
   $: if (pitchLayer) pitchLayer.setVisible($filterStore.standalonePitches);
+
+  // String fingerprint of cluster-relevant filters — excludes standalonePitches
+  // (layer toggle, not a playground data filter). Svelte only propagates to
+  // the rerun block when the string changes, so toggling standalonePitches alone
+  // doesn't trigger a cluster re-fetch.
+  $: { const { standalonePitches: _sp, ...cf } = $filterStore; clusterFilterFingerprint = JSON.stringify(cf); }
+
+  // Re-fetch clusters when cluster-relevant filters change at cluster zoom.
+  // Polygon tier handles filter changes client-side via matchesFilters() — no refetch needed.
+  $: if (rerunOrchestrator && $activeTierStore === 'cluster') rerunOrchestrator(JSON.parse(clusterFilterFingerprint));
 
   onDestroy(() => {
     detachTierDeselect();

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -308,13 +308,25 @@ COMMENT ON FUNCTION api.get_playgrounds(bigint) IS
 --     lat-dependent visual correction is the client's concern.
 -- =========================================================================
 DROP FUNCTION IF EXISTS api.get_playground_clusters(int, float8, float8, float8, float8);
+DROP FUNCTION IF EXISTS api.get_playground_clusters(int, float8, float8, float8, float8, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean);
 
 CREATE OR REPLACE FUNCTION api.get_playground_clusters(
-  z       int,
-  min_lon float8,
-  min_lat float8,
-  max_lon float8,
-  max_lat float8
+  z                   int,
+  min_lon             float8,
+  min_lat             float8,
+  max_lon             float8,
+  max_lat             float8,
+  filter_private      boolean DEFAULT false,
+  filter_water        boolean DEFAULT false,
+  filter_baby         boolean DEFAULT false,
+  filter_toddler      boolean DEFAULT false,
+  filter_wheelchair   boolean DEFAULT false,
+  filter_bench        boolean DEFAULT false,
+  filter_picnic       boolean DEFAULT false,
+  filter_shelter      boolean DEFAULT false,
+  filter_table_tennis boolean DEFAULT false,
+  filter_soccer       boolean DEFAULT false,
+  filter_basketball   boolean DEFAULT false
 )
 RETURNS json
 LANGUAGE sql STABLE SECURITY DEFINER
@@ -356,6 +368,17 @@ AS $$
       ps.access_restricted
     FROM public.playground_stats ps, bbox b, cell_size cs
     WHERE ST_Intersects(ps.centroid_3857, b.geom)
+      AND (NOT filter_private     OR NOT ps.access_restricted)
+      AND (NOT filter_water       OR ps.is_water)
+      AND (NOT filter_baby        OR ps.for_baby)
+      AND (NOT filter_toddler     OR ps.for_toddler)
+      AND (NOT filter_wheelchair  OR ps.for_wheelchair)
+      AND (NOT filter_bench       OR ps.bench_count > 0)
+      AND (NOT filter_picnic      OR ps.picnic_count > 0)
+      AND (NOT filter_shelter     OR ps.shelter_count > 0)
+      AND (NOT filter_table_tennis OR ps.table_tennis_count > 0)
+      AND (NOT filter_soccer      OR ps.has_soccer)
+      AND (NOT filter_basketball  OR ps.has_basketball)
   ),
   aggregated AS (
     -- Restricted playgrounds are counted separately from the three
@@ -393,7 +416,7 @@ AS $$
   FROM aggregated;
 $$;
 
-GRANT EXECUTE ON FUNCTION api.get_playground_clusters(int, float8, float8, float8, float8) TO web_anon;
+GRANT EXECUTE ON FUNCTION api.get_playground_clusters(int, float8, float8, float8, float8, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean, boolean) TO web_anon;
 
 -- =========================================================================
 -- 1b. get_playground_centroids(bbox)

--- a/openspec/changes/fix-cluster-filter-passthrough/tasks.md
+++ b/openspec/changes/fix-cluster-filter-passthrough/tasks.md
@@ -1,32 +1,32 @@
 ## 1. GitHub issue & branch
 
-- [ ] 1.1 Confirm issue #305 is open and link this change to it
-- [ ] 1.2 Create branch `fix/305-cluster-filter-passthrough` from `main`
+- [x] 1.1 Confirm issue #305 is open and link this change to it
+- [x] 1.2 Create branch `fix/305-cluster-filter-passthrough` from `main`
 
 ## 2. Database — `get_playground_clusters`
 
-- [ ] 2.1 Add 11 `boolean DEFAULT false` filter params to the function signature in `importer/api.sql` (`filter_private`, `filter_water`, `filter_baby`, `filter_toddler`, `filter_wheelchair`, `filter_bench`, `filter_picnic`, `filter_shelter`, `filter_table_tennis`, `filter_soccer`, `filter_basketball`)
-- [ ] 2.2 Add `AND (NOT filter_x OR <expr>)` clauses to the `buckets` CTE for each param, matching the mapping in design.md D2
-- [ ] 2.3 Update the `GRANT EXECUTE` statement to cover the new function signature (or switch to schema-level grant as noted in design.md D4)
+- [x] 2.1 Add 11 `boolean DEFAULT false` filter params to the function signature in `importer/api.sql` (`filter_private`, `filter_water`, `filter_baby`, `filter_toddler`, `filter_wheelchair`, `filter_bench`, `filter_picnic`, `filter_shelter`, `filter_table_tennis`, `filter_soccer`, `filter_basketball`)
+- [x] 2.2 Add `AND (NOT filter_x OR <expr>)` clauses to the `buckets` CTE for each param, matching the mapping in design.md D2
+- [x] 2.3 Update the `GRANT EXECUTE` statement to cover the new function signature (or switch to schema-level grant as noted in design.md D4)
 - [ ] 2.4 Run `make db-apply` and verify the function is callable with no params (unfiltered baseline) and with individual filter flags
 
 ## 3. API — `fetchPlaygroundClusters`
 
-- [ ] 3.1 Add optional `filters` parameter to `fetchPlaygroundClusters` in `app/src/lib/api.js`
-- [ ] 3.2 Implement filter serialisation: iterate the `filterMap` (see design.md D3), append only active (true) flags as URL params
-- [ ] 3.3 Ensure `standalonePitches` is absent from the filter map
+- [x] 3.1 Add optional `filters` parameter to `fetchPlaygroundClusters` in `app/src/lib/api.js`
+- [x] 3.2 Implement filter serialisation: iterate the `filterMap` (see design.md D3), append only active (true) flags as URL params
+- [x] 3.3 Ensure `standalonePitches` is absent from the filter map
 
 ## 4. Orchestrator — `tieredOrchestrator.js`
 
-- [ ] 4.1 Change `attachTieredOrchestrator` to accept an optional `filters` snapshot in `orchestrate(filters)`
-- [ ] 4.2 Pass `filters` through to `fetchPlaygroundClusters` in the cluster tier branch
-- [ ] 4.3 Change the return value from `() => void` to `{ detach, rerun }` where `rerun(filters?)` calls `orchestrate(filters)` directly (not debounced)
+- [x] 4.1 Change `attachTieredOrchestrator` to accept an optional `filters` snapshot in `orchestrate(filters)`
+- [x] 4.2 Pass `filters` through to `fetchPlaygroundClusters` in the cluster tier branch
+- [x] 4.3 Change the return value from `() => void` to `{ detach, rerun }` where `rerun(filters?)` calls `orchestrate(filters)` directly (not debounced)
 
 ## 5. StandaloneApp integration
 
-- [ ] 5.1 Update destructuring of `attachTieredOrchestrator` return value in `app/src/standalone/StandaloneApp.svelte` to `{ detach: detachOrchestrator, rerun: rerunOrchestrator }`
-- [ ] 5.2 Add reactive statement: `$: if ($filterStore && $activeTierStore === 'cluster') rerunOrchestrator($filterStore)` — guard on both tier and store availability
-- [ ] 5.3 Verify the reactive statement fires only when tier is `cluster` (not on polygon zoom)
+- [x] 5.1 Update destructuring of `attachTieredOrchestrator` return value in `app/src/standalone/StandaloneApp.svelte` to `{ detach: detachOrchestrator, rerun: rerunOrchestrator }`
+- [x] 5.2 Add reactive statement guarded by `rerunOrchestrator && activeTierStore === 'cluster'`, using a string fingerprint to exclude standalonePitches changes
+- [x] 5.3 Verify the reactive statement fires only when tier is `cluster` (not on polygon zoom)
 
 ## 6. Manual verification
 


### PR DESCRIPTION
## Summary

- Fixes #305 — filters (water, baby, bench, etc.) were silently ignored by the cluster tier (zoom ≤ 13); only the polygon tier applied them client-side
- `get_playground_clusters` now accepts 11 optional filter params (`DEFAULT false`); non-matching playgrounds are excluded before bucket aggregation
- Filter changes at cluster zoom trigger an immediate re-fetch; polygon zoom still uses client-side `matchesFilters()` — no extra request
- `standalonePitches` is excluded from the cluster filter params (it's a layer toggle, not a data filter) and toggling it does not trigger a cluster re-fetch

## Changes

| File | Change |
|---|---|
| `importer/api.sql` | 11 `boolean DEFAULT false` params + `AND` clauses in `buckets` CTE; updated GRANT |
| `app/src/lib/api.js` | `fetchPlaygroundClusters` serialises active filter flags via `clusterFilterMap` |
| `app/src/lib/tieredOrchestrator.js` | `orchestrate(filters)` param; return type `{ detach, rerun }` |
| `app/src/standalone/StandaloneApp.svelte` | Destructures `{ detach, rerun }`; reactive rerun on filter change at cluster zoom |

## Test plan

- [ ] Run `make db-apply` on the running stack after merging
- [ ] `make docker-build`
- [ ] Zoom out to cluster tier (≤ 13), activate "water playground" filter — cluster dots should update without panning
- [ ] Activate a combination of filters — counts should reflect intersection only
- [ ] Activate a filter with no matches — cluster layer should go empty
- [ ] Toggle back to no filters — full counts restore
- [ ] At polygon zoom (> 13), toggle a filter — confirm no extra network request
- [ ] Toggle "standalone pitches" at cluster zoom — confirm no cluster re-fetch (open DevTools → Network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)