### PR TITLE
docs(openspec): refresh Weblate i18n design for epic #348

### DIFF
--- a/openspec/changes/add-weblate-community-translations/design.md
+++ b/openspec/changes/add-weblate-community-translations/design.md
@@ -1,21 +1,31 @@
 ## Context
 
-spieli currently supports DE and EN via `svelte-i18n` with flat JSON files using ICU message format (`locales/de.json`, `locales/en.json`, ~320 keys each). Ten additional locale files exist in `locales/` from a previous attempt (cs, es, fr, it, ja, nl, pl, pt, sv, uk) but are auto-generated and not registered in `i18n.js`. There is no external translation tooling — strings are edited directly in the repo.
+spieli uses `svelte-i18n` with nested JSON files in `locales/`. DE and EN are complete at 580 keys each. Ten additional locale files (cs, es, fr, it, ja, nl, pl, pt, sv, uk) exist from a previous attempt — they cover 15–19% of current strings and each contains 15 stale plural-suffix keys (`_one`, `_few`, `_other`) that predate the current ICU-inline plural format.
 
-The goal is to invite OSM community translators to contribute new languages. Translators in this context are non-developers who should not need GitHub access or knowledge of ICU syntax.
+Current state of partial locales vs. what Weblate would see:
 
-**Constraint**: Setup should happen after issue #249 (project rename to "spieli") so the Weblate project name is consistent with the final repo and DNS name.
+```
+cs/es/fr/…  ████░░░░░░░░░░░░░░░░  ~17% of 580 keys
+             + 15 orphaned _one/_few/_other keys
+               (no match in en.json → Weblate imports as noise)
+```
+
+After cleanup: 89–94 valid keys per language remain. These are genuinely useful as a translator starting point for the app-shell strings (search, filters, nav, completeness), even though the large equipment vocabulary sections are blank.
+
+Both blocking prerequisites are resolved: #249 (project rename to "spieli") and #157 (svelte-i18n re-integration) are closed.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Enable community translation contributions via a web UI (no GitHub access required)
+- Enable community translation contributions via a Weblate web UI — no GitHub access required
 - Keep translation PRs in the maintainer's review queue — no direct pushes to `main`
-- Support existing `locales/*.json` format with zero changes to file structure
+- Import existing partial locale files as starting points with minimal friction
 - Provide a clear threshold for when a new language goes live in the app
+- Raise spieli's profile in the OSM translator community
 
 **Non-Goals:**
-- Automated language promotion (adding to `SUPPORTED` stays a manual maintainer decision)
+- Pre-populating the equipment vocabulary sections from external data sources (OSM wiki, iD translations) — valuable but out of scope; that's a future bootstrap task
+- Automated language promotion — adding to `SUPPORTED` stays a manual maintainer step
 - Self-hosted Weblate infrastructure
 - Changing the JSON translation format or ICU syntax
 
@@ -23,65 +33,43 @@ The goal is to invite OSM community translators to contribute new languages. Tra
 
 ### 1. EN as Weblate source language (not DE)
 
-**Decision**: `locales/en.json` is the Weblate template; translators work from English.
-
-**Rationale**: The vast majority of community translators on hosted.weblate.org work from English. Using DE as source would require translators to know German grammar — a significant barrier, especially for e.g. Japanese or Czech contributors. The German genitive suffix in `{regionName}er spieli` (vs. `{regionName} Playground Map` in EN) illustrates the problem concretely.
-
-**Trade-off**: The maintainer must keep `locales/en.json` and `locales/de.json` in sync manually (as they do today). Weblate treats DE as a translation like any other, but the maintainer edits it directly in the repo rather than via Weblate UI.
-
-**Alternative considered**: DE as source. Rejected — see rationale above.
+`locales/en.json` is the Weblate template; translators work from English. The vast majority of hosted.weblate.org translators work from EN. Using DE as source would require knowledge of German grammar for e.g. Japanese or Czech contributors. Maintainer keeps DE in sync manually, as today.
 
 ### 2. hosted.weblate.org, free OSS tier
 
-**Decision**: Use hosted.weblate.org rather than self-hosted Weblate.
+spieli qualifies as libre open-source. Zero infrastructure. Weblate handles GitHub webhook integration, translation memory, machine translation suggestions, and quality checks. No self-hosting burden.
 
