### PR TITLE
fix(map): 10 px hit-tolerance for polygon selection (#343)

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -161,6 +161,7 @@
     olMap.on('click', (evt) => {
       const polygonHit = olMap.forEachFeatureAtPixel(evt.pixel, (f) => f, {
         layerFilter: (l) => l === playgroundLayer,
+        hitTolerance: 10,
       });
       if (polygonHit) {
         const backendUrl = polygonHit.get('_backendUrl') ?? defaultBackendUrl;
@@ -215,6 +216,7 @@
       });
       const playHit = olMap.forEachFeatureAtPixel(evt.pixel, f => f, {
         layerFilter: l => l === playgroundLayer,
+        hitTolerance: 10,
       });
       // Cluster tier hits get the pointer cursor too — click-to-zoom is
       // wired for them and users need the affordance.


### PR DESCRIPTION
## Summary

- Small playground polygons are hard to tap on mobile at lower polygon-tier zoom levels (zoom 14–15).
- OpenLayers' `forEachFeatureAtPixel` accepts a `hitTolerance` option that expands the hit area around features by N pixels.
- Added `hitTolerance: 10` to the polygon hit-test in both the **click handler** (selection) and the **pointermove handler** (pointer cursor), so tapping/hovering within 10 px of a polygon edge is treated as a hit.
- Cluster and macro layers are not affected — their click targets (zoom-in, fit-to-bbox) are already large enough.

## Test plan

- [ ] At polygon zoom (≥ 14), tap slightly outside a small playground polygon — it should now select
- [ ] Hover cursor should appear within ~10 px of polygon edges (desktop)
- [ ] Neighbouring playgrounds with a narrow gap: tapping in the gap still selects the nearer one, not both
- [ ] Cluster and macro clicks unchanged

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)