### PR TITLE
fix(panel): disable pinch-to-zoom in details panel (#393)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -645,6 +645,7 @@
     display: flex;
     flex-direction: column;
     background: #ffffff;
+    touch-action: pan-y;
     color-scheme: light;
     --color-background: #ffffff;
     --color-foreground: #1f2937;

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -711,6 +711,7 @@
     display: none;
     flex-direction: column;
     border-right: 1px solid #e5e7eb;
+    touch-action: pan-y;
     color-scheme: light;
 
     /* Force light theme variables */


### PR DESCRIPTION
Closes #393

## Summary

- Two-finger pinch-to-zoom was active inside the playground details panel, causing a disorienting zoom effect
- Fix: add `touch-action: pan-y` to the mobile full-screen panel (AppShell) and the desktop side panel (PlaygroundPanel)
- This tells the browser to only handle vertical panning on those elements — pinch-zoom is blocked, scrolling is unaffected

## Test plan

- [ ] Mobile: open a playground detail panel and try to pinch-zoom — page should not zoom
- [ ] Mobile: confirm vertical scrolling in the panel still works
- [ ] Desktop touchscreen: same checks on the side panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)