-**Rationale**: spieli qualifies as a libre open-source project. Zero infrastructure to maintain. Weblate handles GitHub webhook integration, translation memory, machine translation suggestions, and quality checks out of the box.
+### 3. `json-i18n` file format
 
-**Alternative considered**: Self-hosted Weblate (Docker). Rejected — adds operational burden with no benefit for a volunteer-maintained project.
+`locales/*.json` uses ICU message format for plurals (`{count, plural, one {# bench} other {# benches}}`). Weblate's `json-i18n` format understands ICU syntax and presents plural forms as separate fields. Plain `json-nested` treats ICU strings as opaque — wrong for this format.
 
-### 3. `json-i18n` file format (not `json-nested`)
+### 4. Clean up stale plural keys before import
 
-**Decision**: Configure the Weblate component with file format `json-i18n`.
+The 15 `_one`/`_few`/`_other` keys in each partial locale are from an older format where plural forms were separate keys. They have no counterpart in `en.json`. Weblate would import them as untranslatable orphans. Strip them from all ten files before the Weblate component is connected.
 
-**Rationale**: The locale files use ICU message format for plurals (`{count, plural, one {# Spielgerät} other {# Spielgeräte}}`). Weblate's plain `json-nested` format treats these as opaque strings, losing plural form awareness. `json-i18n` understands ICU syntax and presents plural forms as separate translation fields in the UI.
+The valid residual content (89–94 keys per language) is worth keeping — these cover the app-shell strings (search, navigation, completeness labels, info panel) that translators encounter first.
 
-**Risk**: ICU plural syntax in Weblate requires translators to understand the `{count, plural, ...}` pattern for their target language's plural rules (e.g. Slavic languages have 3–4 plural forms). Weblate surfaces this automatically in the UI, so it's manageable.
+### 5. Push to dedicated branch, merge via PR
 
-### 4. Push to dedicated branch, merge via PR
+Weblate pushes commits to `weblate-translations`. PR to `main` for maintainer review. Matches the project's "never push directly to main" policy. Weblate's GitHub integration can open PRs automatically, or the maintainer creates them manually.
 
-**Decision**: Weblate pushes translation commits to a `weblate-translations` branch. A PR from that branch to `main` is opened for maintainer review.
+### 6. 80% completion threshold for language graduation
 
-**Rationale**: Matches the project's `Never push directly to main` policy (CLAUDE.md). Maintainer can review, squash, and merge on their own schedule. Prevents unreviewed strings landing in production.
+A language is added to `SUPPORTED` in `i18n.js` only when it reaches ≥ 80% translated in Weblate. With 580 keys, 80% = 464 keys. This is more work than the original estimate (~256 keys at the old 320-key count), but the quality bar is correct: below 80%, the equipment vocabulary sections would be largely untranslated and the app experience would be jarring.
 
-**Configuration**: In Weblate project settings, set "Push branch" to `weblate-translations`. The Weblate GitHub integration can open PRs automatically, or the maintainer creates them manually.
+The threshold is documented in the Weblate project description. Translator motivation: Weblate shows percentage bars and activity badges — reaching 80% is a visible milestone.
 
-### 5. 80% completion threshold for language graduation
+### 7. Developer workflow: EN first, DE in same commit
 
-**Decision**: A language is added to `SUPPORTED` in `i18n.js` (and becomes visible in the app) only when it reaches ≥ 80% translated strings in Weblate.
-
-**Rationale**: A language at 30% completion produces a jarring mixed-language UI. 80% ensures most screens are fully translated before users encounter the language. The threshold is documented in the Weblate project description so translators know the bar.
-
-**Note**: The maintainer adds the language manually: add to `SUPPORTED` array in `i18n.js`, add a `register()` call, and add a `register()` call targeting `locales/<lang>.json`.
-
-### 6. Old locale files kept as starting points
-
-**Decision**: Retain `locales/cs.json`, `es.json`, `fr.json`, `it.json`, `ja.json`, `nl.json`, `pl.json`, `pt.json`, `sv.json`, `uk.json`.
-
-**Rationale**: Even auto-generated translations provide a starting point and populate Weblate's translation memory. Weblate quality checks flag suspicious strings. Community translators benefit from having something to review rather than a blank slate.
+When a new string is added, `en.json` is updated first, `de.json` in the same commit. Weblate detects the new EN key and surfaces it to all language translators immediately. Adding to `de.json` only without an EN counterpart breaks the source → translation chain.
 
 ## Risks / Trade-offs
 
