### PR TITLE
docs(i18n): add translation workflow and language graduation guide (#355)

### DIFF
--- a/docs/contributing/translation-guide.md
+++ b/docs/contributing/translation-guide.md
@@ -1,0 +1,57 @@
+# Translating spieli
+
+Thanks for helping translate spieli! This guide explains everything you need to know.
+
+## What is spieli?
+
+spieli is a free, interactive playground map based on OpenStreetMap data.
+Your translation makes it accessible to communities in your language.
+
+## How to translate
+
+1. Create a free account on [hosted.weblate.org](https://hosted.weblate.org)
+2. Open the **spieli** project and pick your language
+3. Click any untranslated string and type your translation
+4. Save — that's it. No GitHub account needed.
+
+## What to translate
+
+Most strings are short UI labels like buttons, tooltips, and status messages:
+
+| English | Example translation (DE) |
+|---|---|
+| `Show my location` | `Meinen Standort anzeigen` |
+| `Filter` | `Filter` |
+| `Reset all` | `Alle zurücksetzen` |
+
+## Plural forms
+
+Some strings contain a count, like:
+
+```
+{count, plural, one {# bench} other {# benches}}
+```
+
+Keep the `{count, plural, ...}` wrapper and translate only the text inside:
+
+```
+{count, plural, one {# Sitzbank} other {# Sitzbänke}}
+```
+
+If your language has more than two plural forms (e.g. Polish, Czech),
+Weblate will show you the correct number of fields automatically.
+
+## Things to keep as-is
+
+- Placeholders like `{regionName}`, `{count}`, `{name}` — do not translate these
+- The `{count, plural, one {...} other {...}}` structure — only translate the text inside the `{}`
+
+## When does my translation go live?
+
+A language appears in the app once it reaches **80% completion**.
+Until then your work is saved and visible to other translators.
+
+## Questions?
+
+Open an issue at [github.com/mfuhrmann/spieli](https://github.com/mfuhrmann/spieli)
+or leave a comment directly in Weblate.

--- a/docs/contributing/translations.md
+++ b/docs/contributing/translations.md
@@ -1,0 +1,54 @@
+# Translate spieli
+
+spieli uses [hosted.weblate.org](https://hosted.weblate.org) for community translations. Translators work through a web UI — no GitHub account or knowledge of JSON is required.
+
+## How translations reach the app
+
+```
+Translator edits strings       Weblate pushes commit         Maintainer merges PR
+on hosted.weblate.org    →     to weblate-translations   →   into main
+  (web UI, no GitHub)           branch on GitHub              → make docker-build
+                                                               → live in app
+```
+
+Weblate batches translation saves and periodically pushes a commit to the `weblate-translations` branch. The maintainer opens a PR from `weblate-translations` → `main`, reviews the JSON diff, and merges. The next `make docker-build` bundles the updated locale files into the app.
+
+Weblate never pushes directly to `main` — every translation update goes through a PR.
+
+## Language graduation
+
+A language becomes visible in the app only when it reaches **≥ 80% completion** (≥ 464 of 580 keys) in Weblate. Below that threshold the locale file exists in the repo and Weblate keeps improving it, but the running app ignores it — users with that browser language fall back to English.
+
+When a language crosses the threshold:
+
+1. Open a PR editing `app/src/lib/i18n.js`:
+    - Add the language code to the `SUPPORTED` array
+    - Add a `register()` call: `register('<lang>', () => import('../../../locales/<lang>.json'));`
+2. Title the PR: `feat(i18n): add <Language> language support`
+3. After merging, run `make docker-build` — users with that browser language now see the app in their language
+
+## Adding new UI strings (developer workflow)
+
+New translatable strings **must** be added to `locales/en.json` first. `locales/de.json` must be updated in the **same commit**. Adding a key only to `de.json` breaks Weblate — it uses `locales/en.json` as the source template and won't surface keys that are absent from it.
+
+Keys follow the existing nested structure. Plural strings use ICU inline format:
+
+```json
+"deviceCount": "{count, plural, one {# piece of equipment} other {# pieces of equipment}}"
+```
+
+When you add a new key, Weblate automatically marks it as needing translation in all registered languages.
+
+## Weblate component settings
+
+The `.weblate.yml` file in the repo root documents the intended component configuration for the manual setup step. Key settings:
+
+| Setting | Value |
+|---|---|
+| File format | `json-nested` |
+| File mask | `locales/*.json` |
+| Source template | `locales/en.json` |
+| Source language | `en` |
+| Push branch | `weblate-translations` |
+
+ICU plural strings appear as a single field in the Weblate editor. Translators write the full ICU expression for their language — Weblate's built-in checks catch syntax errors.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Contributing:
       - Add a Playground Device: contributing/add-device.md
       - Add a Sport Pitch Type: contributing/add-sport-type.md
+      - Translate spieli: contributing/translations.md
   - Reference:
       - Architecture: reference/architecture.md
       - Tech Stack: reference/tech-stack.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Add a Playground Device: contributing/add-device.md
       - Add a Sport Pitch Type: contributing/add-sport-type.md
       - Translate spieli: contributing/translations.md
+      - Translation Guide: contributing/translation-guide.md
   - Reference:
       - Architecture: reference/architecture.md
       - Tech Stack: reference/tech-stack.md


### PR DESCRIPTION
## Summary

Adds `docs/contributing/translations.md` covering the three things contributors and maintainers need to know about i18n in spieli. Registered in the mkdocs nav under Contributing.

## What's documented

**For community translators** — the end-to-end flow: translate on Weblate → Weblate pushes to `weblate-translations` → maintainer merges PR → `make docker-build` → live in app. No GitHub account needed.

**For maintainers** — the language graduation process: once a language hits ≥ 80% (≥ 464/580 keys) in Weblate, open a PR adding it to `SUPPORTED` in `i18n.js` with a `register()` call.

**For developers** — the new-string rule: add to `locales/en.json` first, `locales/de.json` in the same commit. Never `de.json` only — Weblate uses EN as its source template.

Also includes a short Weblate component settings reference table (linking to `.weblate.yml` for details) and a note on ICU plural handling in the editor.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)