### PR TITLE
feat(ui): info modal with version number and links

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -12,7 +12,7 @@
   import DataContributionModal from './DataContributionModal.svelte';
   import CompletenessLegend from './CompletenessLegend.svelte';
   import { onDestroy, onMount } from 'svelte';
-  import { Pencil, Plus, Minus, ArrowLeft } from 'lucide-svelte';
+  import { Info, Plus, Minus, ArrowLeft } from 'lucide-svelte';
   import { _ } from 'svelte-i18n';
   import GeoJSON from 'ol/format/GeoJSON.js';
   import { mapStore } from '../stores/map.js';
@@ -60,8 +60,8 @@
   export let nearestFetcher = null;
 
   /**
-   * Links shown in the data-contribution modal.
-   * @type {{ wikiUrl: string, chatUrl: string | null }}
+   * Links shown in the info modal.
+   * @type {{ chatUrl: string | null }}
    */
   export let dataContribLinks;
 
@@ -436,10 +436,10 @@
       <button
         class="control-btn"
         onclick={() => dataModalOpen = true}
-        title={$_('nav.addData')}
-        aria-label={$_('nav.addData')}
+        title={$_('nav.about')}
+        aria-label={$_('nav.about')}
       >
-        <Pencil class="h-5 w-5" />
+        <Info class="h-5 w-5" />
       </button>
       <FilterPanel />
     </div>
@@ -509,7 +509,6 @@
 
   <DataContributionModal
     bind:open={dataModalOpen}
-    wikiUrl={dataContribLinks.wikiUrl}
     chatUrl={dataContribLinks.chatUrl}
   />
 </div>

--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -1,12 +1,11 @@
 <script>
-  import { regionPlaygroundWikiUrl, regionChatUrl } from '../lib/config.js';
-  import { _ } from 'svelte-i18n';
+  import { _ , locale } from 'svelte-i18n';
+  import { version } from '../../package.json';
 
   export let open = false;
-  /** OSM wiki page shown as "Erfassungsregeln für Spielplätze in dieser Region". */
-  export let wikiUrl = regionPlaygroundWikiUrl;
   /** Community chat URL; hidden when null/falsy. */
