### PR TITLE
chore(i18n): add .weblate.yml Weblate component config reference (#354)

### DIFF
--- a/.weblate.yml
+++ b/.weblate.yml
@@ -1,0 +1,27 @@
+# Weblate component configuration reference.
+#
+# This file is NOT automatically read by Weblate. Use it as a checklist
+# when manually configuring the component on hosted.weblate.org (#356).
+# Field names and values map directly to the Weblate REST API schema:
+# https://docs.weblate.org/en/latest/api.html#post--api-components-
+#
+# NOTE: The design doc originally specified file_format: json-i18n — that
+# identifier does not exist in Weblate. The correct format for nested JSON
+# files is json-nested. ICU plural strings (e.g. equipment.deviceCount) are
+# treated as opaque string values; translators write the full ICU expression
+# for their language's plural forms, which Weblate's string checks validate.
+
+component:
+  name: spieli
+  slug: spieli
+  file_format: json-nested
+  filemask: locales/*.json
+  template: locales/en.json
+  source_language: en
+  push_branch: weblate-translations
+  push_on_commit: true
+  squash_commits: true
+  commit_message: "chore(i18n): update translations from Weblate"
+  add_message: "chore(i18n): add {{ language_name }} translation from Weblate"
+  delete_message: "chore(i18n): remove {{ language_name }} translation from Weblate"
+  new_lang: add


### PR DESCRIPTION
## Summary

Adds `.weblate.yml` to the repo root as a reference document for configuring the Weblate component on hosted.weblate.org (part of #348, prerequisite for #356).

## Important corrections vs. the original design spec

After verifying against the [Weblate API docs](https://docs.weblate.org/en/latest/api.html#post--api-components-) and [format reference](https://docs.weblate.org/en/latest/formats/json.html):

| Spec said | Reality |
|---|---|
| `file_format: json-i18n` | **`json-i18n` does not exist** in Weblate. Correct identifier is `json-nested` |
| File auto-read by Weblate | **No such mechanism exists.** Weblate has no YAML component discovery file — configuration is done manually in the UI or via the API |

The file is therefore a checklist/reference for #356 (manual Weblate setup), not an automatically consumed config.

## ICU plurals in json-nested

`json-nested` treats all string values as opaque. ICU plural strings like `{count, plural, one {# Spielgerät} other {# Spielgeräte}}` appear as a single field in the Weblate editor — translators write the full ICU expression for their language. Weblate's built-in string consistency checks catch malformed ICU syntax.

This is the correct trade-off: the alternative formats (i18next, formatjs) use different plural conventions incompatible with svelte-i18n's ICU inline format.

## Depends on

- #353 (locale cleanup) — merged or in review

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)