### PR TITLE
fix(api): emit playground=structure closed ways as Polygon from get_equipment

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -678,7 +678,10 @@ AS $$
         OR p.leisure IN ('picnic_table', 'pitch', 'fitness_station')
       )
   ),
-  -- Ways rendered as lines (zip wires, slides mapped as linear ways …)
+  -- Ways rendered as lines (zip wires, slides mapped as linear ways …).
+  -- playground=structure closed ways land here (not in planet_osm_polygon)
+  -- because osm2pgsql's classic schema does not treat that tag as an area.
+  -- Emit them as Polygon so equipmentGrouping.js can use them as containers.
   equip_lines AS (
     SELECT
       p.osm_id,
@@ -688,7 +691,13 @@ AS $$
       p.leisure,
       p.sport,
       p.tags,
-      ST_Transform(p.way, 4326) AS geom
+      CASE
+        WHEN p.tags->'playground' = 'structure'
+             AND ST_IsClosed(p.way)
+             AND ST_NPoints(p.way) >= 4
+        THEN ST_Transform(ST_MakePolygon(p.way), 4326)
+        ELSE ST_Transform(p.way, 4326)
+      END AS geom
     FROM planet_osm_line p, bbox b
     WHERE p.way && b.geom
       AND (


### PR DESCRIPTION
## Summary

- `playground=structure` closed ways land in `planet_osm_line` (not `planet_osm_polygon`) because osm2pgsql's classic schema doesn't treat that tag as an area
- `get_equipment` was emitting them as `LineString` — `equipmentGrouping.js` only accepts `Polygon`/`MultiPolygon` as structure containers, so all child devices stayed standalone
- Fix: detect closed `playground=structure` linestrings in `equip_lines` CTE and convert via `ST_MakePolygon`
- Covers both node and way devices inside the structure

## Verified

```
climbing_slope LineString → first point inside structure Polygon ✓
climbingwall   LineString → first point inside structure Polygon ✓
playhouse      LineString → first point inside structure Polygon ✓
structure      Polygon ✓  (was LineString before fix)
```

## Test plan

- [ ] `make docker-build` and open playground containing structure way/1507720326
- [ ] Equipment panel shows structure group with climbing_slope, climbingwall, playhouse as children — not as standalone items
- [ ] Node devices (e.g. sand_pulley) inside a structure polygon still group correctly

Closes #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)