### PR TITLE
fix(mobile): block accidental touches on detail panel open (#391)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -317,7 +317,10 @@
     if (dismissUnsub) { dismissUnsub(); dismissUnsub = null; }
   }
 
-  onDestroy(() => { if (dismissUnsub) dismissUnsub(); });
+  onDestroy(() => {
+    if (dismissUnsub) dismissUnsub();
+    clearTimeout(panelBlockTimer);
+  });
 
   // Responsive: track if we're on mobile
   let isMobile = false;
@@ -326,6 +329,22 @@
   }
   $: if (typeof window !== 'undefined') {
     checkMobile();
+  }
+
+  // Briefly block pointer events on the mobile detail panel body after it opens
+  // to prevent the map tap that triggered the selection from bleeding into links
+  // (email, Panoramax, etc.) that appear at the same screen coordinates.
+  let panelBlockTouch = false;
+  let panelBlockTimer = null;
+  let _panelWasOpen = false;
+  $: {
+    const panelOpen = isMobile && $hasSelection;
+    if (panelOpen && !_panelWasOpen) {
+      panelBlockTouch = true;
+      clearTimeout(panelBlockTimer);
+      panelBlockTimer = setTimeout(() => { panelBlockTouch = false; }, 350);
+    }
+    _panelWasOpen = panelOpen;
   }
 
   // Center the map on the selected playground when the mobile full-screen panel
@@ -498,7 +517,7 @@
           <span>{$_('info.backToMap')}</span>
         </button>
       </div>
-      <div class="mobile-detail-body">
+      <div class="mobile-detail-body" style={panelBlockTouch ? 'pointer-events: none' : ''}>
         <PlaygroundPanel embedded={true} />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- When a user taps a playground on the map, the mobile full-screen detail panel opens immediately
- The touch event that triggered the selection could bleed into interactive elements (email/phone links, Panoramax buttons, accordion toggles) that appeared at the same screen coordinates in the newly visible panel body
- Fix: disable `pointer-events` on the panel body for 350 ms after it opens, absorbing the tail of the touch sequence without any noticeable UX impact

## Test plan

- [ ] On a mobile device (or DevTools mobile emulation), tap a playground that has a contact email or Panoramax link — the detail panel should open without accidentally triggering those links
- [ ] Confirm that after ~350 ms all links and buttons in the panel are fully interactive
- [ ] Confirm the back-to-map button in the header remains immediately tappable (it is outside the guarded body)
- [ ] Confirm desktop behaviour is unchanged (the guard only applies when `isMobile && hasSelection` transitions from false to true)

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)