-- **Stale EN/DE sync**: If a new string is added to `de.json` but not `en.json`, Weblate won't surface it to translators. Mitigation: treat EN as the authoritative source; add new strings to `en.json` first, then `de.json`.
-- **ICU plural complexity**: Languages with complex plural rules (Polish, Russian, Arabic) require translators to handle multiple forms. Weblate guides this but can't prevent wrong plural patterns. Mitigation: Weblate's built-in plural validation catches most errors.
-- **Weblate PR flood**: Active translation periods may produce frequent PRs. Mitigation: Weblate batches commits; "Squash commits" option in Weblate settings keeps PR history clean.
-- **`.weblate.yml` format drift**: Weblate's discovery file format may differ by version. Mitigation: verify exact YAML schema against hosted.weblate.org docs at setup time.
-
-## Migration Plan
-
-1. Wait for issue #249 (rename to "spieli") to land
-2. Register on hosted.weblate.org, create project "spieli" linked to the GitHub repo
-3. Add `.weblate.yml` to repo root (component discovery config)
-4. Configure component: file format `json-i18n`, template `locales/en.json`, push branch `weblate-translations`
-5. Weblate imports existing locale files — translators see partially-completed languages
-6. Document graduation threshold in Weblate project description
-7. As languages reach 80%: open PR to add them to `i18n.js`
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Stale keys missed during cleanup — Weblate imports orphans | Low | Python script to diff `locales/*.json` against `en.json` before connecting |
+| EN/DE sync drift — new strings added only to `de.json` | Medium | Dev workflow documented; CI lint rule possible future addition |
+| ICU plural complexity confuses translators | Low | Weblate surfaces plural forms as separate fields with language-specific plural rules; most common case (one/other) needs no explanation |
+| Weblate PR flood during active translation periods | Low | Weblate squash-commits option; batch push delay setting |
+| 80% threshold feels too high for minority languages with few speakers | Low–Medium | Threshold can be lowered per-language by maintainer; documented as guidance not hard policy |
+| `.weblate.yml` format drift between Weblate versions | Low | Verify exact schema against hosted.weblate.org docs at setup time |

--- a/openspec/changes/add-weblate-community-translations/proposal.md
+++ b/openspec/changes/add-weblate-community-translations/proposal.md
@@ -1,31 +1,30 @@
 ## Why
 
-UI strings in spieli are hardcoded German with only DE and EN supported, making the app inaccessible to non-German-speaking communities who discover it through OSM. Weblate gives community translators a web UI to contribute new languages without needing GitHub access, turning translation into a self-service OSM community activity.
+spieli's UI is fully localised in DE and EN, but no other language is active in the app. The OSM community is global — connecting spieli to hosted.weblate.org puts it in front of community translators and raises project visibility, turning translation into a self-service activity that runs without developer involvement. The two prerequisite blockers (#249 project rename, #157 svelte-i18n epic) are both closed: setup can begin now.
 
 ## What Changes
 
-- Add a `.weblate.yml` component-discovery config to the repo root so hosted.weblate.org can auto-detect the translation component
-- Register the project on hosted.weblate.org (free OSS tier) as "spieli", linked to the GitHub repo via webhook
-- Configure Weblate to use EN as the source language and `locales/en.json` as the template, with `json-i18n` format (ICU plural-aware)
-- Keep existing `locales/*.json` files (cs, es, fr, it, ja, nl, pl, pt, sv, uk) as partial starting points for community translators
-- Weblate pushes translation updates to a dedicated `weblate-translations` branch; maintainer merges via PR (never direct to `main`)
-- Document language graduation threshold: when a language reaches ≥ 80% translated in Weblate, add it to `SUPPORTED` in `i18n.js` and add a `register()` call
+- Add `.weblate.yml` to the repo root so hosted.weblate.org auto-discovers the translation component
+- Register spieli on hosted.weblate.org (free OSS tier) linked to the GitHub repo via webhook
+- Clean up stale plural-suffix keys (`_one`, `_few`, `_other`) from the ten partial locale files — these predate the ICU-inline format and would appear as untranslatable noise in Weblate
+- Configure Weblate to use EN as the source language and `json-i18n` file format (ICU-plural-aware)
+- Set the push branch to `weblate-translations`; all translation PRs go through maintainer review before reaching `main`
+- Document the language graduation threshold (≥ 80% completion) in the Weblate project description
 
 ## Capabilities
 
 ### New Capabilities
 
