### PR TITLE
docs(spec): scheduled OSM re-import with hub visibility and data-node auto-update (#386, #406)

### DIFF
--- a/openspec/changes/scheduled-osm-reimport/.openspec.yaml
+++ b/openspec/changes/scheduled-osm-reimport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/scheduled-osm-reimport/design.md
+++ b/openspec/changes/scheduled-osm-reimport/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The spieli importer runs `osm2pgsql --slim --drop`, which drops and recreates the `planet_osm_*` tables in the `public` schema. During this phase (which can take several minutes on a real region PBF), the backend's playground data is partially absent or inconsistent. The `api` schema (including `api.import_status`) lives separately and remains fully queryable during the osm2pgsql run.
+
+The hub polls each backend's `/api/rpc/get_meta` every 60 seconds via `poll-federation.sh` and writes `/federation-status.json`. The hub UI reads this file and renders per-backend status in the drawer. The plumbing exists; it just needs an `importing` flag to flow through it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface an `importing: true` signal in `get_meta` while osm2pgsql is running
+- Carry that flag through to `/federation-status.json` and the hub drawer
+- Clear the flag unconditionally on importer exit (success or failure)
+- Leave all existing clients unaffected (additive-only change)
+
+**Non-Goals:**
+- Progress reporting (percentage complete, ETA)
+- Pausing hub requests or blocking user interactions during import
+- Configuring the scheduled timer itself (covered by the existing `scheduled-importer` spec)
+- Changing the import cadence or PBF source selection
+
+## Decisions
+
+### D1 — Column on `api.import_status`, not a separate table
+
+The `importing` flag is a property of the same singleton that already holds `last_import_at`. Adding it as a column avoids a join, keeps `get_meta` a single-table read, and reuses the existing `ON CONFLICT (id) DO UPDATE` UPSERT pattern. No new table or schema migration strategy is needed — the column is added by `api.sql` which is re-applied on every `make db-apply` / import run anyway (idempotent DDL via `CREATE TABLE IF NOT EXISTS … ADD COLUMN IF NOT EXISTS`).
+
+### D2 — Set flag with a bare `psql` call before osm2pgsql, clear it in an EXIT trap
+
+`import.sh` already exports `PGPASSWORD` and has `set -e`. The flag must be cleared even when the script exits early (killed, network error, SQL error). Using a POSIX `trap 'psql … SET importing=false' EXIT` ensures the flag is cleared on any exit path, including `kill`. The flag is set to `true` immediately before the osm2pgsql invocation (not at script start) so the pre-flight validation and PBF download phases do not trigger the "updating" badge unnecessarily.
+
+**Alternative considered**: clear the flag only on success (in a separate step after the schema apply). Rejected because a killed or crashed importer would leave `importing=true` indefinitely, misleading users.
+
+### D3 — `get_meta` exposes `importing` as a JSON boolean
+
+`get_meta` already builds a `json_build_object`; adding `'importing', importing` is a one-liner. No new RPC or schema change. The hub's existing `/api/rpc/get_meta` call picks it up transparently.
+
+### D4 — Hub drawer shows a pill/badge, not an error state
+
+`importing: true` is not an error — the backend is healthy but temporarily refreshing. The drawer already has `instance-badge` elements (e.g. for version). An "updating" badge (distinct colour from the error indicator) is the appropriate treatment. The hub UI must handle `importing` being absent (`undefined`) for backward-compatible operation against older backends.
+
+### D5 — `poll-federation.sh` passes `importing` through to status JSON
+
+The poll script already extracts fields from `get_meta` via `jq`. Adding `importing` to the extracted object requires a one-line `jq` change. The `/federation-status.json` schema gains an optional `importing` boolean per backend entry.
+
+## Risks / Trade-offs
+
+- **Race between poll and import start**: If the importer sets `importing=true` between two hub polls, the hub sees the "updating" state for up to 60 seconds after the import actually started. Acceptable — the signal is advisory, not transactional.
+- **Stale `importing=true` if container is SIGKILL'd before the EXIT trap fires**: The trap fires on SIGTERM and normal exits; SIGKILL bypasses it. In practice, `docker compose run --rm` sends SIGTERM first. Operators can manually clear with `psql -c "UPDATE api.import_status SET importing=false WHERE id=1"`. This is documented in ops/troubleshooting.
+- **Old backends without `importing` field**: Hub must treat a missing or null `importing` as `false`. `jq` default (`// false`) handles this.
+
+## Migration Plan
+
+1. Deploy updated `api.sql` via `make db-apply` (adds `importing` column, `get_meta` exposes it). No data loss; existing rows get `importing = false` from the column default.
+2. Deploy updated `import.sh` (flag lifecycle). No restart required.
+3. Deploy updated hub container image (updated `poll-federation.sh` + drawer badge). Hub immediately starts carrying `importing` in `/federation-status.json`.
+4. Rollback: re-run `make db-apply` with the old `api.sql`; the column stays (harmless) but `get_meta` no longer emits it; hub silently treats absence as `false`.

--- a/openspec/changes/scheduled-osm-reimport/design.md
+++ b/openspec/changes/scheduled-osm-reimport/design.md
@@ -4,19 +4,25 @@ The spieli importer runs `osm2pgsql --slim --drop`, which drops and recreates th
 
 The hub polls each backend's `/api/rpc/get_meta` every 60 seconds via `poll-federation.sh` and writes `/federation-status.json`. The hub UI reads this file and renders per-backend status in the drawer. The plumbing exists; it just needs an `importing` flag to flow through it.
 
+This change also addresses issue #406 (auto-update for data nodes): data-node operators should not need to manually trigger re-imports, apply schema changes, or update container images. The daemon mode and Watchtower profile together eliminate that burden while keeping manual control available.
+
 ## Goals / Non-Goals
 
 **Goals:**
 - Surface an `importing: true` signal in `get_meta` while osm2pgsql is running
 - Carry that flag through to `/federation-status.json` and the hub drawer
 - Clear the flag unconditionally on importer exit (success or failure)
-- Leave all existing clients unaffected (additive-only change)
+- Enable automatic, recurring OSM re-imports via container-native daemon mode
+- Prevent unplanned re-imports when the container restarts for unrelated reasons (e.g. image update)
+- Provide an opt-in Watchtower profile for automatic image and schema updates
+- Wire the auto-update choice into `install.sh` so operators set it once at install time
+- Leave all existing clients unaffected (additive-only changes)
 
 **Non-Goals:**
 - Progress reporting (percentage complete, ETA)
 - Pausing hub requests or blocking user interactions during import
-- Configuring the scheduled timer itself (covered by the existing `scheduled-importer` spec)
-- Changing the import cadence or PBF source selection
+- Changing the PBF source selection algorithm
+- Removing the `deploy/` systemd units (kept as alternative for existing users)
 
 ## Decisions
 
@@ -42,15 +48,54 @@ The `importing` flag is a property of the same singleton that already holds `las
 
 The poll script already extracts fields from `get_meta` via `jq`. Adding `importing` to the extracted object requires a one-line `jq` change. The `/federation-status.json` schema gains an optional `importing` boolean per backend entry.
 
+### D6 — Daemon mode in the container, not a host-level scheduler
+
+**Options considered:**
+- Systemd service + timer (already shipped in `deploy/`)
+- External scheduler container (ofelia, etc.)
+- Importer container with a built-in sleep loop
+
+The daemon-mode loop in `import.sh` is chosen as the primary approach because it requires no host configuration, works on any OS with Docker, and is entirely self-contained in the compose stack. The systemd units in `deploy/` remain for operators who already have them configured; they are not removed.
+
+The restart policy for the importer in `compose.prod.yml` changes from `restart: "no"` to `restart: on-failure`. In daemon mode the script loops forever (never exits 0), so `on-failure` only fires on an unexpected crash. In one-shot mode the script exits 0 on success — `on-failure` does nothing, preserving the existing behaviour.
+
+### D7 — Startup grace check reads `last_import_at` before the first run
+
+When the importer container restarts (e.g. after a Watchtower image update), a naïve daemon would immediately trigger a re-import regardless of when the last one ran. Instead, on startup the script queries `api.import_status.last_import_at`:
+
+- If absent (fresh DB, table not yet created): run immediately.
+- If within the configured interval: sleep for `(last_import_at + random_interval) - now`.
+- If overdue: run immediately.
+
+The DB query may fail if PostgREST isn't ready yet; the script retries with a short backoff (up to 30 seconds) before giving up and treating the absence as "run immediately."
+
+**Why a random interval and not a fixed time?** Random jitter between `MIN` and `MAX` days prevents thundering-herd behaviour when many data-nodes are deployed from the same installer defaults. Each node drifts onto its own schedule naturally.
+
+### D8 — Watchtower as opt-in `auto-update` compose profile
+
+Watchtower requires mounting `/var/run/docker.sock`, which is a privilege escalation vector. Making it opt-in (profile `auto-update`) means operators who don't want it simply omit the profile — it is never started by default. The Watchtower service polls daily (`WATCHTOWER_POLL_INTERVAL: 86400`), which is sufficient given the startup grace check (D7) absorbs the restart without triggering an immediate re-import.
+
+**Why not recommend external Watchtower?** Bundling it in `compose.prod.yml` means data-node operators get it with one installer prompt answer, with no additional research required.
+
+### D9 — `install.sh` auto-update prompt, default yes
+
+The installer already walks operators through deployment mode, region, and infrastructure choices. Adding one more question — "Automatically keep data and software up to date?" — at the end of the infrastructure section is consistent with the existing flow. Defaulting to yes (recommended) means the low-maintenance path is the easy path. Operators who choose no receive:
+- A reminder to run `docker compose run --rm importer` periodically
+- A pointer to `deploy/spieli-import.service` and `deploy/spieli-import.timer` for host-level scheduling
+
 ## Risks / Trade-offs
 
 - **Race between poll and import start**: If the importer sets `importing=true` between two hub polls, the hub sees the "updating" state for up to 60 seconds after the import actually started. Acceptable — the signal is advisory, not transactional.
-- **Stale `importing=true` if container is SIGKILL'd before the EXIT trap fires**: The trap fires on SIGTERM and normal exits; SIGKILL bypasses it. In practice, `docker compose run --rm` sends SIGTERM first. Operators can manually clear with `psql -c "UPDATE api.import_status SET importing=false WHERE id=1"`. This is documented in ops/troubleshooting.
+- **Stale `importing=true` if container is SIGKILL'd before the EXIT trap fires**: The trap fires on SIGTERM and normal exits; SIGKILL bypasses it. In practice, `docker compose` sends SIGTERM first. Operators can manually clear with `psql -c "UPDATE api.import_status SET importing=false WHERE id=1"`. Documented in ops/troubleshooting.
 - **Old backends without `importing` field**: Hub must treat a missing or null `importing` as `false`. `jq` default (`// false`) handles this.
+- **Watchtower Docker socket exposure**: Mitigated by making Watchtower opt-in and documenting the privilege implication. Operators on high-security hosts can use the systemd timer + manual image pulls instead.
+- **Very long sleep in daemon mode**: The importer container sleeps for up to 10 days. Docker's `restart: on-failure` only helps if the container crashes — it won't re-run a healthy sleeping container that has somehow become stuck. Operators can force an early re-import by restarting the container (`docker compose restart importer`).
 
 ## Migration Plan
 
 1. Deploy updated `api.sql` via `make db-apply` (adds `importing` column, `get_meta` exposes it). No data loss; existing rows get `importing = false` from the column default.
-2. Deploy updated `import.sh` (flag lifecycle). No restart required.
-3. Deploy updated hub container image (updated `poll-federation.sh` + drawer badge). Hub immediately starts carrying `importing` in `/federation-status.json`.
-4. Rollback: re-run `make db-apply` with the old `api.sql`; the column stays (harmless) but `get_meta` no longer emits it; hub silently treats absence as `false`.
+2. Deploy updated `import.sh` (flag lifecycle + daemon loop + startup grace check). No restart required for existing one-shot users.
+3. Deploy updated `compose.prod.yml` (restart policy + Watchtower service). Existing deployments that don't set interval vars continue to work in one-shot mode.
+4. Deploy updated `install.sh`. Existing `.env` files are not affected; the new vars are absent, preserving one-shot behaviour.
+5. Deploy updated hub container image (`poll-federation.sh` + drawer badge). Hub immediately starts carrying `importing` in `/federation-status.json`.
+6. Rollback: re-run `make db-apply` with the old `api.sql`; the column stays (harmless) but `get_meta` no longer emits it; hub silently treats absence as `false`.

--- a/openspec/changes/scheduled-osm-reimport/proposal.md
+++ b/openspec/changes/scheduled-osm-reimport/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+When an OSM re-import is running, the backend's data is partially rebuilt — playgrounds may disappear or appear mid-import, making the map inconsistent. Hub operators and end-users currently have no visibility into this transient state; the hub drawer shows "healthy" even while a backend is actively replacing its dataset. Adding an `importing` flag to `get_meta` and surfacing it in the hub drawer gives users a clear "updating" signal instead of a confusing mid-import view.
+
+## What Changes
+
+- `api.import_status` gains a boolean column `importing` (default `false`)
+- `importer/import.sh` sets `importing = true` before osm2pgsql runs and `false` on clean exit
+- `get_meta` exposes the `importing` field
+- `poll-federation.sh` carries the field through into `/federation-status.json`
+- Hub drawer shows an "updating" badge next to the affected backend when `importing: true`
+- A systemd timer (or cron) can be configured to run the importer in the early morning (Geofabrik dumps are available from ~04:00 UTC)
+
+## Capabilities
+
+### New Capabilities
+
+- `import-in-progress-signal`: Importer marks itself as active in `api.import_status` before the disruptive osm2pgsql phase and clears the flag on success or failure; backends expose this via `get_meta`.
+
+### Modified Capabilities
+
+- `scheduled-importer`: Extend the existing importer spec to cover the `importing` flag lifecycle (set before osm2pgsql, cleared on finish).
+- `federation-health-exposition`: Extend the hub's poll/status pipeline to carry `importing` through `/federation-status.json` and surface it in the hub drawer.
+
+## Impact
+
+- **`importer/api.sql`** — new `importing` column on `api.import_status`; `get_meta` adds the field
+- **`importer/import.sh`** — two additional `psql` calls (set flag before, clear after)
+- **`oci/hub/poll-federation.sh`** — pass `importing` through to status JSON
+- **`app/src/hub/InstancePanel.svelte`** (or equivalent drawer component) — render "updating" badge when `importing: true`
+- **No breaking changes** — `importing` is an additive field; existing clients that ignore it continue to work

--- a/openspec/changes/scheduled-osm-reimport/proposal.md
+++ b/openspec/changes/scheduled-osm-reimport/proposal.md
@@ -1,15 +1,21 @@
 ## Why
 
-When an OSM re-import is running, the backend's data is partially rebuilt — playgrounds may disappear or appear mid-import, making the map inconsistent. Hub operators and end-users currently have no visibility into this transient state; the hub drawer shows "healthy" even while a backend is actively replacing its dataset. Adding an `importing` flag to `get_meta` and surfacing it in the hub drawer gives users a clear "updating" signal instead of a confusing mid-import view.
+Two related problems motivate this change:
+
+**Hub visibility during imports.** When an OSM re-import is running, the backend's data is partially rebuilt — playgrounds may disappear or appear mid-import, making the map inconsistent. Hub operators and end-users currently have no visibility into this transient state; the hub drawer shows "healthy" even while a backend is actively replacing its dataset.
+
+**Data-node maintenance burden (issue #406).** Data-node operators host a backend for the wider project but should not need to actively manage re-imports, schema updates, or software upgrades. Currently they must manually trigger re-imports, apply API schema changes after a hub release, and update container images themselves. Combining scheduled automatic re-imports with optional image auto-update (Watchtower) removes this burden while keeping manual control available for operators who prefer it.
 
 ## What Changes
 
 - `api.import_status` gains a boolean column `importing` (default `false`)
-- `importer/import.sh` sets `importing = true` before osm2pgsql runs and `false` on clean exit
+- `importer/import.sh` sets `importing = true` before osm2pgsql runs, clears it on exit, and gains a daemon mode: when `REIMPORT_INTERVAL_MIN_DAYS` / `REIMPORT_INTERVAL_MAX_DAYS` are set it loops after each run, sleeping for a random interval between the bounds
+- On daemon-mode startup, the importer checks `last_import_at` and skips an import if one ran recently, preventing unplanned re-imports on container restart (e.g. after a Watchtower image update)
 - `get_meta` exposes the `importing` field
-- `poll-federation.sh` carries the field through into `/federation-status.json`
+- `poll-federation.sh` carries `importing` through into `/federation-status.json`
 - Hub drawer shows an "updating" badge next to the affected backend when `importing: true`
-- A systemd timer (or cron) can be configured to run the importer in the early morning (Geofabrik dumps are available from ~04:00 UTC)
+- `compose.prod.yml` changes the importer restart policy to `on-failure` and adds a `watchtower` service under the opt-in `auto-update` profile
+- `install.sh` gains an auto-update prompt (default: yes) that writes interval vars to `.env` and starts the `auto-update` profile; operators who decline get manual instructions and a pointer to the systemd units in `deploy/`
 
 ## Capabilities
 
@@ -19,13 +25,15 @@ When an OSM re-import is running, the backend's data is partially rebuilt — pl
 
 ### Modified Capabilities
 
-- `scheduled-importer`: Extend the existing importer spec to cover the `importing` flag lifecycle (set before osm2pgsql, cleared on finish).
+- `scheduled-importer`: Replace the "configure a systemd timer" approach with a container-native daemon mode. The importer loops internally on a randomised 2–10 day interval (configurable). Systemd units remain as a documented alternative. Adds startup grace check, Watchtower support, and installer auto-update prompt.
 - `federation-health-exposition`: Extend the hub's poll/status pipeline to carry `importing` through `/federation-status.json` and surface it in the hub drawer.
 
 ## Impact
 
 - **`importer/api.sql`** — new `importing` column on `api.import_status`; `get_meta` adds the field
-- **`importer/import.sh`** — two additional `psql` calls (set flag before, clear after)
-- **`oci/hub/poll-federation.sh`** — pass `importing` through to status JSON
-- **`app/src/hub/InstancePanel.svelte`** (or equivalent drawer component) — render "updating" badge when `importing: true`
-- **No breaking changes** — `importing` is an additive field; existing clients that ignore it continue to work
+- **`importer/import.sh`** — importing flag lifecycle, daemon loop, startup grace check
+- **`compose.prod.yml`** — importer `restart: on-failure`; new `REIMPORT_INTERVAL_*` env vars; new `watchtower` service under `auto-update` profile
+- **`install.sh`** — new auto-update prompt; writes interval vars and starts `auto-update` profile when selected
+- **`oci/app/poll-federation.sh`** — pass `importing` through to status JSON
+- **`app/src/hub/InstancePanelDrawer.svelte`** (or equivalent) — render "updating" badge when `importing: true`
+- **No breaking changes** — `importing` is an additive field; one-shot mode is preserved when interval vars are absent; existing `deploy/` systemd units remain valid

--- a/openspec/changes/scheduled-osm-reimport/specs/federation-health-exposition/spec.md
+++ b/openspec/changes/scheduled-osm-reimport/specs/federation-health-exposition/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Hub carries `importing` through federation status JSON
+The hub container's poll pipeline SHALL include the `importing` field from each backend's `get_meta` response in the corresponding entry of `/federation-status.json`. When the field is absent (older backend), the hub SHALL treat it as `false`.
+
+#### Scenario: Status JSON reflects `importing: true` from a backend
+- **WHEN** a backend returns `"importing": true` in its `get_meta` response during a poll
+- **THEN** the corresponding entry in `/federation-status.json` includes `"importing": true`
+
+#### Scenario: Status JSON defaults to `importing: false` for older backends
+- **WHEN** a backend's `get_meta` response does not include the `importing` field
+- **THEN** the corresponding entry in `/federation-status.json` includes `"importing": false`
+
+### Requirement: Hub drawer shows "updating" badge when a backend is importing
+The hub UI SHALL display a distinct visual indicator (e.g. an "updating" badge) next to a backend's entry in the instances drawer when its `/federation-status.json` entry has `importing: true`. When `importing` is absent or `false` the drawer renders normally.
+
+#### Scenario: Drawer shows "updating" badge during an active import
+- **WHEN** the hub's `/federation-status.json` entry for a backend has `"importing": true`
+- **THEN** the corresponding row in the hub drawer displays an "updating" indicator alongside the backend name
+- **AND** no error/down state is shown (the backend is healthy)
+
+#### Scenario: Drawer shows no "updating" badge during normal operation
+- **WHEN** the hub's `/federation-status.json` entry for a backend has `"importing": false` or the field is absent
+- **THEN** no "updating" indicator is shown for that backend

--- a/openspec/changes/scheduled-osm-reimport/specs/import-in-progress-signal/spec.md
+++ b/openspec/changes/scheduled-osm-reimport/specs/import-in-progress-signal/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Importer sets `importing` flag before osm2pgsql runs
+The importer SHALL set `api.import_status.importing = true` immediately before invoking osm2pgsql and clear it unconditionally on script exit (success, failure, or signal).
+
+#### Scenario: Flag is true while osm2pgsql is running
+- **WHEN** a client calls `/api/rpc/get_meta` while the importer's osm2pgsql phase is active
+- **THEN** the response includes `"importing": true`
+
+#### Scenario: Flag is cleared on successful import
+- **WHEN** the importer pipeline completes with exit code 0
+- **THEN** `api.import_status.importing` is set back to `false`
+- **AND** a subsequent call to `/api/rpc/get_meta` returns `"importing": false`
+
+#### Scenario: Flag is cleared when importer exits with an error
+- **WHEN** the importer exits with a non-zero status (e.g. osm2pgsql failure, schema-apply error)
+- **THEN** `api.import_status.importing` is set to `false` via the shell EXIT trap
+- **AND** `last_import_at` is NOT updated (failure does not update the timestamp)
+
+#### Scenario: Flag is cleared when importer receives SIGTERM
+- **WHEN** the importer process receives SIGTERM (e.g. `docker stop` during an import)
+- **THEN** the shell EXIT trap fires and sets `api.import_status.importing = false`
+
+#### Scenario: Flag is absent before any import has run
+- **WHEN** a client calls `/api/rpc/get_meta` on a freshly provisioned backend with an empty `api.import_status` table
+- **THEN** `importing` is present in the response with value `false` (column default)
+
+### Requirement: `get_meta` exposes `importing` as a JSON boolean
+`api.get_meta` SHALL include an `importing` key in its JSON response whose value reflects the current `api.import_status.importing` column value.
+
+#### Scenario: `get_meta` returns `importing: false` during normal operation
+- **WHEN** no import is running and the column holds its default value
+- **THEN** `GET /api/rpc/get_meta` returns a JSON object containing `"importing": false`
+
+#### Scenario: `get_meta` returns `importing: true` during an import
+- **WHEN** `api.import_status.importing` is `true`
+- **THEN** `GET /api/rpc/get_meta` returns a JSON object containing `"importing": true`

--- a/openspec/changes/scheduled-osm-reimport/specs/scheduled-importer/spec.md
+++ b/openspec/changes/scheduled-osm-reimport/specs/scheduled-importer/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Importer records successful-run timestamp
+
+The importer SHALL record the timestamp of each successful run into a persistent, SQL-queryable location so that downstream clients (federation hub, monitoring tools) can observe data freshness per backend. The importer SHALL also manage the `importing` boolean flag in `api.import_status` around the osm2pgsql phase: set to `true` before the phase starts and cleared unconditionally on script exit.
+
+#### Scenario: Successful run writes a timestamp
+
+- **WHEN** the importer's full pipeline (osm2pgsql + schema apply via `psql … < /api.sql`) completes with exit code 0
+- **THEN** the `api.import_status` singleton row is upserted with `last_import_at = now()`
+- **AND** `importing` is set back to `false`
+
+> The trigger keys on the *full pipeline* succeeding, not on `osm2pgsql` alone, because the `api.import_status` table is created by the schema-apply step itself. See design D3.
+
+#### Scenario: Failed run does not update timestamp
+
+- **WHEN** the importer exits with a non-zero status, is killed, or aborts at any point in the pipeline (PBF download, osmium prefilter, osm2pgsql, schema apply)
+- **THEN** the previous `last_import_at` value is preserved unchanged
+- **AND** no partial or speculative timestamp is written
+- **AND** `importing` is set to `false` via the EXIT trap
+
+#### Scenario: Singleton integrity enforced at schema level
+
+- **WHEN** any client attempts to `INSERT` a second row into `api.import_status`
+- **THEN** the insertion fails with a CHECK violation
+- **AND** the existing row is unaffected

--- a/openspec/changes/scheduled-osm-reimport/specs/scheduled-importer/spec.md
+++ b/openspec/changes/scheduled-osm-reimport/specs/scheduled-importer/spec.md
@@ -24,3 +24,80 @@ The importer SHALL record the timestamp of each successful run into a persistent
 - **WHEN** any client attempts to `INSERT` a second row into `api.import_status`
 - **THEN** the insertion fails with a CHECK violation
 - **AND** the existing row is unaffected
+
+## ADDED Requirements
+
+### Requirement: Daemon mode via env-var interval
+
+When `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` are set, the importer SHALL run in daemon mode: execute the full pipeline, sleep for a uniformly random duration between the two bounds, then repeat indefinitely. When neither variable is set the importer runs once and exits (one-shot mode, backward compatible).
+
+#### Scenario: Daemon loops after a successful import
+
+- **GIVEN** `REIMPORT_INTERVAL_MIN_DAYS=2` and `REIMPORT_INTERVAL_MAX_DAYS=10` are set
+- **WHEN** the import pipeline completes with exit code 0
+- **THEN** the importer sleeps for a random duration between 2 and 10 days
+- **AND** after the sleep, it runs the full pipeline again without restarting the container
+
+#### Scenario: Daemon retries after a failed import
+
+- **GIVEN** daemon mode is configured
+- **WHEN** the import pipeline exits with a non-zero status
+- **THEN** the importer sleeps for a short retry interval (at most 1 hour) before trying again
+- **AND** `last_import_at` is NOT updated
+
+#### Scenario: One-shot mode exits after a single run
+
+- **GIVEN** `REIMPORT_INTERVAL_MIN_DAYS` is not set
+- **WHEN** the import pipeline completes
+- **THEN** the importer exits immediately (existing behaviour preserved)
+
+### Requirement: Skip import if ran recently (startup grace check)
+
+On startup, before the first import, the importer SHALL query `api.import_status.last_import_at`. If the last successful run is within the configured interval window, the importer SHALL sleep until the next scheduled time. If the table is absent or empty, it SHALL run immediately.
+
+#### Scenario: Container restarts shortly after a recent import
+
+- **GIVEN** `last_import_at` is 1 day ago and `REIMPORT_INTERVAL_MIN_DAYS=2`
+- **WHEN** the container restarts (e.g. Watchtower image update)
+- **THEN** the importer sleeps for `(last_import_at + random_interval) - now` before importing
+
+#### Scenario: Container restarts after interval has elapsed
+
+- **GIVEN** `last_import_at` is 12 days ago and `REIMPORT_INTERVAL_MAX_DAYS=10`
+- **WHEN** the container restarts
+- **THEN** the importer runs an import immediately
+
+#### Scenario: First-ever run on a fresh database
+
+- **GIVEN** `api.import_status` does not yet exist
+- **WHEN** the container starts
+- **THEN** the importer runs immediately without raising an error
+
+### Requirement: compose.prod.yml daemon mode and Watchtower support
+
+`compose.prod.yml` SHALL change the importer's restart policy to `on-failure` and expose `REIMPORT_INTERVAL_MIN_DAYS` / `REIMPORT_INTERVAL_MAX_DAYS` as passthrough env vars. A new `watchtower` service under the `auto-update` profile SHALL pull updated images daily.
+
+#### Scenario: Watchtower pulls a new importer image
+
+- **GIVEN** the `auto-update` profile is active
+- **WHEN** Watchtower detects a new `spieli-importer:latest` image
+- **THEN** it restarts the importer container
+- **AND** the startup grace check prevents an immediate re-import if one ran recently
+- **AND** the next scheduled run uses the updated `api.sql`
+
+### Requirement: Installer prompts for auto-update preference
+
+`install.sh` SHALL ask data-node operators whether to enable automatic updates (default: yes). Yes writes interval vars to `.env` and starts the `auto-update` profile; no preserves one-shot behaviour and prints manual instructions.
+
+#### Scenario: Operator selects automatic updates
+
+- **WHEN** the operator answers yes at the auto-update prompt
+- **THEN** `REIMPORT_INTERVAL_MIN_DAYS=2` and `REIMPORT_INTERVAL_MAX_DAYS=10` are written to `.env`
+- **AND** the stack starts with the `auto-update` profile
+
+#### Scenario: Operator selects manual updates
+
+- **WHEN** the operator answers no
+- **THEN** no interval vars are written (one-shot mode)
+- **AND** `install.sh` prints instructions for running the importer manually
+- **AND** notes the systemd units in `deploy/` as a scheduling alternative

--- a/openspec/changes/scheduled-osm-reimport/tasks.md
+++ b/openspec/changes/scheduled-osm-reimport/tasks.md
@@ -1,0 +1,32 @@
+## 1. Database schema
+
+- [ ] 1.1 Add `importing BOOLEAN NOT NULL DEFAULT false` column to `api.import_status` in `importer/api.sql` (use `ADD COLUMN IF NOT EXISTS`)
+- [ ] 1.2 Add `'importing', importing` to the `json_build_object` in `get_meta` in `importer/api.sql`
+- [ ] 1.3 Run `make db-apply` and verify `curl .../rpc/get_meta | jq .importing` returns `false`
+
+## 2. Importer script
+
+- [ ] 2.1 Add a POSIX EXIT trap in `importer/import.sh` that runs `psql … UPDATE api.import_status SET importing = false WHERE id = 1`
+- [ ] 2.2 Insert a `psql … UPDATE api.import_status SET importing = true WHERE id = 1` call immediately before the `osm2pgsql` invocation
+- [ ] 2.3 Confirm the trap fires on both clean exit and simulated error (`kill -TERM`)
+
+## 3. Hub poll pipeline
+
+- [ ] 3.1 Update `oci/hub/poll-federation.sh` to extract `importing` from `get_meta` and include it in the per-backend entry written to `/federation-status.json` (default to `false` if field absent)
+- [ ] 3.2 Verify `/federation-status.json` includes `"importing": false` for all backends during normal operation
+
+## 4. Hub drawer UI
+
+- [ ] 4.1 In the hub instances drawer component, check each backend's `importing` field from `/federation-status.json`
+- [ ] 4.2 Render an "updating" badge (distinct from the error/down state) next to the backend name when `importing: true`
+- [ ] 4.3 Confirm no "updating" badge appears when `importing` is `false` or absent
+
+## 5. Tests
+
+- [ ] 5.1 Add a Playwright test to `tests/hub-pill.spec.js` that stubs `get_meta` with `importing: true` for one backend and asserts the "updating" badge appears in the drawer
+- [ ] 5.2 Add a scenario that stubs `importing: false` (or omits the field) and asserts no badge
+
+## 6. Documentation
+
+- [ ] 6.1 Update `docs/reference/api.md` — add `importing` to the `get_meta` response table
+- [ ] 6.2 Add a note to `docs/ops/troubleshooting.md` explaining how to manually clear a stuck `importing=true` flag (`UPDATE api.import_status SET importing = false WHERE id = 1`)

--- a/openspec/changes/scheduled-osm-reimport/tasks.md
+++ b/openspec/changes/scheduled-osm-reimport/tasks.md
@@ -4,29 +4,53 @@
 - [ ] 1.2 Add `'importing', importing` to the `json_build_object` in `get_meta` in `importer/api.sql`
 - [ ] 1.3 Run `make db-apply` and verify `curl .../rpc/get_meta | jq .importing` returns `false`
 
-## 2. Importer script
+## 2. Importer script — importing flag
 
 - [ ] 2.1 Add a POSIX EXIT trap in `importer/import.sh` that runs `psql … UPDATE api.import_status SET importing = false WHERE id = 1`
 - [ ] 2.2 Insert a `psql … UPDATE api.import_status SET importing = true WHERE id = 1` call immediately before the `osm2pgsql` invocation
 - [ ] 2.3 Confirm the trap fires on both clean exit and simulated error (`kill -TERM`)
 
-## 3. Hub poll pipeline
+## 3. Importer script — daemon mode and startup grace check
 
-- [ ] 3.1 Update `oci/hub/poll-federation.sh` to extract `importing` from `get_meta` and include it in the per-backend entry written to `/federation-status.json` (default to `false` if field absent)
-- [ ] 3.2 Verify `/federation-status.json` includes `"importing": false` for all backends during normal operation
+- [ ] 3.1 Wrap the main import logic in a `run_import` function
+- [ ] 3.2 Add startup grace check: query `api.import_status.last_import_at`; if within the configured interval, compute next scheduled time and sleep until then; if absent or overdue, proceed immediately. Handle DB unavailability with a short retry loop (max 30 s) before falling back to "run immediately".
+- [ ] 3.3 Add daemon loop: if `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` are set, after a successful import sleep for a uniformly random duration between the bounds, then loop back to `run_import`. On a failed run, sleep for a short retry interval (≤ 1 hour) before retrying.
+- [ ] 3.4 Ensure daemon mode never exits with code 0 between runs (loop is infinite); exit code propagates only on unexpected crash.
+- [ ] 3.5 Verify one-shot behaviour is unchanged when interval vars are absent
 
-## 4. Hub drawer UI
+## 4. Hub poll pipeline
 
-- [ ] 4.1 In the hub instances drawer component, check each backend's `importing` field from `/federation-status.json`
-- [ ] 4.2 Render an "updating" badge (distinct from the error/down state) next to the backend name when `importing: true`
-- [ ] 4.3 Confirm no "updating" badge appears when `importing` is `false` or absent
+- [ ] 4.1 Update `oci/app/poll-federation.sh` to extract `importing` from `get_meta` and include it in the per-backend entry written to `/federation-status.json` (default `false` if field absent via `jq`'s `// false`)
+- [ ] 4.2 Verify `/federation-status.json` includes `"importing": false` for all backends during normal operation
 
-## 5. Tests
+## 5. Hub drawer UI
 
-- [ ] 5.1 Add a Playwright test to `tests/hub-pill.spec.js` that stubs `get_meta` with `importing: true` for one backend and asserts the "updating" badge appears in the drawer
-- [ ] 5.2 Add a scenario that stubs `importing: false` (or omits the field) and asserts no badge
+- [ ] 5.1 In the hub instances drawer component, read each backend's `importing` field from the federation-status data
+- [ ] 5.2 Render an "updating" badge (distinct colour from error/down state) next to the backend name when `importing: true`
+- [ ] 5.3 Confirm no "updating" badge appears when `importing` is `false` or absent
 
-## 6. Documentation
+## 6. compose.prod.yml
 
-- [ ] 6.1 Update `docs/reference/api.md` — add `importing` to the `get_meta` response table
-- [ ] 6.2 Add a note to `docs/ops/troubleshooting.md` explaining how to manually clear a stuck `importing=true` flag (`UPDATE api.import_status SET importing = false WHERE id = 1`)
+- [ ] 6.1 Change importer `restart: "no"` → `restart: on-failure`
+- [ ] 6.2 Add `REIMPORT_INTERVAL_MIN_DAYS: ${REIMPORT_INTERVAL_MIN_DAYS:-}` and `REIMPORT_INTERVAL_MAX_DAYS: ${REIMPORT_INTERVAL_MAX_DAYS:-}` to the importer environment (empty default = one-shot mode)
+- [ ] 6.3 Add `watchtower` service under `profiles: [auto-update]` with `WATCHTOWER_POLL_INTERVAL: 86400`, `WATCHTOWER_CLEANUP: "true"`, `restart: unless-stopped`, and `/var/run/docker.sock` volume mount
+
+## 7. install.sh — auto-update prompt
+
+- [ ] 7.1 Add auto-update prompt in the "Optional: infrastructure" section (default yes, shown only for `data-node` and `data-node-ui` modes)
+- [ ] 7.2 On yes: write `REIMPORT_INTERVAL_MIN_DAYS=2` and `REIMPORT_INTERVAL_MAX_DAYS=10` to `.env`; append `auto-update` to the list of active profiles for the `docker compose up` invocation
+- [ ] 7.3 On no: omit interval vars from `.env`; after the final "Done!" block print: "Run imports manually: `docker compose run --rm importer`. See `deploy/` for systemd timer units."
+- [ ] 7.4 In auto-update mode, skip the "Run the OSM import now?" prompt — the daemon will run the first import automatically on container start
+
+## 8. Tests
+
+- [ ] 8.1 Add a Playwright test to `tests/hub-pill.spec.js` that stubs `get_meta` with `importing: true` for one backend and asserts the "updating" badge appears in the drawer
+- [ ] 8.2 Add a scenario that stubs `importing: false` (or omits the field) and asserts no badge
+
+## 9. Documentation
+
+- [ ] 9.1 Update `docs/reference/api.md` — add `importing` to the `get_meta` response table
+- [ ] 9.2 Add a note to `docs/ops/troubleshooting.md` explaining how to manually clear a stuck `importing=true` flag (`UPDATE api.import_status SET importing = false WHERE id = 1`)
+- [ ] 9.3 Update `docs/ops/configuration.md` — document `REIMPORT_INTERVAL_MIN_DAYS`, `REIMPORT_INTERVAL_MAX_DAYS`, and the `auto-update` compose profile
+- [ ] 9.4 Update the local-dev guide or ops docs to describe the two scheduling approaches (daemon mode vs systemd) and when to use each
+- [ ] 9.5 Close issue #406 in the PR description or release notes, referencing this change

--- a/openspec/specs/scheduled-importer/spec.md
+++ b/openspec/specs/scheduled-importer/spec.md
@@ -2,52 +2,127 @@
 
 ## Purpose
 
-Give operators a drop-in systemd service + timer pair so OSM data refreshes weekly without custom cron jobs or manual intervention. The service runs `docker compose run --rm importer` against the project's existing `.env`; the timer fires weekly with `Persistent=true` to catch missed runs on next boot.
+Keep OSM data and the backend API schema fresh automatically, reducing the maintenance burden for data-node operators. The importer supports two scheduling modes:
+
+1. **Daemon mode** (recommended) — the importer container runs continuously, sleeping between runs for a randomised interval. No host-level scheduler required; the compose stack owns the schedule.
+2. **Systemd mode** (alternative) — a systemd service + timer pair triggers `docker compose run --rm importer` on a weekly cadence. For operators who prefer host-level scheduling or already use systemd.
+
 ## Requirements
-### Requirement: Service unit runs the importer via Docker Compose
-The system SHALL provide a `deploy/spieli-import.service` systemd service unit that executes `docker compose run --rm importer` in the project directory, loading credentials from the `.env` file via `EnvironmentFile=`.
 
-#### Scenario: Service unit executes the importer container
-- **WHEN** the service unit is started (manually or by the timer)
-- **THEN** `docker compose run --rm importer` is invoked in the configured `WorkingDirectory`
-- **THEN** the importer container runs to completion and is removed afterwards
+### Requirement: Daemon mode via env-var interval
 
-#### Scenario: Service unit picks up environment from .env
-- **WHEN** the service unit starts
-- **THEN** environment variables from `.env` (e.g. `OSM_RELATION_ID`, `PBF_URL`) are available to the Docker Compose invocation
+When `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` are set, the importer SHALL run continuously: execute the full import pipeline, sleep for a uniformly random duration between the two bounds, then repeat. When neither variable is set the importer SHALL run once and exit (backward-compatible one-shot behaviour).
 
-### Requirement: Timer unit triggers the importer weekly
-The system SHALL provide a `deploy/spieli-import.timer` systemd timer unit that activates the service unit once a week with `Persistent=true`.
+#### Scenario: Daemon mode loops after a successful import
 
-#### Scenario: Timer fires on the weekly schedule
-- **WHEN** the configured weekly calendar expression elapses
-- **THEN** `spieli-import.service` is started automatically
+- **GIVEN** `REIMPORT_INTERVAL_MIN_DAYS=2` and `REIMPORT_INTERVAL_MAX_DAYS=10` are set
+- **WHEN** the import pipeline completes with exit code 0
+- **THEN** the importer sleeps for a random duration between 2 and 10 days (selected uniformly at startup of each sleep)
+- **AND** after the sleep, it runs the full pipeline again without restarting the container
 
-#### Scenario: Missed run is caught on next boot
-- **WHEN** the system was offline during a scheduled run
-- **THEN** `spieli-import.service` is started once on the next boot due to `Persistent=true`
+#### Scenario: Daemon mode loops after a failed import
 
-### Requirement: Unit files are documented for installation
-The project documentation SHALL describe how to copy, configure, and enable the unit files so operators can set up automated imports without prior systemd expertise.
+- **GIVEN** daemon mode is configured
+- **WHEN** the import pipeline exits with a non-zero status
+- **THEN** the importer sleeps for a shorter retry interval (at most 1 hour) before trying again
+- **AND** `last_import_at` is NOT updated (failed run does not advance the schedule)
 
-#### Scenario: Operator follows the documented install steps
-- **WHEN** an operator follows the documented procedure (copy units, edit `WorkingDirectory` and `User=`, `systemctl enable --now`)
-- **THEN** the timer is active and the importer runs automatically each week
+#### Scenario: One-shot mode exits after a single run
+
+- **GIVEN** `REIMPORT_INTERVAL_MIN_DAYS` is not set
+- **WHEN** the import pipeline completes (success or failure)
+- **THEN** the importer exits immediately
+- **AND** `docker compose restart: on-failure` handles retries only on non-zero exit
+
+### Requirement: Skip import if ran recently (startup grace check)
+
+On startup, before running the first import, the importer SHALL check `api.import_status.last_import_at` in the database. If the last successful import completed within the configured interval window, the importer SHALL sleep until the next scheduled time rather than importing immediately. If the table does not exist or the row is absent (first-ever run or fresh DB), the importer SHALL run immediately.
+
+This prevents an unplanned import every time the container is restarted (e.g. by Watchtower after an image update) when a run has occurred recently.
+
+#### Scenario: Container restarts shortly after a recent import
+
+- **GIVEN** daemon mode is active and `last_import_at` is 1 day ago with `REIMPORT_INTERVAL_MIN_DAYS=2`
+- **WHEN** the container restarts (e.g. image update via Watchtower)
+- **THEN** the importer does NOT run an import immediately
+- **AND** instead sleeps for approximately `(last_import_at + random_interval) - now`
+
+#### Scenario: Container restarts after interval has elapsed
+
+- **GIVEN** daemon mode is active and `last_import_at` is 12 days ago with `REIMPORT_INTERVAL_MAX_DAYS=10`
+- **WHEN** the container restarts
+- **THEN** the importer runs an import immediately (overdue)
+
+#### Scenario: First-ever run on a fresh database
+
+- **GIVEN** `api.import_status` does not yet exist (table created by the import itself)
+- **WHEN** the container starts
+- **THEN** the importer runs the import immediately
+- **AND** no error is raised for the absent table
+
+### Requirement: compose.prod.yml supports daemon mode
+
+`compose.prod.yml` SHALL configure the importer service to restart on failure (`restart: on-failure`) and expose `REIMPORT_INTERVAL_MIN_DAYS` / `REIMPORT_INTERVAL_MAX_DAYS` as passthrough environment variables (empty by default = one-shot mode).
+
+#### Scenario: Importer daemon survives a container crash
+
+- **GIVEN** daemon mode is configured and the importer container crashes mid-sleep
+- **WHEN** Docker restarts it (via `restart: on-failure`)
+- **THEN** the startup grace check runs, determines whether to sleep or import, and continues normally
+
+### Requirement: Optional Watchtower service for image auto-update
+
+`compose.prod.yml` SHALL include a `watchtower` service under the `auto-update` profile. When the profile is active, Watchtower polls Docker Hub/GHCR daily for new importer and app images and restarts updated containers. Operators who prefer manual image control simply omit the `auto-update` profile.
+
+#### Scenario: Watchtower pulls a new importer image
+
+- **GIVEN** the `auto-update` profile is active and a new `spieli-importer:latest` image is available
+- **WHEN** Watchtower detects the update
+- **THEN** the importer container is restarted with the new image
+- **AND** the startup grace check prevents an immediate re-import if one ran recently
+- **AND** the next scheduled run uses the new `api.sql` (updated schema + RPCs)
+
+### Requirement: Installer prompts for auto-update preference
+
+`install.sh` SHALL ask data-node operators whether to enable automatic updates during setup. The default answer is yes (recommended). The choice affects which compose profiles are started and which env vars are written to `.env`.
+
+#### Scenario: Operator chooses automatic updates (recommended)
+
+- **WHEN** the operator answers yes (or presses Enter) at the auto-update prompt
+- **THEN** `install.sh` writes `REIMPORT_INTERVAL_MIN_DAYS=2` and `REIMPORT_INTERVAL_MAX_DAYS=10` to `.env`
+- **AND** starts the stack with the `auto-update` profile (includes Watchtower)
+- **AND** the first import runs immediately as the daemon's first iteration
+
+#### Scenario: Operator chooses manual updates
+
+- **WHEN** the operator answers no at the auto-update prompt
+- **THEN** `install.sh` does not write interval vars to `.env` (one-shot mode)
+- **AND** the stack starts without the `auto-update` profile
+- **AND** `install.sh` prints instructions for running the importer manually and notes the systemd units in `deploy/` as a scheduling alternative
+
+### Requirement: Systemd units provided as alternative
+
+The project SHALL continue to ship `deploy/spieli-import.service` and `deploy/spieli-import.timer` for operators who prefer host-level scheduling. Documentation SHALL describe both approaches and note that daemon mode requires no additional host configuration.
+
+#### Scenario: Operator follows the documented systemd install steps
+
+- **WHEN** an operator copies the unit files, edits `WorkingDirectory=` and `User=`, and runs `systemctl enable --now spieli-import.timer`
+- **THEN** the timer fires weekly with `Persistent=true` and triggers a one-shot import
 
 ### Requirement: Importer records successful-run timestamp
 
-The importer SHALL record the timestamp of each successful run into a persistent, SQL-queryable location so that downstream clients (federation hub, monitoring tools) can observe data freshness per backend.
+The importer SHALL record the timestamp of each successful run into `api.import_status` so that downstream clients (federation hub, monitoring tools) can observe data freshness per backend.
 
 #### Scenario: Successful run writes a timestamp
 
 - **WHEN** the importer's full pipeline (osm2pgsql + schema apply via `psql … < /api.sql`) completes with exit code 0
 - **THEN** the `api.import_status` singleton row is upserted with `last_import_at = now()`
 
-> The trigger keys on the *full pipeline* succeeding, not on `osm2pgsql` alone, because the `api.import_status` table is created by the schema-apply step itself — an UPSERT issued before that step has run would fail on a fresh database. See design D3.
+> The trigger keys on the *full pipeline* succeeding, not on `osm2pgsql` alone, because the `api.import_status` table is created by the schema-apply step itself. See design D3.
 
 #### Scenario: Failed run does not update timestamp
 
-- **WHEN** the importer exits with a non-zero status, is killed, or aborts at any point in the pipeline (PBF download, osmium prefilter, osm2pgsql, schema apply)
+- **WHEN** the importer exits with a non-zero status, is killed, or aborts at any point in the pipeline
 - **THEN** the previous `last_import_at` value is preserved unchanged
 - **AND** no partial or speculative timestamp is written
 
@@ -56,4 +131,3 @@ The importer SHALL record the timestamp of each successful run into a persistent
 - **WHEN** any client attempts to `INSERT` a second row into `api.import_status`
 - **THEN** the insertion fails with a CHECK violation
 - **AND** the existing row is unaffected
-


### PR DESCRIPTION
## Summary

- Expands the OpenSpec proposal, design, and specs for issues #386 and #406
- **Issue #386**: `importing` flag in `api.import_status` / `get_meta` so the hub drawer shows an "updating" badge during an active osm2pgsql phase
- **Issue #406**: container-native daemon mode for recurring re-imports (randomised 2–10 day interval), startup grace check against `last_import_at` to prevent surprise re-imports on container restart, opt-in Watchtower profile in `compose.prod.yml`, and an `install.sh` auto-update prompt — replacing the old "configure a systemd timer" placeholder

## What's in this PR

This is a **spec-only PR** — no implementation code is changed. It establishes the contract for the implementation PR(s) that follow.

| File | Purpose |
|---|---|
| `openspec/changes/scheduled-osm-reimport/proposal.md` | Why + what changes (expanded for #406) |
| `openspec/changes/scheduled-osm-reimport/design.md` | Technical decisions D1–D9 |
| `openspec/changes/scheduled-osm-reimport/specs/import-in-progress-signal/spec.md` | New capability spec |
| `openspec/changes/scheduled-osm-reimport/specs/scheduled-importer/spec.md` | Delta: daemon mode, grace check, Watchtower, installer prompt |
| `openspec/changes/scheduled-osm-reimport/specs/federation-health-exposition/spec.md` | Delta: hub carries `importing` + drawer badge |
| `openspec/specs/scheduled-importer/spec.md` | Base spec rewritten — daemon mode is the primary approach, systemd remains as alternative |
| `openspec/changes/scheduled-osm-reimport/tasks.md` | Ordered implementation checklist (9 sections) |

## Test plan

- [ ] Review proposal, design, and specs for correctness and completeness
- [ ] Confirm tasks cover all spec scenarios, including daemon loop, grace check, Watchtower, and installer prompt
- [ ] Merge when satisfied; implementation follows via `/opsx:apply`

Closes #386
Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)