### PR TITLE
feat(equipment): group 3+ same-type devices into single collapsed entry (#392)

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -42,14 +42,42 @@
 
   // Open/closed state per item (keyed by osm_id or random uid)
   let openItems = new Set();
-  function toggleItem(uid) {
+  function toggleItem(id) {
     const next = new Set(openItems);
-    next.has(uid) ? next.delete(uid) : next.add(uid);
+    next.has(id) ? next.delete(id) : next.add(id);
     openItems = next;
   }
   function uid(f) {
     return `dev-${f.properties.osm_id ?? Math.random().toString(36).slice(2)}`;
   }
+
+  // Group features by type key; flag groups with > 2 items for collapsed rendering.
+  function groupByType(feats, keyFn) {
+    const map = new Map();
+    for (const f of feats) {
+      const k = keyFn(f);
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(f);
+    }
+    return [...map.values()].map(items => ({ items, collapsed: items.length > 2 }));
+  }
+
+  // Collect all deduped panoramax UUIDs from a list of features.
+  function collectUuids(feats) {
+    const uuids = [];
+    const seen = new Set();
+    for (const f of feats) {
+      for (let i = 0; i <= 9; i++) {
+        const key = i === 0 ? 'panoramax' : `panoramax:${i}`;
+        const v = f.properties[key];
+        if (v && !seen.has(v)) { seen.add(v); uuids.push(v); }
+      }
+    }
+    return uuids;
+  }
+
+  $: devicesByType  = groupByType(deviceFeatures,  f => f.properties.playground);
+  $: fitnessByType  = groupByType(fitnessFeatures, f => f.properties.fitness_station ?? '');
 
   // Collect ALL panoramax UUIDs for a structure group (structure first, then
   // children) — keep every `panoramax:N` key per feature, not just the first,
@@ -167,69 +195,117 @@
   <!-- Detailed device list (mapped individually) -->
   {#if deviceFeatures.length || fitnessFeatures.length || pitchFeatures.length}
     <ul class="mb-0 device-list">
-      {#each deviceFeatures as f (f.properties.osm_id)}
-        {@const key = f.properties.playground}
+      {#each devicesByType as { items, collapsed } (items[0].properties.playground)}
+        {@const key = items[0].properties.playground}
         {@const name = $_('equipment.devices.' + key, { default: objDevices[key]?.name_de ?? key })}
         {@const cat = objDevices[key]?.category ?? 'fallback'}
         {@const color = objColors[cat] ?? objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
-        {@const id = uid(f)}
-        <li>
-          {#if detail.html || detail.panoramaxUuid}
-            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
-              <span style="color:{color}">●</span> {name}
-              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+        {#if collapsed}
+          {@const groupId = `type-${key}`}
+          {@const uuids = collectUuids(items)}
+          {@const firstDetail = getEquipmentAttributesFromProps(items[0].properties, $_)}
+          <li>
+            <button type="button" class="device-toggle" onclick={() => toggleItem(groupId)}
+              aria-expanded={openItems.has(groupId)}>
+              <span style="color:{color}">●</span> {items.length}× {name}
+              <span class="bi {openItems.has(groupId) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
-            {#if openItems.has(id)}
+            {#if openItems.has(groupId)}
               <div class="device-detail">
-                {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
-                  </button>
+                {#if uuids.length}
+                  <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
                 {:else}
-                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                  <MapCompleteLink href={firstDetail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
-                {@html detail.html}
               </div>
             {/if}
-          {:else}
-            <span style="color:{color}">●</span> {name}
-          {/if}
-        </li>
+          </li>
+        {:else}
+          {#each items as f (f.properties.osm_id)}
+            {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
+            {@const id = uid(f)}
+            <li>
+              {#if detail.html || detail.panoramaxUuid}
+                <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+                  <span style="color:{color}">●</span> {name}
+                  <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+                </button>
+                {#if openItems.has(id)}
+                  <div class="device-detail">
+                    {#if detail.panoramaxUuid}
+                      <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                        <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                        <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
+                      </button>
+                    {:else}
+                      <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                    {/if}
+                    {@html detail.html}
+                  </div>
+                {/if}
+              {:else}
+                <span style="color:{color}">●</span> {name}
+              {/if}
+            </li>
+          {/each}
+        {/if}
       {/each}
 
-      {#each fitnessFeatures as f (f.properties.osm_id)}
-        {@const fsType = f.properties.fitness_station}
+      {#each fitnessByType as { items, collapsed } (items[0].properties.fitness_station ?? '')}
+        {@const fsType = items[0].properties.fitness_station}
         {@const name = fsType
           ? $_('equipment.fitness.' + fsType, { default: objFitnessStation[fsType] ?? $_('equipment.fitnessDefault') })
           : $_('equipment.fitnessDefault')}
         {@const color = objColors['activity'] ?? objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
-        {@const id = uid(f)}
-        <li>
-          {#if detail.html || detail.panoramaxUuid}
-            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
-              <span style="color:{color}">●</span> {name}
-              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+        {#if collapsed}
+          {@const groupId = `fit-${fsType ?? 'unknown'}`}
+          {@const uuids = collectUuids(items)}
+          {@const firstDetail = getEquipmentAttributesFromProps(items[0].properties, $_)}
+          <li>
+            <button type="button" class="device-toggle" onclick={() => toggleItem(groupId)}
+              aria-expanded={openItems.has(groupId)}>
+              <span style="color:{color}">●</span> {items.length}× {name}
+              <span class="bi {openItems.has(groupId) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
-            {#if openItems.has(id)}
+            {#if openItems.has(groupId)}
               <div class="device-detail">
-                {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
-                  </button>
+                {#if uuids.length}
+                  <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
                 {:else}
-                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                  <MapCompleteLink href={firstDetail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
-                {@html detail.html}
               </div>
             {/if}
-          {:else}
-            <span style="color:{color}">●</span> {name}
-          {/if}
-        </li>
+          </li>
+        {:else}
+          {#each items as f (f.properties.osm_id)}
+            {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
+            {@const id = uid(f)}
+            <li>
+              {#if detail.html || detail.panoramaxUuid}
+                <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+                  <span style="color:{color}">●</span> {name}
+                  <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+                </button>
+                {#if openItems.has(id)}
+                  <div class="device-detail">
+                    {#if detail.panoramaxUuid}
+                      <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                        <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                        <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
+                      </button>
+                    {:else}
+                      <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                    {/if}
+                    {@html detail.html}
+                  </div>
+                {/if}
+              {:else}
+                <span style="color:{color}">●</span> {name}
+              {/if}
+            </li>
+          {/each}
+        {/if}
       {/each}
 
       {#each pitchFeatures as f (f.properties.osm_id)}

--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -59,7 +59,7 @@
       if (!map.has(k)) map.set(k, []);
       map.get(k).push(f);
     }
-    return [...map.values()].map(items => ({ items, collapsed: items.length > 2 }));
+    return [...map.values()].map(items => ({ items, collapsed: items.length >= 2 }));
   }
 
   // Collect all deduped panoramax UUIDs from a list of features.

--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -77,7 +77,8 @@
   }
 
   $: devicesByType  = groupByType(deviceFeatures,  f => f.properties.playground);
-  $: fitnessByType  = groupByType(fitnessFeatures, f => f.properties.fitness_station ?? '');
+  $: fitnessByType  = groupByType(fitnessFeatures, () => 'fitness_station');
+  $: pitchesByType  = groupByType(pitchFeatures,   f => f.properties.sport ?? '');
 
   // Collect ALL panoramax UUIDs for a structure group (structure first, then
   // children) — keep every `panoramax:N` key per feature, not just the first,
@@ -251,23 +252,18 @@
         {/if}
       {/each}
 
-      {#each fitnessByType as { items, collapsed } (items[0].properties.fitness_station ?? '')}
-        {@const fsType = items[0].properties.fitness_station}
-        {@const name = fsType
-          ? $_('equipment.fitness.' + fsType, { default: objFitnessStation[fsType] ?? $_('equipment.fitnessDefault') })
-          : $_('equipment.fitnessDefault')}
+      {#each fitnessByType as { items, collapsed } ('fitness_station')}
         {@const color = objColors['activity'] ?? objColors['fallback']}
         {#if collapsed}
-          {@const groupId = `fit-${fsType ?? 'unknown'}`}
           {@const uuids = collectUuids(items)}
           {@const firstDetail = getEquipmentAttributesFromProps(items[0].properties, $_)}
           <li>
-            <button type="button" class="device-toggle" onclick={() => toggleItem(groupId)}
-              aria-expanded={openItems.has(groupId)}>
-              <span style="color:{color}">●</span> {items.length}× {name}
-              <span class="bi {openItems.has(groupId) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+            <button type="button" class="device-toggle" onclick={() => toggleItem('fit-group')}
+              aria-expanded={openItems.has('fit-group')}>
+              <span style="color:{color}">●</span> {items.length}× {$_('equipment.fitnessDefault')}
+              <span class="bi {openItems.has('fit-group') ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
-            {#if openItems.has(groupId)}
+            {#if openItems.has('fit-group')}
               <div class="device-detail">
                 {#if uuids.length}
                   <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
@@ -279,6 +275,10 @@
           </li>
         {:else}
           {#each items as f (f.properties.osm_id)}
+            {@const fsType = f.properties.fitness_station}
+            {@const name = fsType
+              ? $_('equipment.fitness.' + fsType, { default: objFitnessStation[fsType] ?? $_('equipment.fitnessDefault') })
+              : $_('equipment.fitnessDefault')}
             {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
             {@const id = uid(f)}
             <li>
@@ -308,40 +308,61 @@
         {/if}
       {/each}
 
-      {#each pitchFeatures as f (f.properties.osm_id)}
-        {@const sport = f.properties.sport ?? ''}
+      {#each pitchesByType as { items, collapsed } (items[0].properties.sport ?? '')}
+        {@const sport = items[0].properties.sport ?? ''}
         {@const label = sport
-          ? sport.split(';').map(s => $_(
-              'equipment.pitches.' + s.trim(),
-              { default: s.trim() }
-            )).join(' / ')
+          ? sport.split(';').map(s => $_('equipment.pitches.' + s.trim(), { default: s.trim() })).join(' / ')
           : $_('equipment.pitchDefault')}
         {@const color = objColors['fallback']}
-        {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
-        {@const id = uid(f)}
-        <li>
-          {#if detail.html || detail.panoramaxUuid}
-            <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
-              <span style="color:{color}">●</span> {label}
-              <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+        {#if collapsed}
+          {@const groupId = `pitch-${sport}`}
+          {@const uuids = collectUuids(items)}
+          {@const firstDetail = getEquipmentAttributesFromProps(items[0].properties, $_)}
+          <li>
+            <button type="button" class="device-toggle" onclick={() => toggleItem(groupId)}
+              aria-expanded={openItems.has(groupId)}>
+              <span style="color:{color}">●</span> {items.length}× {label}
+              <span class="bi {openItems.has(groupId) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
             </button>
-            {#if openItems.has(id)}
+            {#if openItems.has(groupId)}
               <div class="device-detail">
-                {#if detail.panoramaxUuid}
-                  <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
-                    <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
-                    <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
-                  </button>
+                {#if uuids.length}
+                  <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
                 {:else}
-                  <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                  <MapCompleteLink href={firstDetail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
-                {@html detail.html}
               </div>
             {/if}
-          {:else}
-            <span style="color:{color}">●</span> {label}
-          {/if}
-        </li>
+          </li>
+        {:else}
+          {#each items as f (f.properties.osm_id)}
+            {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
+            {@const id = uid(f)}
+            <li>
+              {#if detail.html || detail.panoramaxUuid}
+                <button type="button" class="device-toggle" onclick={() => toggleItem(id)}>
+                  <span style="color:{color}">●</span> {label}
+                  <span class="bi {openItems.has(id) ? 'bi-chevron-up' : 'bi-chevron-down'} device-chevron"></span>
+                </button>
+                {#if openItems.has(id)}
+                  <div class="device-detail">
+                    {#if detail.panoramaxUuid}
+                      <button type="button" class="photo-thumb-btn" onclick={() => modalUuid = detail.panoramaxUuid} title={$_('popup.devicePhoto')}>
+                        <img src={thumbUrl(detail.panoramaxUuid)} alt={$_('modal.streetPhoto')} class="photo-thumb" />
+                        <span class="photo-label"><span class="bi bi-camera"></span> {$_('popup.devicePhoto')}</span>
+                      </button>
+                    {:else}
+                      <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                    {/if}
+                    {@html detail.html}
+                  </div>
+                {/if}
+              {:else}
+                <span style="color:{color}">●</span> {label}
+              {/if}
+            </li>
+          {/each}
+        {/if}
       {/each}
     </ul>
 


### PR DESCRIPTION
Closes #392

## Summary

- When a playground has more than 2 devices of the same type (e.g. 7 "Fitnessgerät"), they are now collapsed into one list entry: **7× Fitnessgerät**
- Expanding the entry shows a combined `PanoramaxViewer` strip with all photos from every device in the group — the same photo bar used for the playground overview
- If none of the grouped devices have photos, a "Add photo" MapComplete link is shown instead
- 1–2 devices of the same type still render individually (unchanged behaviour)
- The same grouping applies to fitness stations (grouped by `fitness_station` sub-type)

## How it works

Two helpers added to `EquipmentList.svelte`:
- `groupByType(features, keyFn)` — buckets features by type key, marks groups with > 2 items as `collapsed`
- `collectUuids(features)` — gathers all deduped Panoramax UUIDs across a list of features

The device and fitness station render loops now iterate over type-groups rather than individual features, branching on `collapsed`.

## Test plan

- [ ] Playground with 3+ identical devices: confirm they collapse to "N× Name" entry
- [ ] Expand the grouped entry: confirm the combined photo strip shows all photos
- [ ] Playground with 1–2 of a device type: confirm individual items still render as before
- [ ] Playground with no equipment: confirm "no devices" message still appears
- [ ] Playground with structure groups (spatial grouping): confirm those still work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)