### PR TITLE
fix(ui): re-center map after closing mobile detail panel (#345)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -328,17 +328,29 @@
     checkMobile();
   }
 
-  // Center the map on the selected playground before the full-screen panel opens.
-  // Bottom padding accounts for the bottom sheet (~250 px) so the polygon
-  // isn't hidden behind it. This is the single canonical fit for all mobile
-  // selection paths (map click, nearby list, deeplink).
-  $: if (isMobile && $hasSelection) {
-    const feat = $selection.feature;
-    if (feat && $mapStore) {
+  // Center the map on the selected playground when the mobile full-screen panel
+  // opens, and re-center when it closes so the full area is visible on return.
+  // Uses balanced padding — the full-screen panel covers the map entirely while
+  // open, so there is no bottom-sheet offset to account for.
+  let lastMobileFeature = null;
+  $: {
+    if (isMobile && $hasSelection) {
+      const feat = $selection.feature;
+      if (feat && $mapStore) {
+        lastMobileFeature = feat;
+        $mapStore.getView().fit(feat.getGeometry().getExtent(), {
+          padding: [60, 20, 60, 20],
+          maxZoom: 19,
+          duration: 400,
+        });
+      }
+    } else if (isMobile && !$hasSelection && lastMobileFeature && $mapStore) {
+      const feat = lastMobileFeature;
+      lastMobileFeature = null;
       $mapStore.getView().fit(feat.getGeometry().getExtent(), {
-        padding: [60, 20, 250, 20],
+        padding: [80, 40, 80, 40],
         maxZoom: 19,
-        duration: 400,
+        duration: 300,
       });
     }
   }


### PR DESCRIPTION
## Summary

- The mobile full-screen detail panel covers the map entirely while open, so the map view is frozen at the position it was fitted to on selection.
- The old `view.fit` used `padding: [60, 20, 250, 20]` — the 250 px bottom was a leftover from an old bottom-sheet layout that no longer exists. This pushed the playground toward the top of the screen so that, after closing the panel, the area appeared off-center.
- **On open**: padding changed to balanced `[60, 20, 60, 20]`.
- **On close**: explicit re-fit with `[80, 40, 80, 40]` ensures the full playground area is centered when the user returns to the map, regardless of any edge-case interference from Map.svelte's desktop-padded `view.fit`.

## Test plan

- [ ] Open a playground on mobile (< 1024 px viewport)
- [ ] Verify the polygon is centered on the map briefly before the full-screen panel opens
- [ ] Close the panel with the back button
- [ ] Verify the full playground area is now visible and centered on the map
- [ ] Repeat by selecting via the NearbyPlaygrounds list and deeplink
- [ ] On desktop (≥ 1024 px), verify no change: sidebar appears, no re-center on close

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)