### PR TITLE
fix(api): create legal_content table before get_meta references it

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -1033,6 +1033,19 @@ ALTER TABLE api.import_status
 GRANT SELECT ON api.import_status TO web_anon;
 
 -- =========================================================================
+-- 5a. legal_content — stores generated Impressum / Datenschutz HTML for
+--     data-node backends (no nginx webroot). Written by docker-entrypoint.sh
+--     at container startup via psql. Read by get_legal().
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS api.legal_content (
+  type        text        PRIMARY KEY CHECK (type IN ('impressum', 'datenschutz')),
+  content     text        NOT NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+GRANT SELECT ON api.legal_content TO web_anon;
+
+-- =========================================================================
 -- 5. get_meta(relation_id)
 --    Returns instance metadata for federation (Hub discovery).
 --    Includes the OSM relation name, playground count, and bounding box.
@@ -1126,19 +1139,6 @@ AS $$
 $$;
 
 GRANT EXECUTE ON FUNCTION api.get_meta(bigint) TO web_anon;
-
--- =========================================================================
--- 5a. legal_content — stores generated Impressum / Datenschutz HTML for
---     data-node backends (no nginx webroot). Written by docker-entrypoint.sh
---     at container startup via psql. Read by get_legal().
--- =========================================================================
-CREATE TABLE IF NOT EXISTS api.legal_content (
-  type        text        PRIMARY KEY CHECK (type IN ('impressum', 'datenschutz')),
-  content     text        NOT NULL,
-  updated_at  timestamptz NOT NULL DEFAULT now()
-);
-
-GRANT SELECT ON api.legal_content TO web_anon;
 
 -- =========================================================================
 -- 5b. get_legal(type)


### PR DESCRIPTION
## Summary

- `get_meta` referenced `api.legal_content` via `EXISTS()` before the table was defined in `api.sql`
- PostgreSQL validates the reference at function-creation time → fresh import on blank DB always failed
- Fix: move `CREATE TABLE IF NOT EXISTS api.legal_content` + `GRANT` to precede `get_meta`

## Test plan

- [ ] `make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up` completes without error
- [ ] `make db-apply` on an existing install still works (idempotent `CREATE TABLE IF NOT EXISTS`)

Fixes #419. Regression introduced by #411 / #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)