-- `weblate-integration`: Weblate component config, repo webhook, push-branch PR workflow, and language graduation process
+- `weblate-integration`: Weblate component config, repo webhook, push-branch PR workflow, and partial-locale cleanup
 
 ### Modified Capabilities
 
-- `i18n-language-support`: graduation threshold added — new languages go live in the app only once they reach ≥ 80% completion in Weblate
+- `i18n-language-support`: graduation threshold clarified — 80% of 580 keys (~464) needed before a language is added to `SUPPORTED` in `i18n.js`; EN is the authoritative source for new strings
 
 ## Impact
 
-- **New file**: `.weblate.yml` in repo root (Weblate component discovery)
-- **`app/src/lib/i18n.js`**: updated when new languages graduate (≥ 80% complete)
-- **`locales/`**: new language JSON files added over time via Weblate PRs
+- **New file**: `.weblate.yml` in repo root
+- **Modified files**: `locales/cs.json`, `es.json`, `fr.json`, `it.json`, `ja.json`, `nl.json`, `pl.json`, `pt.json`, `sv.json`, `uk.json` — remove 15 stale `_one`/`_few`/`_other` plural keys each
+- **`app/src/lib/i18n.js`**: updated when languages graduate (one-time per language, maintainer-triggered)
 - **External dependency**: hosted.weblate.org account and project setup (one-time manual step)
-- **Sequencing**: should be set up after issue #249 (project rename to "spieli") so the Weblate project name matches the final repo name
-- **No changes** to the JSON translation format — the existing nested ICU structure is already compatible with Weblate's `json-i18n` format
+- **No changes** to `locales/en.json`, `locales/de.json`, or the JSON translation format

--- a/openspec/changes/add-weblate-community-translations/specs/i18n-language-support/spec.md
+++ b/openspec/changes/add-weblate-community-translations/specs/i18n-language-support/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Language graduation threshold
 
-A language SHALL only be added to the app's `SUPPORTED` array in `app/src/lib/i18n.js` when it has reached ≥ 80% translation completion in Weblate. Languages below this threshold SHALL remain in `locales/` (available in Weblate for contributor work) but SHALL NOT appear in the running application.
+A language SHALL only be added to the app's `SUPPORTED` array in `app/src/lib/i18n.js` when it has reached ≥ 80% translation completion in Weblate. With the current 580-key source (`locales/en.json`), that is ≥ 464 keys translated. Languages below this threshold SHALL remain in `locales/` (available in Weblate for contributor work) but SHALL NOT appear in the running application.
 
 #### Scenario: Language reaches 80% in Weblate
 

--- a/openspec/changes/add-weblate-community-translations/specs/weblate-integration/spec.md
+++ b/openspec/changes/add-weblate-community-translations/specs/weblate-integration/spec.md
@@ -1,5 +1,15 @@
 ## ADDED Requirements
 
+### Requirement: Partial locale files cleaned of stale plural-suffix keys before Weblate import
+
+Before connecting hosted.weblate.org to the repository, all ten partial locale files (cs, es, fr, it, ja, nl, pl, pt, sv, uk) SHALL have their 15 stale `_one`/`_few`/`_other` plural-suffix keys removed. These keys are from a prior plural format and have no counterpart in `locales/en.json`; Weblate would import them as untranslatable orphans.
+
+#### Scenario: Weblate imports a cleaned partial locale
+
+- **WHEN** Weblate imports `locales/cs.json` after cleanup
+- **THEN** every key in `cs.json` matches a key in `locales/en.json`
+- **AND** no untranslatable orphan keys appear in the Weblate component
+
 ### Requirement: Weblate component discovery file
 
 The repository SHALL contain a `.weblate.yml` file in the root that configures Weblate component auto-discovery with the following settings: file format `json-i18n`, file mask `locales/*.json`, template `locales/en.json`, source language `en`, push branch `weblate-translations`.
