### PR TITLE
fix(legend): replace completeness swatches with badge chips, add restricted hover label

### DIFF
--- a/app/src/components/CompletenessLegend.svelte
+++ b/app/src/components/CompletenessLegend.svelte
@@ -1,27 +1,15 @@
 <script>
   import { _ } from 'svelte-i18n';
+  import Badge from './ui/Badge.svelte';
 </script>
 
 <aside class="legend">
   <p class="legend-title">{$_('completeness.legendTitle')}</p>
-  <ul class="legend-list">
-    <li class="legend-item">
-      <span class="swatch swatch--complete"></span>
-      <span>{$_('completeness.complete')}</span>
-    </li>
-    <li class="legend-item">
-      <span class="swatch swatch--partial"></span>
-      <span>{$_('completeness.partial')}</span>
-    </li>
-    <li class="legend-item">
-      <span class="swatch swatch--missing"></span>
-      <span>{$_('completeness.missing')}</span>
-    </li>
-    <li class="legend-item legend-item--hatch">
-      <span class="swatch swatch--hatch"></span>
-      <span>{$_('completeness.restrictedHint')}</span>
-    </li>
-  </ul>
+  <div class="legend-chips">
+    <Badge variant="success">{$_('completeness.complete')}</Badge>
+    <Badge variant="warning">{$_('completeness.partial')}</Badge>
+    <Badge variant="destructive">{$_('completeness.missing')}</Badge>
+  </div>
 </aside>
 
 <style>
@@ -45,64 +33,10 @@
     color: #6b7280;
   }
 
-  .legend-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  .legend-chips {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
     gap: 0.3rem;
   }
 
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.45rem;
-    line-height: 1.2;
-  }
-
-  .legend-item--hatch {
-    border-top: 1px solid #e5e7eb;
-    padding-top: 0.3rem;
-    margin-top: 0.05rem;
-    color: #6b7280;
-  }
-
-  .swatch {
-    flex-shrink: 0;
-    width: 14px;
-    height: 14px;
-    border-radius: 3px;
-    border: 1.5px solid;
-  }
-
-  /* Match vectorStyles.js colours exactly */
-  .swatch--complete {
-    background-color: rgba(34, 139, 34, 0.22);
-    border-color: #155215;
-  }
-
-  .swatch--partial {
-    background-color: rgba(234, 179, 8, 0.22);
-    border-color: #92400e;
-  }
-
-  .swatch--missing {
-    background-color: rgba(239, 68, 68, 0.18);
-    border-color: #991b1b;
-  }
-
-  /* Diagonal hatch matching the canvas pattern in vectorStyles.js */
-  .swatch--hatch {
-    background:
-      repeating-linear-gradient(
-        -45deg,
-        rgba(34, 139, 34, 0.55) 0px,
-        rgba(34, 139, 34, 0.55) 1.5px,
-        rgba(34, 139, 34, 0.08) 1.5px,
-        rgba(34, 139, 34, 0.08) 5px
-      );
-    border-color: #155215;
-    border-style: dashed;
-  }
 </style>

--- a/app/src/components/HoverPreview.svelte
+++ b/app/src/components/HoverPreview.svelte
@@ -2,7 +2,7 @@
   import OpeningHours from 'opening_hours';
   import { cn } from '../lib/utils.js';
   import { getPlaygroundTitle } from '../lib/playgroundHelpers.js';
-  import { MapPin, Droplets, Baby, TreeDeciduous, Accessibility, Clock } from 'lucide-svelte';
+  import { MapPin, Droplets, Baby, TreeDeciduous, Accessibility, Clock, LockKeyhole } from 'lucide-svelte';
   import { _ } from 'svelte-i18n';
 
   /** @type {{ x: number, y: number } | null} */
@@ -16,6 +16,7 @@
   $: hasTrees = attr?.tree_count > 0;
   $: forBaby = attr?.for_baby;
   $: isWheelchair = attr?.wheelchair === 'yes' || attr?.wheelchair === 'limited';
+  $: isRestricted = attr?.access === 'private' || attr?.access === 'customers';
   $: area = attr?.area > 0 ? `${Math.round(attr.area / 10) * 10 || attr.area} m²` : null;
 
   $: surface = attr?.surface
@@ -65,6 +66,11 @@
           {#if isWheelchair}
             <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full" style="background:rgba(99,102,241,.1);color:#6366f1;">
               <Accessibility class="h-3 w-3" />{$_('hover.tagAccessible')}
+            </span>
+          {/if}
+          {#if isRestricted}
+            <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full" style="background:rgba(107,114,128,.1);color:#6b7280;">
+              <LockKeyhole class="h-3 w-3" />{$_('completeness.restrictedHint')}
             </span>
           {/if}
         </div>


### PR DESCRIPTION
Fixes #402

## Changes

### Legend redesign
Replace the three colored square swatches in `CompletenessLegend` with the same `Badge` components (`success` / `warning` / `destructive`) used in the playground detail panel. The legend now looks identical to the completeness chip in the panel header.

### Remove "nicht öffentlich" from legend
The hatch pattern on restricted-access playground areas is self-explanatory on the map. The legend entry is removed. On mobile (primary use case), opening a hatched playground shows the access status in the detail panel.

### Restricted label in HoverPreview (desktop)
On desktop hover, restricted-access playgrounds (`access=private` or `access=customers`) now show a gray `🔒 nicht öffentlich` chip in the tag row alongside the existing water / baby / tree / wheelchair labels.

## Test plan

- [ ] Open the map — legend shows three colored chips matching the detail panel style, no hatch swatch
- [ ] Desktop: hover over a hatched (restricted) playground — lock chip appears in tag row
- [ ] Desktop: hover over a public playground — no lock chip shown
- [ ] Mobile: tap a restricted playground — access status visible in detail panel (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)