-  export let chatUrl = regionChatUrl;
+  export let chatUrl = null;
+
   function close() { open = false; }
 
   function onBackdropClick(e) {
@@ -16,6 +15,10 @@
   function onKeydown(e) {
     if (open && e.key === 'Escape') close();
   }
+
+  $: osmWikiUrl = $locale?.startsWith('de')
+    ? 'https://wiki.openstreetmap.org/wiki/DE:Tag:leisure%3Dplayground'
+    : 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
 </script>
 
 <svelte:window onkeydown={onKeydown} />
@@ -24,36 +27,28 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="modal-backdrop" onclick={onBackdropClick}>
-    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="dc-title">
+    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="info-title">
       <div class="modal-header">
-        <h5 class="modal-title" id="dc-title">{$_('nav.addData')}</h5>
+        <h5 class="modal-title" id="info-title">{$_('nav.about')}</h5>
         <button type="button" class="close-btn" onclick={close} aria-label={$_('info.closeBtn')}>✕</button>
       </div>
       <div class="modal-body">
         <p class="small">
-          {@html $_('modal.addData.introText', { values: { name: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>' } })}
+          {@html $_('modal.addData.introText', { values: {
+            osmLink: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>',
+            mapcompleteLink: '<a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>'
+          } })}
         </p>
 
-        <h6 class="section-heading">{$_('modal.addData.equipTitle')}</h6>
-        <p class="small">
-          <a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>
-          — {$_('modal.addData.mapcompleteText')}
-        </p>
+        <div class="links">
+          <a href={osmWikiUrl} target="_blank" rel="noopener">{$_('modal.addData.wikiLinkText')} ↗</a>
+          {#if chatUrl}
+            <a href={chatUrl} target="_blank" rel="noopener">{$_('modal.addData.community.simpleChatLabel')} ↗</a>
+          {/if}
+          <a href="https://github.com/mfuhrmann/spieli" target="_blank" rel="noopener">{$_('modal.addData.githubLabel')} ↗</a>
+        </div>
 
-        <h6 class="section-heading">{$_('modal.addData.wikiTitle')}</h6>
-        <p class="small">
-          <a href={wikiUrl} target="_blank" rel="noopener">
-            {$_('modal.addData.wikiLinkText')}
-          </a>
-        </p>
-
-        {#if chatUrl}
-          <h6 class="section-heading">{$_('modal.addData.community.label')}</h6>
-          <p class="small">
-            {$_('modal.addData.community.simpleText')}
-            <a href={chatUrl} target="_blank" rel="noopener">{$_('modal.addData.community.simpleChatLabel')}</a>.
-          </p>
-        {/if}
+        <p class="version">v{version}</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="ok-btn" onclick={close}>{$_('modal.ok')}</button>
@@ -76,7 +71,7 @@
   .modal-box {
     background: #fff;
     border-radius: 6px;
-    width: min(90vw, 480px);
+    width: min(90vw, 440px);
     max-height: 80vh;
     overflow-y: auto;
     box-shadow: 0 4px 24px rgba(0,0,0,0.2);
@@ -106,12 +101,26 @@
 
   .modal-body { padding: 1rem; }
 
-  .small { font-size: 0.875rem; color: #495057; margin: 0 0 0.5rem; }
+  .small { font-size: 0.875rem; color: #495057; margin: 0 0 1rem; }
 
-  .section-heading { font-size: 0.875rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
+  .links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+  }
 
-  a { color: #6c757d; }
-  a:hover { color: #343a40; }
+  .links a {
+    font-size: 0.875rem;
+    color: #6c757d;
+  }
+  .links a:hover { color: #343a40; }
+
+  .version {
+    font-size: 0.75rem;
+    color: #adb5bd;
+    margin: 0;
+  }
 
   .modal-footer {
     padding: 0.5rem 1rem;

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -14,9 +14,6 @@
   import { clusterMaxZoom } from '../lib/config.js';
   import * as osmIdDedup from './osmIdDedup.js';
 
-  // Generic OSM wiki link for the contribution modal (hub is region-agnostic).
-  const HUB_WIKI_URL = 'https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground';
-
   // Three sources owned by the hub — the orchestrator populates cluster /
   // polygon on every moveend; MacroView (P2 §5) populates macro from
   // backend metadata (no fetch). Map.svelte toggles layer visibility from
@@ -48,7 +45,7 @@
     fetchNearestAcrossBackends,
   } = createRegistry();
 
-  const dataContribLinks = { wikiUrl: HUB_WIKI_URL, chatUrl: null };
+  const dataContribLinks = { chatUrl: null };
 
   // Sync resolver for deep-link slug → backend URL. Reads the current backends
   // list via `get()` so AppShell can call it from its restore loop without

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -10,7 +10,6 @@
   import {
     apiBaseUrl,
     osmRelationId,
-    regionPlaygroundWikiUrl,
     regionChatUrl,
   } from '../lib/config.js';
   import {
@@ -82,7 +81,6 @@
     : null;
 
   const dataContribLinks = {
-    wikiUrl: regionPlaygroundWikiUrl,
     chatUrl: regionChatUrl,
   };
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -313,11 +313,9 @@
     "nextPhoto": "Nächstes Foto",
     "ok": "OK",
     "addData": {
-      "introText": "Die Daten dieser Karte stammen aus {name}. Du kannst sie direkt bearbeiten – kein Account nötig bei MapComplete.",
-      "equipTitle": "Spielgeräte & Details ergänzen",
-      "mapcompleteText": "Spielgeräte, Fotos und weitere Details einfach per Klick eintragen.",
-      "wikiTitle": "OSM-Wiki",
-      "wikiLinkText": "Erfassungsregeln für Spielplätze in dieser Region",
+      "introText": "Die Daten dieser Karte stammen aus {osmLink}. Du kannst sie direkt mit {mapcompleteLink} bearbeiten – kein weiterer Account außer einem OpenStreetMap-Konto (kostenlos) erforderlich.",
+      "wikiLinkText": "OSM-Wiki: Spielplätze",
+      "githubLabel": "Quellcode auf GitHub",
       "osm": {
         "label": "OpenStreetMap",
         "text": "Die Daten stammen aus {osmLink} — einer freien, kollaborativen Weltkarte von Millionen Freiwilligen. Nur was eingetragen wurde, erscheint auch hier.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -313,11 +313,9 @@
     "nextPhoto": "Next photo",
     "ok": "OK",
     "addData": {
-      "introText": "The data on this map comes from {name}. You can edit it directly – no account needed for MapComplete.",
-      "equipTitle": "Equipment & details",
-      "mapcompleteText": "Add equipment, photos and further details with a click.",
-      "wikiTitle": "OSM wiki",
-      "wikiLinkText": "Mapping rules for playgrounds in this region",
+      "introText": "The data on this map comes from {osmLink}. You can edit it directly using {mapcompleteLink} – no additional account beyond a free OpenStreetMap account is required.",
+      "wikiLinkText": "OSM Wiki: Playgrounds",
+      "githubLabel": "Source code on GitHub",
       "osm": {
         "label": "OpenStreetMap",
         "text": "The data comes from {osmLink} — a free, collaborative world map built by millions of volunteers. Only what has been mapped will appear here.",


### PR DESCRIPTION
Closes #381, closes #379

## Summary

- Replaces the pencil (add data) button with an ⓘ (Info) button in the top-right controls
- Consolidates data-contribution and about-project content into a single reworked modal titled "Über das Projekt" / "About"
- Simplified intro text: OSM as data source + MapComplete for editing + free OSM account note
- Removed the "Equipment & details" section
- Locale-aware OSM wiki link (German wiki page when locale is `de`, English otherwise)
- GitHub repo link (`mfuhrmann/spieli`)
- App version number (`v0.4.1-rc`) read from `package.json` at build time — always reflects the running version
- Drops the now-unused `wikiUrl` prop and `regionPlaygroundWikiUrl` wiring through the component tree

## Test plan

- [ ] Click the ⓘ button — modal opens titled "Über das Projekt"
- [ ] Intro paragraph links to openstreetmap.org and mapcomplete.org
- [ ] OSM Wiki link points to the DE wiki page when locale is German
- [ ] GitHub link opens `github.com/mfuhrmann/spieli`
- [ ] Version number matches `package.json`
- [ ] Modal closes via ✕, OK button, Escape key, and backdrop click
- [ ] No regressions in hub mode (HubApp no longer passes `wikiUrl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)