@@ -26,15 +36,15 @@ The Weblate component SHALL be configured to push translation commits to a branc
 - **THEN** the updated `locales/*.json` files are bundled into the next Docker build
 - **AND** the changes become visible in the live app after `make docker-build`
 
-### Requirement: Existing locale files preserved as starting points
+### Requirement: Existing locale files preserved as starting points (after cleanup)
 
-All existing locale files in `locales/` (cs, es, fr, it, ja, nl, pl, pt, sv, uk) SHALL be retained in the repository and SHALL be imported by Weblate as partially-translated starting points. They SHALL NOT be deleted or replaced with empty files.
+After the stale-key cleanup (see above), the remaining valid keys in the ten partial locale files SHALL be retained and imported by Weblate. They cover the app-shell strings (search, navigation, completeness labels, info panel) and give translators a non-blank starting point.
 
 #### Scenario: Community translator opens an existing language
 
 - **WHEN** a translator opens e.g. the French component in Weblate
-- **THEN** they see partially pre-filled translations (from the existing auto-generated `fr.json`)
-- **AND** they can review, correct, and complete the strings rather than starting from blank
+- **THEN** they see ~99 pre-filled translations covering core UI strings
+- **AND** they can review, correct, and complete the remaining strings rather than starting from blank
 
 ### Requirement: ICU plural forms presented correctly in Weblate UI
 

--- a/openspec/changes/add-weblate-community-translations/tasks.md
+++ b/openspec/changes/add-weblate-community-translations/tasks.md
@@ -1,29 +1,36 @@
-## 1. Prerequisites
+## 1. Locale Cleanup (repo-side, before Weblate connects)
 
-- [ ] 1.1 Confirm issue #249 (project rename to "spieli") is merged before proceeding — Weblate project name must match final repo name
-- [ ] 1.2 Register on hosted.weblate.org and create project named "spieli" (libre OSS plan)
-- [ ] 1.3 Connect the GitHub repo to Weblate via deploy key and webhook (Weblate guided setup)
+- [ ] 1.1 Strip the 15 stale `_one`/`_few`/`_other` plural-suffix keys from each of the ten partial locale files (cs, es, fr, it, ja, nl, pl, pt, sv, uk) — these predate the ICU-inline plural format and have no counterpart in `en.json`
+- [ ] 1.2 Verify no partial locale file contains keys absent from `en.json` (run a diff script: `python3 -c "..."` comparing leaves of each locale against en.json)
+- [ ] 1.3 Commit cleanup as `chore(i18n): remove stale plural-suffix keys from partial locales`
 
-## 2. Repository Config
+## 2. Weblate Account & Project Setup (manual, external)
 
-- [ ] 2.1 Add `.weblate.yml` to repo root: file format `json-i18n`, file mask `locales/*.json`, template `locales/en.json`, source language `en`, push branch `weblate-translations`
-- [ ] 2.2 Verify Weblate detects the component automatically from `.weblate.yml` after connecting (check Weblate component list)
-- [ ] 2.3 Confirm Weblate imports all existing `locales/*.json` files including the partial translations (cs, es, fr, it, ja, nl, pl, pt, sv, uk)
+- [ ] 2.1 Register on hosted.weblate.org — create project named "spieli" (libre OSS plan, free)
+- [ ] 2.2 Connect the GitHub repo to Weblate via deploy key and webhook (Weblate guided setup in project settings)
+- [ ] 2.3 Set the Weblate project description to include the graduation threshold: "Languages are enabled in the app once they reach ≥ 80% completion"
 
-## 3. Weblate Component Configuration
+## 3. Repository Config
 
-- [ ] 3.1 Set push branch to `weblate-translations` in Weblate component settings
-- [ ] 3.2 Enable "Squash commits" in Weblate to keep PR history clean
-- [ ] 3.3 Verify ICU plural strings (e.g. `equipment.deviceCount`) appear as separate plural-form fields in the Weblate editor, not as a single raw string
-- [ ] 3.4 Add graduation threshold to Weblate project description: "Languages are enabled in the app once they reach ≥ 80% completion"
+- [ ] 3.1 Add `.weblate.yml` to repo root with: file format `json-i18n`, file mask `locales/*.json`, template `locales/en.json`, source language `en`, push branch `weblate-translations`
+- [ ] 3.2 Verify Weblate detects the component automatically from `.weblate.yml` after connecting (check Weblate component list — should appear without manual path configuration)
+- [ ] 3.3 Confirm Weblate imports all twelve locale files including the cleaned-up partial translations
 
