### PR TITLE
fix(images): replace broken Wikimedia Commons filenames for 4 equipment types

### DIFF
--- a/app/src/lib/objPlaygroundEquipment.js
+++ b/app/src/lib/objPlaygroundEquipment.js
@@ -68,7 +68,7 @@
 export const objDevices = {
     slide: {
         name_de: "Rutsche",
-        image: "File:Accessibleplay-Slide.jpg",
+        image: "File:Playground Slide Metal.jpg",
         category: "stationary",
         filterable: true,
         filter_attr: ["length", "height"],
@@ -81,7 +81,7 @@ export const objDevices = {
     },
     springy: {
         name_de: "Federwipptier",
-        image: "File:Springy horse.jpg",
+        image: "File:Playground springs in Obermenzing 02.jpg",
         category: "stationary",
     },
     structure: {
@@ -605,7 +605,7 @@ export const objFeatures = {
         name_de: "Tischtennisplatte",
         icon: "table_tennis",
         size: 12,
-        image: "File:Table tennis court.jpg",
+        image: "File:Outdoor table tennis - geograph.org.uk - 7959772.jpg",
     },
     soccer: {
         tags: {
@@ -615,7 +615,7 @@ export const objFeatures = {
         name_de: "Bolzplatz",
         icon: "soccer",
         size: 12,
-        image: "File:Erding Bolzplatz Feldkirchener Str.jpg",
+        image: "File:Erlebnisspielplatz Marsbachtal Bolzplatz mit Kleintoren.jpg",
     },
     basketball: {
         tags: {


### PR DESCRIPTION
## Summary

Four equipment example images were returning 404 on Wikimedia Commons (and the OSM wiki fallback for two of them), causing broken image icons in the equipment panel.

| Entry | Old (broken) | New (verified 200) |
|---|---|---|
| `slide` | `Accessibleplay-Slide.jpg` | `Playground Slide Metal.jpg` |
| `springy` | `Springy horse.jpg` | `Playground springs in Obermenzing 02.jpg` |
| `table_tennis` | `Table tennis court.jpg` | `Outdoor table tennis - geograph.org.uk - 7959772.jpg` |
| `soccer` | `Erding Bolzplatz Feldkirchener Str.jpg` | `Erlebnisspielplatz Marsbachtal Bolzplatz mit Kleintoren.jpg` |

All replacements verified with HTTP 200 on Commons before committing.

## Test plan

- [ ] Select a playground with a slide → equipment panel shows slide image
- [ ] Select a playground with a Bolzplatz → shows Bolzplatz image
- [ ] Select a playground with a Tischtennisplatte → shows table tennis image
- [ ] No broken image icons in any of the above

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)