### PR TITLE
fix(reviews): add required q parameter to Mangrove geo URI

### DIFF
--- a/app/src/lib/reviews.js
+++ b/app/src/lib/reviews.js
@@ -65,7 +65,7 @@ function b64urlBytes(buf) {
 // ── Subject URI ────────────────────────────────────────────────────────────
 
 export function mangroveSubject(lat, lon) {
-    return `geo:${lat.toFixed(5)},${lon.toFixed(5)}?u=50`;
+    return `geo:${lat.toFixed(5)},${lon.toFixed(5)}?q=playground&u=50`;
 }
 
 // ── Fetch reviews ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #432.

## Summary

- Mangrove.reviews API rejects geo URIs missing a `q=` parameter (RFC-conformant requirement)
- `mangroveSubject()` was returning `geo:lat,lon?u=50` → API returned 400 "Missing required parameter 'q' in geo URI"
- Fix: `geo:lat,lon?q=playground&u=50`

## Test plan

- [ ] Open a playground, submit a review — confirm no 400 error
- [ ] Existing reviews still load (fetch uses same subject URI, now includes `q=playground`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)