-## 4. PR Workflow Verification
+## 4. Weblate Component Configuration
 
-- [ ] 4.1 Make a test translation change in Weblate and confirm it pushes to `weblate-translations` branch (not `main`)
-- [ ] 4.2 Confirm a PR from `weblate-translations` → `main` can be opened and merged following the normal review workflow
-- [ ] 4.3 After merging a test PR, confirm the updated locale file is present in `main` and `make docker-build` picks it up
+- [ ] 4.1 Set push branch to `weblate-translations` in Weblate component settings (if not already set from `.weblate.yml`)
+- [ ] 4.2 Enable "Squash commits" in Weblate settings to keep PR history clean
+- [ ] 4.3 Verify ICU plural strings (e.g. `equipment.deviceCount`) appear as separate plural-form fields in the Weblate editor, not as a single raw ICU string
+- [ ] 4.4 Enable machine translation suggestions (LibreTranslate or DeepL if available on OSS tier) to help bootstrap the equipment vocabulary sections
 
-## 5. Developer Workflow Documentation
+## 5. PR Workflow Verification
 
-- [ ] 5.1 Add a note to the contributing guide (or docs) explaining: new strings go to `en.json` first, then `de.json` in the same commit
-- [ ] 5.2 Document language graduation process: when a language hits 80% in Weblate, open a PR adding it to `SUPPORTED` in `i18n.js` with a `register()` call
+- [ ] 5.1 Make a test translation change in Weblate and confirm it pushes to `weblate-translations` branch (not `main`)
+- [ ] 5.2 Confirm a PR from `weblate-translations` → `main` can be opened and merged following the normal review workflow
+- [ ] 5.3 After merging the test PR, confirm the updated locale file is present in `main` and `make docker-build` picks it up correctly
+
+## 6. Developer Workflow Documentation
+
+- [ ] 6.1 Add a note to `CLAUDE.md` (or a `docs/contributing.md`): new strings go to `en.json` first, then `de.json` in the same commit — never `de.json` only
+- [ ] 6.2 Document language graduation process: when a language hits ≥ 80% in Weblate, open a PR adding it to `SUPPORTED` in `app/src/lib/i18n.js` with a `register()` call targeting `locales/<lang>.json`
+- [ ] 6.3 Close legacy sub-issues #264–#268 (superseded by this epic #348)


### PR DESCRIPTION
## Summary

Refreshes the `add-weblate-community-translations` OpenSpec change to reflect the current state of the codebase and supersedes the old epic #248 (and sub-issues #264–#268).

**What changed since the original design was written:**
- Both prerequisites are now closed: #249 (project rename) and #157 (svelte-i18n re-integration)
- `locales/en.json` has grown from ~320 to 580 keys — the partial locale files are now at 15–19% coverage (not the ~33% originally assumed)
- The partial locale files contain 15 stale `_one`/`_few`/`_other` plural-suffix keys per language that predate the current ICU-inline format; Weblate would import them as untranslatable orphans
- The 80% graduation threshold now means ≥ 464 keys (not ~256)

**Changes per artifact:**
- `proposal.md` — prerequisites removed, locale cleanup added, community-attention framing
- `design.md` — stale-key cleanup as named decision, 80% threshold reframed, machine-translation suggestions added
- `tasks.md` — new §1 "Locale Cleanup" as first step; old sub-issue refs updated to #348
- `specs/weblate-integration/spec.md` — new requirement for pre-import cleanup
- `specs/i18n-language-support/spec.md` — 80% threshold quantified (≥ 464 of 580)

## Test plan

- [ ] All five OpenSpec artifacts render correctly in the repo
- [ ] `openspec status --change add-weblate-community-translations` shows all artifacts complete
- [ ] Old epic #248 and sub-issues #264–#268 closed by maintainer after merge

Closes part of #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)