### PR TITLE
test: add unit tests for completeness, deeplink, filters + E2E for FilterPanel

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "test:unit": "node src/lib/equipmentGrouping.test.js"
+    "test:unit": "node src/lib/equipmentGrouping.test.js && node src/lib/completeness.test.js && node src/lib/deeplink.test.js && node --conditions=node src/stores/filters.test.js"
   },
   "dependencies": {
     "bootstrap": "^5.3.8",

--- a/app/src/lib/completeness.test.js
+++ b/app/src/lib/completeness.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { playgroundCompleteness } from './completeness.js';
+
+// 1. All three signals present → complete
+{
+  const props = { name: 'Playground', panoramax: 'abc123', surface: 'sand' };
+  assert.equal(playgroundCompleteness(props), 'complete');
+}
+
+// 2. panoramax: prefix counts as photo → complete
+{
+  const props = { name: 'Playground', 'panoramax:sequence': 'abc', operator: 'City' };
+  assert.equal(playgroundCompleteness(props), 'complete');
+}
+
+// 3. photo + name, no info → partial
+{
+  const props = { name: 'Park', panoramax: 'abc' };
+  assert.equal(playgroundCompleteness(props), 'partial');
+}
+
+// 4. name + info, no photo → partial
+{
+  assert.equal(playgroundCompleteness({ name: 'Park', surface: 'grass' }), 'partial');
+}
+
+// 5. photo only → partial
+{
+  assert.equal(playgroundCompleteness({ panoramax: 'abc' }), 'partial');
+}
+
+// 6. name only → partial
+{
+  assert.equal(playgroundCompleteness({ name: 'Park' }), 'partial');
+}
+
+// 7. operator counts as info → partial
+{
+  assert.equal(playgroundCompleteness({ operator: 'City Parks' }), 'partial');
+}
+
+// 8. opening_hours counts as info → partial
+{
+  assert.equal(playgroundCompleteness({ opening_hours: 'Mo-Su 08:00-20:00' }), 'partial');
+}
+
+// 9. surface counts as info → partial
+{
+  assert.equal(playgroundCompleteness({ surface: 'sand' }), 'partial');
+}
+
+// 10. non-trivial access counts as info → partial
+{
+  assert.equal(playgroundCompleteness({ access: 'private' }), 'partial');
+  assert.equal(playgroundCompleteness({ access: 'no' }), 'partial');
+  assert.equal(playgroundCompleteness({ access: 'permissive' }), 'partial');
+}
+
+// 11. access: 'yes' does NOT count as info → missing
+{
+  assert.equal(playgroundCompleteness({ access: 'yes' }), 'missing');
+}
+
+// 12. none present → missing
+{
+  assert.equal(playgroundCompleteness({}), 'missing');
+  assert.equal(playgroundCompleteness({ nearest_highway: 'residential' }), 'missing');
+}
+
+console.log('All completeness tests passed.');

--- a/app/src/lib/deeplink.test.js
+++ b/app/src/lib/deeplink.test.js
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { parseHash, writeHash, isValidSlug } from './deeplink.js';
+
+// --- parseHash ---
+
+// 1. Falsy / empty input → null
+{
+  assert.equal(parseHash(null), null);
+  assert.equal(parseHash(''), null);
+  assert.equal(parseHash('#'), null);
+}
+
+// 2. Legacy form #W<id>
+{
+  const r = parseHash('#W123');
+  assert.deepEqual(r, { slug: null, osmId: 123 });
+}
+
+// 3. Slug form #<slug>/W<id>
+{
+  const r = parseHash('#fulda/W456');
+  assert.deepEqual(r, { slug: 'fulda', osmId: 456 });
+}
+
+// 4. Slug with digits and hyphens
+{
+  const r = parseHash('#my-city-01/W789');
+  assert.deepEqual(r, { slug: 'my-city-01', osmId: 789 });
+}
+
+// 5. Input without leading # is accepted (function prepends it)
+{
+  const r = parseHash('W123');
+  assert.deepEqual(r, { slug: null, osmId: 123 });
+}
+
+// 6. Uppercase slug is not a valid slug → null
+{
+  assert.equal(parseHash('#Berlin/W100'), null);
+}
+
+// 7. Hash without W prefix or osm_id → null
+{
+  assert.equal(parseHash('#just-text'), null);
+  assert.equal(parseHash('#123'), null);
+  assert.equal(parseHash('#/W123'), null);
+}
+
+// --- writeHash ---
+
+// 8. Null/undefined slug → legacy form
+{
+  assert.equal(writeHash({ slug: null, osmId: 123 }), '#W123');
+  assert.equal(writeHash({ slug: undefined, osmId: 99 }), '#W99');
+}
+
+// 9. Valid slug → prefixed form
+{
+  assert.equal(writeHash({ slug: 'fulda', osmId: 456 }), '#fulda/W456');
+  assert.equal(writeHash({ slug: 'my-city-01', osmId: 1 }), '#my-city-01/W1');
+}
+
+// 10. Invalid slug (uppercase) → legacy form
+{
+  assert.equal(writeHash({ slug: 'Fulda', osmId: 1 }), '#W1');
+}
+
+// 11. Empty string slug → legacy form
+{
+  assert.equal(writeHash({ slug: '', osmId: 5 }), '#W5');
+}
+
+// 12. parseHash(writeHash(x)) round-trips correctly
+{
+  const legacy = { slug: null, osmId: 42 };
+  assert.deepEqual(parseHash(writeHash(legacy)), legacy);
+
+  const withSlug = { slug: 'fulda', osmId: 99 };
+  assert.deepEqual(parseHash(writeHash(withSlug)), withSlug);
+}
+
+// --- isValidSlug ---
+
+// 13. Valid slugs
+{
+  assert.equal(isValidSlug('fulda'), true);
+  assert.equal(isValidSlug('my-city'), true);
+  assert.equal(isValidSlug('abc123'), true);
+  assert.equal(isValidSlug('a'), true);
+}
+
+// 14. Invalid slugs
+{
+  assert.equal(isValidSlug(''), false);
+  assert.equal(isValidSlug('Berlin'), false);
+  assert.equal(isValidSlug('my_city'), false);
+  assert.equal(isValidSlug(null), false);
+  assert.equal(isValidSlug(42), false);
+  assert.equal(isValidSlug('has space'), false);
+}
+
+console.log('All deeplink tests passed.');

--- a/app/src/stores/filters.test.js
+++ b/app/src/stores/filters.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { matchesFilters, hasActiveFilters } from './filters.js';
+
+const noFilters = {
+  private: false, water: false, baby: false, toddler: false,
+  wheelchair: false, bench: false, picnic: false, shelter: false,
+  tableTennis: false, soccer: false, basketball: false, standalonePitches: false,
+};
+
+// --- matchesFilters ---
+
+// 1. No active filters → always passes
+{
+  assert.equal(matchesFilters({}, noFilters), true);
+  assert.equal(matchesFilters({ access: 'private', is_water: false }, noFilters), true);
+}
+
+// 2. private filter: access=private or access=no → excluded; anything else → included
+{
+  const f = { ...noFilters, private: true };
+  assert.equal(matchesFilters({ access: 'private' }, f), false);
+  assert.equal(matchesFilters({ access: 'no' }, f), false);
+  assert.equal(matchesFilters({ access: 'yes' }, f), true);
+  assert.equal(matchesFilters({}, f), true);
+}
+
+// 3. water filter
+{
+  const f = { ...noFilters, water: true };
+  assert.equal(matchesFilters({ is_water: true }, f), true);
+  assert.equal(matchesFilters({ is_water: false }, f), false);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 4. baby filter
+{
+  const f = { ...noFilters, baby: true };
+  assert.equal(matchesFilters({ for_baby: true }, f), true);
+  assert.equal(matchesFilters({ for_baby: false }, f), false);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 5. toddler filter
+{
+  const f = { ...noFilters, toddler: true };
+  assert.equal(matchesFilters({ for_toddler: true }, f), true);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 6. wheelchair filter
+{
+  const f = { ...noFilters, wheelchair: true };
+  assert.equal(matchesFilters({ for_wheelchair: true }, f), true);
+  assert.equal(matchesFilters({ for_wheelchair: false }, f), false);
+}
+
+// 7. bench filter — bench_count must be > 0
+{
+  const f = { ...noFilters, bench: true };
+  assert.equal(matchesFilters({ bench_count: 2 }, f), true);
+  assert.equal(matchesFilters({ bench_count: 0 }, f), false);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 8. picnic filter
+{
+  const f = { ...noFilters, picnic: true };
+  assert.equal(matchesFilters({ picnic_count: 1 }, f), true);
+  assert.equal(matchesFilters({ picnic_count: 0 }, f), false);
+}
+
+// 9. shelter filter
+{
+  const f = { ...noFilters, shelter: true };
+  assert.equal(matchesFilters({ shelter_count: 1 }, f), true);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 10. tableTennis filter
+{
+  const f = { ...noFilters, tableTennis: true };
+  assert.equal(matchesFilters({ table_tennis_count: 1 }, f), true);
+  assert.equal(matchesFilters({ table_tennis_count: 0 }, f), false);
+}
+
+// 11. soccer filter
+{
+  const f = { ...noFilters, soccer: true };
+  assert.equal(matchesFilters({ has_soccer: true }, f), true);
+  assert.equal(matchesFilters({ has_soccer: false }, f), false);
+}
+
+// 12. basketball filter
+{
+  const f = { ...noFilters, basketball: true };
+  assert.equal(matchesFilters({ has_basketball: true }, f), true);
+  assert.equal(matchesFilters({}, f), false);
+}
+
+// 13. Multiple active filters — ALL must match
+{
+  const f = { ...noFilters, water: true, bench: true };
+  assert.equal(matchesFilters({ is_water: true, bench_count: 1 }, f), true);
+  assert.equal(matchesFilters({ is_water: true, bench_count: 0 }, f), false);
+  assert.equal(matchesFilters({ is_water: false, bench_count: 1 }, f), false);
+}
+
+// --- hasActiveFilters ---
+
+// 14. All false → false
+{
+  assert.equal(hasActiveFilters(noFilters), false);
+}
+
+// 15. Any single true → true
+{
+  assert.equal(hasActiveFilters({ ...noFilters, water: true }), true);
+  assert.equal(hasActiveFilters({ ...noFilters, standalonePitches: true }), true);
+  assert.equal(hasActiveFilters({ ...noFilters, basketball: true }), true);
+}
+
+console.log('All filter tests passed.');

--- a/tests/filter-panel.spec.js
+++ b/tests/filter-panel.spec.js
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { injectApiConfig, stubApiRoutes } from './helpers.js';
+
+test.describe('FilterPanel', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectApiConfig(page);
+    await stubApiRoutes(page);
+    await page.goto('/');
+    await expect(page.locator('canvas')).toBeVisible();
+  });
+
+  test('filter button is visible on the map', async ({ page }) => {
+    await expect(page.locator('.filter-container button')).toBeVisible();
+  });
+
+  test('clicking filter button opens the dropdown', async ({ page }) => {
+    await expect(page.locator('.filter-dropdown')).not.toBeVisible();
+    await page.locator('.filter-container button').click();
+    await expect(page.locator('.filter-dropdown')).toBeVisible();
+  });
+
+  test('clicking filter button again closes the dropdown', async ({ page }) => {
+    const btn = page.locator('.filter-container button');
+    await btn.click();
+    await expect(page.locator('.filter-dropdown')).toBeVisible();
+    await btn.click();
+    await expect(page.locator('.filter-dropdown')).not.toBeVisible();
+  });
+
+  test('no badge shown before any filter is active', async ({ page }) => {
+    await expect(page.locator('.filter-container .badge')).not.toBeVisible();
+  });
+
+  test('toggling a filter shows badge with count 1', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    await page.locator('.filter-list .filter-item input[type="checkbox"]').first().click();
+    await expect(page.locator('.filter-container .badge')).toBeVisible();
+    await expect(page.locator('.filter-container .badge')).toHaveText('1');
+  });
+
+  test('toggling two filters shows badge with count 2', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    const checkboxes = page.locator('.filter-list .filter-item input[type="checkbox"]');
+    await checkboxes.nth(0).click();
+    await checkboxes.nth(1).click();
+    await expect(page.locator('.filter-container .badge')).toHaveText('2');
+  });
+
+  test('clear-all button appears only when a filter is active', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    await expect(page.locator('.clear-btn')).not.toBeVisible();
+    await page.locator('.filter-list .filter-item input[type="checkbox"]').first().click();
+    await expect(page.locator('.clear-btn')).toBeVisible();
+  });
+
+  test('clear-all removes all active filters and hides the badge', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    const checkboxes = page.locator('.filter-list .filter-item input[type="checkbox"]');
+    await checkboxes.nth(0).click();
+    await checkboxes.nth(1).click();
+    await page.locator('.clear-btn').click();
+    await expect(page.locator('.filter-container .badge')).not.toBeVisible();
+    await expect(page.locator('.clear-btn')).not.toBeVisible();
+  });
+
+  test('untoggling a filter decrements the badge count', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    const checkboxes = page.locator('.filter-list .filter-item input[type="checkbox"]');
+    await checkboxes.nth(0).click();
+    await checkboxes.nth(1).click();
+    await expect(page.locator('.filter-container .badge')).toHaveText('2');
+    await checkboxes.nth(0).click();
+    await expect(page.locator('.filter-container .badge')).toHaveText('1');
+  });
+
+  test('clicking outside the dropdown closes it', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    await expect(page.locator('.filter-dropdown')).toBeVisible();
+    await page.mouse.click(10, 10);
+    await expect(page.locator('.filter-dropdown')).not.toBeVisible();
+  });
+
+  test('layers section contains the standalone pitches toggle', async ({ page }) => {
+    await page.locator('.filter-container button').click();
+    await expect(page.locator('.layer-section')).toBeVisible();
+    const pitchToggle = page.locator('.layer-section input[type="checkbox"]');
+    await expect(pitchToggle).toBeVisible();
+    await expect(pitchToggle).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
Closes #376

## Summary

- `app/src/lib/completeness.test.js` — 12 unit tests for `playgroundCompleteness`: all three completeness tiers, every info signal variant, `access:'yes'` edge case
- `app/src/lib/deeplink.test.js` — 14 unit tests for `parseHash`, `writeHash`, `isValidSlug`: both hash forms, round-trip correctness, slug validation edge cases
- `app/src/stores/filters.test.js` — 15 unit tests for `matchesFilters` and `hasActiveFilters`: every filter key, multi-filter AND logic, count boundary checks
- `tests/filter-panel.spec.js` — 11 Playwright E2E tests for FilterPanel: open/close toggle, badge count increments/decrements, clear-all, outside-click dismiss, layers section

Updates `app/package.json` `test:unit` script to run all four unit test files. The filters test uses `--conditions=node` so `svelte/store` resolves correctly in plain Node.

## Test plan

- [ ] `make test-unit` — all 4 unit test files pass (40 assertions)
- [ ] `npx playwright test tests/filter-panel.spec.js` — 11 E2E tests pass
- [ ] `make test` — full suite (unit + all Playwright) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)