### PR TITLE
docs: rework README, move local-dev and external-services to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,6 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 
 > **Origin:** This project is a further development of the original [Berliner Spielplatzkarte](https://github.com/SupaplexOSM/spielplatzkarte) by Alex Seidel.
 
-## Matrix Contact
-
-Come and let's play:
-https://matrix.to/#/#spieli:matrix.org
-
----
-
-## Documentation
-
-**[mfuhrmann.github.io/spieli](https://mfuhrmann.github.io/spieli/)**
-
-Includes deployment guides, configuration reference, contributing how-tos, and architecture docs.
-
----
-
-## Tech stack
-
-Svelte 5 · OpenLayers · PostgreSQL/PostGIS · PostgREST · nginx · Docker
-
-Full details: [Tech stack reference](https://mfuhrmann.github.io/spieli/reference/tech-stack/)
-
 ---
 
 ## Deploy
@@ -61,11 +40,34 @@ For deploying from source, see [Manual Deploy](https://mfuhrmann.github.io/spiel
 
 ---
 
+## Documentation
+
+**[mfuhrmann.github.io/spieli](https://mfuhrmann.github.io/spieli/)**
+
+Includes deployment guides, configuration reference, contributing how-tos, and architecture docs.
+
+---
+
+## Tech stack
+
+Svelte 5 · OpenLayers · PostgreSQL/PostGIS · PostgREST · nginx · Docker
+
+Full details: [Tech stack reference](https://mfuhrmann.github.io/spieli/reference/tech-stack/)
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow (branch → commit → PR), or the [docs](https://mfuhrmann.github.io/spieli/) for how-to guides (e.g. [adding a playground device](https://mfuhrmann.github.io/spieli/contributing/add-device/)).
 
 New to OSM concepts like relation IDs or PBF files? See the [glossary](https://mfuhrmann.github.io/spieli/reference/glossary/).
+
+---
+
+## Matrix Contact
+
+Come and let's play:
+https://matrix.to/#/#spieli:matrix.org
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 *Pronunciation:* **[ˈʃpiːli]**
 
 <u>Meaning/Definition:</u>
-A German word, that usually marks an area for children, often equipped with various facilities or devices for playing [Usage: children’s language]
+A German word, that usually marks an area for children, often equipped with various facilities or devices for playing [Usage: children's language]
 
 <u>Article/Gender:</u>
-In German, the grammatical gender is masculine: „der Spieli“.
-In English, it is used as a neuter noun: “the spieli”.
+In German, the grammatical gender is masculine: „der Spieli".
+In English, it is used as a neuter noun: "the spieli".
 
 ---
 
@@ -26,26 +26,13 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 Come and let's play:
 https://matrix.to/#/#spieli:matrix.org
 
+---
 
-## Modes
+## Documentation
 
-**Standalone** — a single-region map backed by its own database.
+**[mfuhrmann.github.io/spieli](https://mfuhrmann.github.io/spieli/)**
 
-```
-Browser ──► nginx ──► PostgREST ──► PostgreSQL/PostGIS
-             │
-             └── serves the app, proxies /api/ to PostgREST
-```
-
-**Hub** — aggregates multiple standalone instances onto one shared map. No own database; the Hub fetches data from registered backends over HTTP:
-
-```
-                   ┌─ backend A ──► PostgREST ──► PostgreSQL (region A) ─┐
-Browser ──► nginx ─┤                                                     │
-  (Hub UI)         └─ backend B ──► PostgREST ──► PostgreSQL (region B) ─┘
-```
-
-Set `APP_MODE=standalone` (default) or `APP_MODE=hub` in `.env`.
+Includes deployment guides, configuration reference, contributing how-tos, and architecture docs.
 
 ---
 
@@ -82,98 +69,11 @@ For deploying from source, see [Manual Deploy](https://mfuhrmann.github.io/spiel
 
 ---
 
-## Configuration
-
-Key variables (full reference at [docs/ops/configuration](https://mfuhrmann.github.io/spieli/ops/configuration/)):
-
-| Variable | Default | Description |
-|---|---|---|
-| `APP_MODE` | `standalone` | `standalone` for a single region; `hub` to aggregate multiple backends |
-| `OSM_RELATION_ID` | `454863` | OSM relation ID for backend 1 (standalone + hub) |
-| `OSM_RELATION_ID2` | `454881` | OSM relation ID for backend 2 (hub dev testing only) |
-| `PBF_URL` | Hessen extract | Geofabrik `.osm.pbf` download URL |
-| `REGISTRY_URL` | `/registry.json` | URL of the registry JSON listing backends (hub mode only) |
-| `APP_PORT` | `8080` | Host port the app is exposed on |
-| `MAP_ZOOM` | `12` | Initial map zoom level |
-| `POSTGRES_PASSWORD` | `change-me` | Database password — **change in production** |
-
----
-
-## Local development
-
-**Requirements:** Node.js v18+, Docker with Docker Compose
-
-### Standalone mode
-
-```bash
-make install      # install Node dependencies (once)
-make up           # start db + PostgREST + nginx
-make import       # download Hessen PBF and import Fulda Stadt (454863) — ~300 MB, run once
-make dev          # Vite dev server with hot-reload at http://localhost:5173
-```
-
-For quick testing without a full import, load the bundled fixture (4 Fulda playgrounds):
-
-```bash
-make seed-load
-```
-
-### Hub mode
-
-The stack includes a second backend (`db2` / `postgrest2`) pre-wired at `/api2/`. Both backends use the Hessen PBF — the importer caches it by filename, so the second import reuses the download.
-
-```bash
-# In .env: set APP_MODE=hub (and optionally OSM_RELATION_ID / OSM_RELATION_ID2)
-make docker-build
-make up
-make import       # imports Fulda Stadt (454863) into db  — downloads Hessen PBF (~300 MB)
-make import2      # imports Neuhof (454881) into db2 — reuses cached PBF
-```
-
-`registry.json` lists both backends (`/api` = Fulda, `/api2` = Neuhof). Open `http://localhost:8080` to see the Hub with two real regions.
-
-Run `make help` to list all available targets.
-
----
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow (branch → commit → PR), or the [docs](https://mfuhrmann.github.io/spieli/) for how-to guides (e.g. [adding a playground device](https://mfuhrmann.github.io/spieli/contributing/add-device/)).
 
 New to OSM concepts like relation IDs or PBF files? See the [glossary](https://mfuhrmann.github.io/spieli/reference/glossary/).
-
----
-
-## Federation (Hub mode)
-
-Multiple regional instances can be aggregated into a single Hub map by deploying with `APP_MODE=hub` and pointing `REGISTRY_URL` at a JSON file that lists the backends:
-
-```json
-{
-  "instances": [
-    { "slug": "fulda",      "url": "https://fulda.example.com",      "name": "Fulda" },
-    { "slug": "vogelsberg", "url": "https://vogelsberg.example.com", "name": "Vogelsberg" }
-  ]
-}
-```
-
-The Hub fetches playground data from every listed backend and renders them on a shared map. Each regional instance exposes `/api/rpc/get_playgrounds` and `/api/rpc/get_meta` for cross-origin federation. See [docs/reference/federation](https://mfuhrmann.github.io/spieli/reference/federation/).
-
----
-
-## External services
-
-| Service | Purpose |
-|---|---|
-| [Geofabrik](https://download.geofabrik.de) | Source of OSM PBF extracts for import |
-| [Nominatim](https://nominatim.openstreetmap.org) | Location search and region bounding box |
-| [CartoDB Voyager](https://carto.com/basemaps) | Background map tiles |
-| [Panoramax](https://panoramax.xyz) | Street-level photos |
-| [Mangrove.reviews](https://mangrove.reviews) | Pseudonymous community reviews |
-| [MapComplete](https://mapcomplete.org) | Contribute photos and equipment |
-| [Wikidata](https://wikidata.org) | Operator entity linking |
-
-All data comes from OpenStreetMap or the free services listed above. No proprietary data, no user accounts, no tracking.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,9 @@ Includes deployment guides, configuration reference, contributing how-tos, and a
 
 ## Tech stack
 
-| Component | Technology |
-|---|---|
-| Map | [OpenLayers](https://openlayers.org/) |
-| UI / icons | [Bootstrap 5](https://getbootstrap.com/) + [Tailwind CSS 4](https://tailwindcss.com/) + [lucide-svelte](https://lucide.dev/) |
-| Language | [Svelte 5](https://svelte.dev/) |
-| Build tool | [Vite 6](https://vitejs.dev/) |
-| Database | [PostgreSQL 16](https://www.postgresql.org/) + [PostGIS 3.4](https://postgis.net/) |
-| OSM import | [osm2pgsql](https://osm2pgsql.org/) + [osmium-tool](https://osmcode.org/osmium-tool/) |
-| API layer | [PostgREST v12](https://postgrest.org/) |
-| Web server | [nginx](https://nginx.org/) |
-| Container runtime | Docker / Docker Compose |
+Svelte 5 · OpenLayers · PostgreSQL/PostGIS · PostgREST · nginx · Docker
+
+Full details: [Tech stack reference](https://mfuhrmann.github.io/spieli/reference/tech-stack/)
 
 ---
 

--- a/docs/contributing/local-dev.md
+++ b/docs/contributing/local-dev.md
@@ -1,0 +1,43 @@
+# Local Development
+
+**Requirements:** Node.js v18+, Docker with the Compose plugin
+
+## Setup
+
+```bash
+make install      # install Node dependencies (once)
+make up           # start db + PostgREST + nginx
+make import       # download Hessen PBF and import Fulda Stadt (454863) — ~300 MB, run once
+make dev          # Vite dev server with hot-reload at http://localhost:5173
+```
+
+For quick testing without a full import, load the bundled fixture (4 Fulda playgrounds):
+
+```bash
+make seed-load
+```
+
+Run `make help` to list all available targets.
+
+## Hub mode
+
+The stack includes a second backend (`db2` / `postgrest2`) pre-wired at `/api2/`. Both backends use the Hessen PBF — the importer caches it by filename, so the second import reuses the download.
+
+```bash
+# In .env: set APP_MODE=hub (and optionally OSM_RELATION_ID / OSM_RELATION_ID2)
+make docker-build
+make up
+make import       # imports Fulda Stadt (454863) into db  — downloads Hessen PBF (~300 MB)
+make import2      # imports Neuhof (454881) into db2 — reuses cached PBF
+```
+
+`registry.json` lists both backends (`/api` = Fulda, `/api2` = Neuhof). Open `http://localhost:8080` to see the Hub with two real regions.
+
+## Frontend-only (no database)
+
+When `apiBaseUrl` is empty in `app/public/config.js`, the frontend falls back to the Overpass API — no database required for basic frontend work:
+
+```bash
+make install
+make dev
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A free, interactive web map for exploring playgrounds based on [OpenStreetMap](https://openstreetmap.org) data — configurable for any region.
 
-> **Origin:** This project is a further development of the original [Berliner spieli](https://github.com/SupaplexOSM/spieli) by Alex Seidel.
+> **Origin:** This project is a further development of the original [Berliner Spielplatzkarte](https://github.com/SupaplexOSM/spielplatzkarte) by Alex Seidel.
 
 ---
 
@@ -12,26 +12,55 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
                   ┌─────────────────────────────────────────────────────┐
                   │                   Production                        │
                   │                                                     │
-  Browser ──────► nginx ──────► PostgREST ──────► PostgreSQL/PostGIS   │
-  (your phone      (serves        (turns SQL          (holds all the    │
-   or laptop)      the app,       functions into      OSM playground    │
-                   proxies API    HTTP endpoints)     data)             │
-                   requests)                                            │
+  Browser ──────► | nginx ──────► PostgREST ──────► PostgreSQL/PostGIS  │
+  (your phone     | (serves        (turns SQL          (holds all the   │
+   or laptop)     | the app,       functions into      OSM playground   │
+                  | proxies API    HTTP endpoints)     data)            │
+                  | requests)                                           │
                   └─────────────────────────────────────────────────────┘
 ```
 
 Your browser loads the app from nginx. Playground data requests go to `/api/`, which nginx forwards to PostgREST. PostgREST runs a SQL function in PostgreSQL and returns JSON — no custom server code needed. The database is pre-loaded with OpenStreetMap data by the osm2pgsql importer.
 
+Multiple regional instances can be aggregated into a single **Hub** map — see [Architecture](reference/architecture.md) and [Federation](reference/federation.md) for details.
+
 ---
 
-## Where to go next
+## Getting started
 
 | I want to… | Go to… |
 |---|---|
-| Deploy for my region | [Quick Start](getting-started/quick-start.md) |
+| Deploy spieli for my region | [Quick Start](getting-started/quick-start.md) |
 | Deploy from source | [Manual Deploy](ops/manual-deploy.md) |
+| Connect my backend to an existing Hub | [Quick Start → Joining an existing Hub](getting-started/quick-start.md#joining-an-existing-hub) |
+
+## Operations
+
+| I want to… | Go to… |
+|---|---|
 | Configure environment variables | [Configuration](ops/configuration.md) |
+| Stand up a Hub + multiple data-nodes | [Federated Deployment](ops/federated-deployment.md) |
+| Monitor a running instance | [Monitoring](ops/monitoring.md) |
 | Fix a problem | [Troubleshooting](ops/troubleshooting.md) |
+
+## Contributing
+
+| I want to… | Go to… |
+|---|---|
 | Add a new playground device type | [Add a Device](contributing/add-device.md) |
-| Understand the tech stack | [Tech Stack](reference/tech-stack.md) |
-| Learn OSM terminology | [Glossary](reference/glossary.md) |
+| Add a new sport type | [Add a Sport Type](contributing/add-sport-type.md) |
+| Translate the app (Weblate) | [Translator Instructions](contributing/translation-guide.md) |
+| Understand the translation workflow | [Translation Workflow](contributing/translations.md) |
+| Set up a local dev environment | [Local Development](contributing/local-dev.md) |
+
+## Reference
+
+| Topic | Go to… |
+|---|---|
+| Tech stack | [Tech Stack](reference/tech-stack.md) |
+| System architecture & deployment modes | [Architecture](reference/architecture.md) |
+| PostgREST API endpoints | [API Reference](reference/api.md) |
+| Hub federation protocol | [Federation](reference/federation.md) |
+| `registry.json` schema | [Registry JSON](reference/registry-json.md) |
+| External services used at runtime | [External Services](reference/external-services.md) |
+| OSM and project terminology | [Glossary](reference/glossary.md) |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -8,11 +8,11 @@ One region, one database. `APP_MODE=standalone` (the default).
                   ┌─────────────────────────────────────────────────────┐
                   │                   Production                        │
                   │                                                     │
-  Browser ──────► nginx ──────► PostgREST ──────► PostgreSQL/PostGIS   │
-  (your phone      (serves        (turns SQL          (holds all the    │
-   or laptop)      the app,       functions into      OSM playground    │
-                   proxies API    HTTP endpoints)     data)             │
-                   requests)                                            │
+  Browser ──────► | nginx ──────► PostgREST ──────► PostgreSQL/PostGIS  │
+  (your phone     | (serves        (turns SQL          (holds all the   │
+   or laptop)     | the app,       functions into      OSM playground   │
+                  | proxies API    HTTP endpoints)     data)            │
+                  | requests)                                           │
                   └─────────────────────────────────────────────────────┘
 ```
 

--- a/docs/reference/external-services.md
+++ b/docs/reference/external-services.md
@@ -1,0 +1,15 @@
+# External Services
+
+spieli integrates with the following free external services at runtime:
+
+| Service | Purpose |
+|---|---|
+| [Geofabrik](https://download.geofabrik.de) | Source of OSM PBF extracts for import |
+| [Nominatim](https://nominatim.openstreetmap.org) | Location search and region bounding box |
+| [CartoDB Voyager](https://carto.com/basemaps) | Background map tiles |
+| [Panoramax](https://panoramax.xyz) | Street-level photos |
+| [Mangrove.reviews](https://mangrove.reviews) | Pseudonymous community reviews |
+| [MapComplete](https://mapcomplete.org) | Contribute photos and equipment |
+| [Wikidata](https://wikidata.org) | Operator entity linking |
+
+All map data comes from OpenStreetMap or the free services listed above. No proprietary data, no user accounts, no tracking.

--- a/docs/reference/tech-stack.md
+++ b/docs/reference/tech-stack.md
@@ -7,7 +7,7 @@
 | Language | [Svelte 5](https://svelte.dev/) |
 | Build tool | [Vite 6](https://vitejs.dev/) |
 | Database | [PostgreSQL 16](https://www.postgresql.org/) + [PostGIS 3.4](https://postgis.net/) |
-| OSM import | [osm2pgsql](https://osm2pgsql.org/) |
+| OSM import | [osm2pgsql](https://osm2pgsql.org/) + [osmium-tool](https://osmcode.org/osmium-tool/) |
 | API layer | [PostgREST v12](https://postgrest.org/) |
 | Web server | [nginx](https://nginx.org/) |
 | Container runtime | Docker / Docker Compose |


### PR DESCRIPTION
## Summary

- Removes the obsolete configuration variable table — canonical reference is `docs/ops/configuration.md`
- Removes the Federation/Hub mode section — covered in `docs/reference/federation.md`
- Moves Local development → `docs/contributing/local-dev.md`
- Moves External services → `docs/reference/external-services.md`
- Adds a prominent link to the GitHub Pages docs site near the top of the README

## Test plan

- [ ] README renders cleanly on GitHub — no broken sections or dangling references
- [ ] `docs/contributing/local-dev.md` content matches what was in the README
- [ ] `docs/reference/external-services.md` content matches what was in the README
- [ ] All links in the updated README resolve correctly

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)