### PR TITLE
fix(api): dedup multipolygon playgrounds in get_playgrounds_bbox

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -238,17 +238,18 @@ AS $$
   playgrounds AS (
     SELECT
       p.osm_id,
-      p.name,
-      p.leisure,
-      p.operator,
-      p.access,
-      p.surface,
-      p.way_area::int AS area,
-      p.tags,
-      ST_Transform(p.way, 4326) AS geom
+      MAX(p.name)                                          AS name,
+      MAX(p.leisure)                                       AS leisure,
+      MAX(p.operator)                                      AS operator,
+      MAX(p.access)                                        AS access,
+      MAX(p.surface)                                       AS surface,
+      SUM(p.way_area)::int                                 AS area,
+      (array_agg(p.tags ORDER BY ST_Area(p.way) DESC))[1] AS tags,
+      ST_Transform(ST_Union(p.way), 4326)                  AS geom
     FROM planet_osm_polygon p
     JOIN region r ON ST_Within(p.way, r.way)
     WHERE p.leisure = 'playground'
+    GROUP BY p.osm_id
   )
   SELECT json_build_object(
     'type', 'FeatureCollection',
@@ -495,20 +496,31 @@ AS $$
       3857
     ) AS geom
   ),
-  playgrounds AS (
-    SELECT
-      p.osm_id,
-      p.name,
-      p.leisure,
-      p.operator,
-      p.access,
-      p.surface,
-      p.way_area::int AS area,
-      p.tags,
-      ST_Transform(p.way, 4326) AS geom
+  -- Collect all osm_ids with at least one ring intersecting the viewport.
+  -- Using a separate CTE instead of filtering playgrounds directly ensures that
+  -- multipolygon relations (one osm_id, multiple planet_osm_polygon rows) are
+  -- returned in full even when only one of their rings touches the bbox edge.
+  ids_in_view AS (
+    SELECT DISTINCT p.osm_id
     FROM planet_osm_polygon p
     JOIN bbox b ON ST_Intersects(p.way, b.geom)
     WHERE p.leisure = 'playground'
+  ),
+  playgrounds AS (
+    SELECT
+      p.osm_id,
+      MAX(p.name)                                          AS name,
+      MAX(p.leisure)                                       AS leisure,
+      MAX(p.operator)                                      AS operator,
+      MAX(p.access)                                        AS access,
+      MAX(p.surface)                                       AS surface,
+      SUM(p.way_area)::int                                 AS area,
+      (array_agg(p.tags ORDER BY ST_Area(p.way) DESC))[1] AS tags,
+      ST_Transform(ST_Union(p.way), 4326)                  AS geom
+    FROM planet_osm_polygon p
+    JOIN ids_in_view i ON i.osm_id = p.osm_id
+    WHERE p.leisure = 'playground'
+    GROUP BY p.osm_id
   )
   SELECT json_build_object(
     'type', 'FeatureCollection',


### PR DESCRIPTION
## Summary

- `get_playgrounds_bbox` and `get_playgrounds` both emitted one GeoJSON feature per `planet_osm_polygon` row, so multipolygon relations (e.g. *Am Pröbelsfeld*, relation 20619595) produced two features with the same `osm_id`. Panning the map so that one ring fell outside the viewport caused that ring to silently disappear from the VectorSource.
- Added `ids_in_view` CTE in `get_playgrounds_bbox` to collect all `osm_id`s with at least one ring in the viewport, then `GROUP BY osm_id + ST_Union` to emit one `MultiPolygon` feature per playground — mirroring the existing `playground_stats` pattern.
- Applied the same `GROUP BY + ST_Union` to the deprecated `get_playgrounds` for consistency.

Closes #427

## Test plan

- [ ] `make db-apply` applies without error
- [ ] Am Pröbelsfeld (relation 20619595) appears as a single `MultiPolygon` feature in the map at polygon zoom
- [ ] Panning so that only one ring is visible no longer drops the other ring
- [ ] All other playgrounds (single-ring ways) are unaffected — area = `way_area` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)