### PR TITLE
feat(i18n): extract legal strings into svelte-i18n keys (#415)

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -466,8 +466,8 @@
       <button
         class="control-btn"
         onclick={() => legalModalOpen = true}
-        title="Rechtliches"
-        aria-label="Impressum und Datenschutz"
+        title={$_('legal.title')}
+        aria-label={$_('legal.buttonLabel')}
       >
         <Scale class="h-5 w-5" />
       </button>

--- a/app/src/components/LegalContentModal.svelte
+++ b/app/src/components/LegalContentModal.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { _ } from 'svelte-i18n';
+
   export let open = false;
   /** @type {string | null} */
   export let content = null;
@@ -25,14 +27,14 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="modal-backdrop" onclick={onBackdropClick}>
-    <div class="modal-box" role="dialog" aria-modal="true" aria-label="Rechtliche Information">
+    <div class="modal-box" role="dialog" aria-modal="true" aria-label={$_('legal.contentTitle')}>
       <div class="modal-header">
-        <span class="modal-title">Rechtliche Information</span>
-        <button type="button" class="close-btn" onclick={close} aria-label="Schließen">✕</button>
+        <span class="modal-title">{$_('legal.contentTitle')}</span>
+        <button type="button" class="close-btn" onclick={close} aria-label={$_('hub.closeBtn')}>✕</button>
       </div>
       <div class="modal-body">
         {#if loading}
-          <p class="status-msg">Wird geladen…</p>
+          <p class="status-msg">{$_('legal.loading')}</p>
         {:else if error}
           <p class="status-msg status-msg--error">{error}</p>
         {:else if info}
@@ -41,7 +43,7 @@
           <iframe
             srcdoc={content}
             sandbox="allow-same-origin"
-            title="Rechtliche Information"
+            title={$_('legal.contentTitle')}
             class="content-frame"
           ></iframe>
         {/if}

--- a/app/src/components/LegalModal.svelte
+++ b/app/src/components/LegalModal.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { _ } from 'svelte-i18n';
+
   /** @type {string | null} */
   export let impressumUrl = null;
   /** @type {string | null} */
@@ -24,19 +26,19 @@
   <div class="modal-backdrop" onclick={onBackdropClick}>
     <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="legal-title">
       <div class="modal-header">
-        <h5 class="modal-title" id="legal-title">Rechtliches</h5>
-        <button type="button" class="close-btn" onclick={close} aria-label="Schließen">✕</button>
+        <h5 class="modal-title" id="legal-title">{$_('legal.title')}</h5>
+        <button type="button" class="close-btn" onclick={close} aria-label={$_('hub.closeBtn')}>✕</button>
       </div>
       <div class="modal-body">
         <div class="links">
           {#if impressumUrl}
-            <a href={impressumUrl} target="_blank" rel="noopener">Impressum ↗</a>
+            <a href={impressumUrl} target="_blank" rel="noopener">{$_('legal.impressum')} ↗</a>
           {/if}
           {#if privacyUrl}
-            <a href={privacyUrl} target="_blank" rel="noopener">Datenschutzerklärung ↗</a>
+            <a href={privacyUrl} target="_blank" rel="noopener">{$_('legal.datenschutz')} ↗</a>
           {/if}
           {#if !impressumUrl && !privacyUrl}
-            <p class="no-legal">Keine rechtlichen Angaben verfügbar.</p>
+            <p class="no-legal">{$_('legal.none')}</p>
           {/if}
         </div>
       </div>

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -72,10 +72,10 @@
       if (data?.content) {
         legalContent = data.content;
       } else {
-        legalError = 'Kein Inhalt verfügbar.';
+        legalError = $_('legal.noContent');
       }
     } catch (e) {
-      legalError = `Fehler beim Laden: ${e.message}`;
+      legalError = $_('legal.loadError', { values: { message: e.message } });
     } finally {
       legalLoading = false;
     }
@@ -90,7 +90,7 @@
     } else {
       legalContent = null;
       legalError = null;
-      legalInfo = `Keine rechtlichen Angaben für ${b.name} verfügbar.`;
+      legalInfo = $_('legal.noneFor', { values: { name: b.name } });
       legalLoading = false;
       legalModalOpen = true;
     }
@@ -143,14 +143,14 @@
             <div class="instance-row-end">
               <button
                 class="legal-btn"
-                title="Impressum"
-                aria-label="Impressum für {b.name}"
+                title={$_('legal.impressum')}
+                aria-label={$_('legal.impressumFor', { values: { name: b.name } })}
                 onclick={() => handleLegalClick(b, 'impressum')}
               >§</button>
               <button
                 class="legal-btn"
-                title="Datenschutz"
-                aria-label="Datenschutzerklärung für {b.name}"
+                title={$_('legal.datenschutz')}
+                aria-label={$_('legal.datenschutzFor', { values: { name: b.name } })}
                 onclick={() => handleLegalClick(b, 'datenschutz')}
               >🔒</button>
               {#if b.importing}

--- a/locales/de.json
+++ b/locales/de.json
@@ -369,6 +369,20 @@
     "W": "W",
     "NW": "NW"
   },
+  "legal": {
+    "title": "Rechtliches",
+    "buttonLabel": "Impressum und Datenschutz",
+    "impressum": "Impressum",
+    "datenschutz": "Datenschutzerklärung",
+    "contentTitle": "Rechtliche Information",
+    "loading": "Wird geladen…",
+    "noContent": "Kein Inhalt verfügbar.",
+    "loadError": "Fehler beim Laden: {message}",
+    "impressumFor": "Impressum für {name}",
+    "datenschutzFor": "Datenschutzerklärung für {name}",
+    "noneFor": "Keine rechtlichen Angaben für {name} verfügbar.",
+    "none": "Keine rechtlichen Angaben verfügbar."
+  },
   "hub": {
     "title": "spieli Hub",
     "registryError": "Registry nicht erreichbar",

--- a/locales/en.json
+++ b/locales/en.json
@@ -369,6 +369,20 @@
     "W": "W",
     "NW": "NW"
   },
+  "legal": {
+    "title": "Legal",
+    "buttonLabel": "Imprint and Privacy",
+    "impressum": "Imprint",
+    "datenschutz": "Privacy policy",
+    "contentTitle": "Legal information",
+    "loading": "Loading…",
+    "noContent": "No content available.",
+    "loadError": "Error loading: {message}",
+    "impressumFor": "Imprint for {name}",
+    "datenschutzFor": "Privacy policy for {name}",
+    "noneFor": "No legal information available for {name}.",
+    "none": "No legal information available."
+  },
   "hub": {
     "title": "spieli Hub",
     "registryError": "Registry unreachable",

--- a/tests/legal.spec.js
+++ b/tests/legal.spec.js
@@ -15,7 +15,7 @@ test.describe('Standalone — LegalButton', () => {
     await injectApiConfig(page);
     await stubApiRoutes(page);
     await page.goto('/');
-    await expect(page.locator('button[aria-label="Impressum und Datenschutz"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button[aria-label="Imprint and Privacy"]')).toBeVisible({ timeout: 5000 });
   });
 
   test('button visible and opens modal when impressumUrl is set', async ({ page }) => {
@@ -23,15 +23,15 @@ test.describe('Standalone — LegalButton', () => {
     await stubApiRoutes(page);
     await page.goto('/');
 
-    const btn = page.locator('button[aria-label="Impressum und Datenschutz"]');
+    const btn = page.locator('button[aria-label="Imprint and Privacy"]');
     await expect(btn).toBeVisible({ timeout: 5000 });
     await btn.click();
 
-    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Rechtliches' });
+    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Legal' });
     await expect(modal).toBeVisible();
-    await expect(modal.locator('a', { hasText: 'Impressum' })).toBeVisible();
+    await expect(modal.locator('a', { hasText: 'Imprint' })).toBeVisible();
     // privacyUrl is null → Datenschutz link must not appear
-    await expect(modal.locator('a', { hasText: 'Datenschutzerklärung' })).toHaveCount(0);
+    await expect(modal.locator('a', { hasText: 'Privacy policy' })).toHaveCount(0);
   });
 
   test('button visible and opens modal when privacyUrl is set', async ({ page }) => {
@@ -39,14 +39,14 @@ test.describe('Standalone — LegalButton', () => {
     await stubApiRoutes(page);
     await page.goto('/');
 
-    const btn = page.locator('button[aria-label="Impressum und Datenschutz"]');
+    const btn = page.locator('button[aria-label="Imprint and Privacy"]');
     await expect(btn).toBeVisible({ timeout: 5000 });
     await btn.click();
 
-    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Rechtliches' });
+    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Legal' });
     await expect(modal).toBeVisible();
-    await expect(modal.locator('a', { hasText: 'Datenschutzerklärung' })).toBeVisible();
-    await expect(modal.locator('a', { hasText: 'Impressum' })).toHaveCount(0);
+    await expect(modal.locator('a', { hasText: 'Privacy policy' })).toBeVisible();
+    await expect(modal.locator('a', { hasText: 'Imprint' })).toHaveCount(0);
   });
 
   test('both links visible when both URLs set', async ({ page }) => {
@@ -57,10 +57,10 @@ test.describe('Standalone — LegalButton', () => {
     await stubApiRoutes(page);
     await page.goto('/');
 
-    await page.locator('button[aria-label="Impressum und Datenschutz"]').click();
-    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Rechtliches' });
-    await expect(modal.locator('a', { hasText: 'Impressum' })).toHaveCount(1);
-    await expect(modal.locator('a', { hasText: 'Datenschutzerklärung' })).toHaveCount(1);
+    await page.locator('button[aria-label="Imprint and Privacy"]').click();
+    const modal = page.locator('[role="dialog"]').filter({ hasText: 'Legal' });
+    await expect(modal.locator('a', { hasText: 'Imprint' })).toHaveCount(1);
+    await expect(modal.locator('a', { hasText: 'Privacy policy' })).toHaveCount(1);
   });
 
   test('Impressum link has correct href and target=_blank', async ({ page }) => {
@@ -68,8 +68,8 @@ test.describe('Standalone — LegalButton', () => {
     await stubApiRoutes(page);
     await page.goto('/');
 
-    await page.locator('button[aria-label="Impressum und Datenschutz"]').click();
-    const link = page.locator('[role="dialog"] a', { hasText: 'Impressum' });
+    await page.locator('button[aria-label="Imprint and Privacy"]').click();
+    const link = page.locator('[role="dialog"] a', { hasText: 'Imprint' });
     await expect(link).toHaveAttribute('href', 'https://example.com/impressum');
     await expect(link).toHaveAttribute('target', '_blank');
   });
@@ -79,10 +79,10 @@ test.describe('Standalone — LegalButton', () => {
     await stubApiRoutes(page);
     await page.goto('/');
 
-    await page.locator('button[aria-label="Impressum und Datenschutz"]').click();
-    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Rechtliches' })).toBeVisible();
+    await page.locator('button[aria-label="Imprint and Privacy"]').click();
+    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Legal' })).toBeVisible();
     await page.keyboard.press('Escape');
-    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Rechtliches' })).toHaveCount(0);
+    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Legal' })).toHaveCount(0);
   });
 });
 
@@ -124,10 +124,10 @@ test.describe('Hub — drawer legal icons', () => {
     });
     await page.goto('/');
     const drawer = await openDrawer(page);
-    const btn = drawer.locator('button[title="Impressum"]').first();
+    const btn = drawer.locator('button[title="Imprint"]').first();
     await expect(btn).toBeVisible();
     await btn.click();
-    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Keine rechtlichen Angaben' })).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[role="dialog"]').filter({ hasText: 'No legal information available' })).toBeVisible({ timeout: 3000 });
   });
 
   test('§ icon visible when impressum_url set; click opens new tab', async ({ page, context }) => {
@@ -147,7 +147,7 @@ test.describe('Hub — drawer legal icons', () => {
     await page.goto('/');
     const drawer = await openDrawer(page);
 
-    const impressumBtn = drawer.locator('button[title="Impressum"]').first();
+    const impressumBtn = drawer.locator('button[title="Imprint"]').first();
     await expect(impressumBtn).toBeVisible();
 
     // Clicking should open a new tab (window.open)
@@ -175,8 +175,8 @@ test.describe('Hub — drawer legal icons', () => {
     });
     await page.goto('/');
     const drawer = await openDrawer(page);
-    await expect(drawer.locator('button[title="Datenschutz"]').first()).toBeVisible();
-    await expect(drawer.locator('button[title="Impressum"]').first()).toBeVisible();
+    await expect(drawer.locator('button[title="Privacy policy"]').first()).toBeVisible();
+    await expect(drawer.locator('button[title="Imprint"]').first()).toBeVisible();
   });
 
   test('icons always present; click shows "keine Angaben" when both URLs null and has_legal false', async ({ page }) => {
@@ -196,10 +196,10 @@ test.describe('Hub — drawer legal icons', () => {
     });
     await page.goto('/');
     const drawer = await openDrawer(page);
-    await expect(drawer.locator('button[title="Impressum"]').first()).toBeVisible();
-    await expect(drawer.locator('button[title="Datenschutz"]').first()).toBeVisible();
-    await drawer.locator('button[title="Impressum"]').first().click();
-    await expect(page.locator('[role="dialog"]').filter({ hasText: 'Keine rechtlichen Angaben' })).toBeVisible({ timeout: 3000 });
+    await expect(drawer.locator('button[title="Imprint"]').first()).toBeVisible();
+    await expect(drawer.locator('button[title="Privacy policy"]').first()).toBeVisible();
+    await drawer.locator('button[title="Imprint"]').first().click();
+    await expect(page.locator('[role="dialog"]').filter({ hasText: 'No legal information available' })).toBeVisible({ timeout: 3000 });
   });
 
   test('§ and 🔒 icons visible when has_legal true with null URLs (data-node)', async ({ page }) => {
@@ -230,11 +230,11 @@ test.describe('Hub — drawer legal icons', () => {
     const drawer = await openDrawer(page);
 
     // Both icons must appear even though URLs are null (content lives in get_legal RPC)
-    await expect(drawer.locator('button[title="Impressum"]').first()).toBeVisible();
-    await expect(drawer.locator('button[title="Datenschutz"]').first()).toBeVisible();
+    await expect(drawer.locator('button[title="Imprint"]').first()).toBeVisible();
+    await expect(drawer.locator('button[title="Privacy policy"]').first()).toBeVisible();
 
     // Click § → openLegal() fetches get_legal → LegalContentModal opens
-    await drawer.locator('button[title="Impressum"]').first().click();
+    await drawer.locator('button[title="Imprint"]').first().click();
     await expect(page.locator('iframe')).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
Closes #415

## Summary

- Adds `legal.*` namespace (12 keys) to `locales/de.json` and `locales/en.json`
- Replaces all hardcoded German strings in `LegalModal`, `LegalContentModal`, `AppShell`, and `InstancePanelDrawer` with `$_()` calls
- Reuses existing `hub.closeBtn` for the shared "Schließen" / "Close" key
- No functional change — string extraction only

## Test plan

- [ ] Open hub mode, verify instance drawer shows translated Impressum/Datenschutz button titles and aria-labels
- [ ] Click a legal button that triggers `openLegal()` — verify "Loading…" and error states use translated strings
- [ ] Open standalone mode, verify legal button title/aria-label translated
- [ ] Open `LegalModal` — verify title, link text, close button, and "no legal info" fallback translated
- [ ] Build passes: `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)