### PR TITLE
fix(config): lower default MAP_MIN_ZOOM from 10 to 7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -175,11 +175,11 @@ fi
 if [[ "$DEPLOY_MODE" != "data-node" ]]; then
     printf "\n${BOLD}── Optional: map display ───────────────────────────────────────${RESET}\n"
     ask MAP_ZOOM      "Initial map zoom level"           "12"
-    ask MAP_MIN_ZOOM  "Minimum zoom level"               "10"
+    ask MAP_MIN_ZOOM  "Minimum zoom level"               "7"
     ask POI_RADIUS_M  "Nearby POI search radius (metres)" "5000"
 else
     MAP_ZOOM="12"
-    MAP_MIN_ZOOM="10"
+    MAP_MIN_ZOOM="7"
     POI_RADIUS_M="5000"
 fi
 

--- a/oci/app/docker-entrypoint.sh
+++ b/oci/app/docker-entrypoint.sh
@@ -61,7 +61,7 @@ window.APP_CONFIG = {
   regionPlaygroundWikiUrl:    '${SAFE_WIKI_URL:-https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground}',
   regionChatUrl:              '${SAFE_CHAT_URL}' || null,
   mapZoom:                    ${MAP_ZOOM:-12},
-  mapMinZoom:                 ${MAP_MIN_ZOOM:-10},
+  mapMinZoom:                 ${MAP_MIN_ZOOM:-7},
   poiRadiusM:                 ${POI_RADIUS_M:-5000},
   apiBaseUrl:                 '${SAFE_API_BASE_URL}',
   clusterMaxZoom:             ${CLUSTER_MAX_ZOOM:-13},


### PR DESCRIPTION
Fixes #436.

## Summary

- Default `MAP_MIN_ZOOM` of 10 prevents zooming out to see the full configured region for large areas (e.g. Hessen)
- Zoom 7 shows roughly all of Germany — a useful overview without too much empty basemap
- Operators can still override via `MAP_MIN_ZOOM` in `.env`
- Updated default in `oci/app/docker-entrypoint.sh` and `install.sh`

## Test plan

- [ ] Fresh install: map allows zooming out to show full region
- [ ] `MAP_MIN_ZOOM=10` in `.env` still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)