### PR TITLE
docs: dedicated uninstall page under Operations

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -124,33 +124,3 @@ The Hub re-reads `registry.json` every 5 minutes — no restart needed.
     The `slug` is optional but recommended — it makes deep-links shareable and stable (e.g. `https://hub.example.com/#new-city/W123456`). Use lowercase ASCII letters, digits, and hyphens only.
 
 For the full federation walkthrough including topology diagrams and verification steps, see [Federated Deployment](../ops/federated-deployment.md).
-
-## Uninstall
-
-To completely remove a spieli deployment installed via `install.sh`:
-
-```bash
-cd spieli
-
-# Stop containers and delete all volumes (database, PBF cache)
-docker compose --profile data-node-ui down -v
-
-# Remove the directory
-cd ..
-rm -rf spieli/ install.sh
-```
-
-Replace `--profile data-node-ui` with the profile you chose during installation (`data-node` or `ui`).
-
-To also remove pulled Docker images:
-
-```bash
-docker image prune -a
-```
-
-If you also set up the nginx+certbot stack, remove it first:
-
-```bash
-docker compose -f spieli-nginx/docker-compose.yml down -v
-rm -rf spieli-nginx/ install-nginx.sh
-```

--- a/docs/ops/manual-deploy.md
+++ b/docs/ops/manual-deploy.md
@@ -87,26 +87,5 @@ Prints your machine's LAN IP and ready-to-use URLs. The Vite dev server and Dock
 !!! warning "Geolocation on mobile"
     Browsers block the geolocation API on plain HTTP. If you need to test the location button on a phone, use Chrome and enable "Insecure origins treated as secure" at `chrome://flags`, or test against the production HTTPS URL.
 
-## Uninstall
-
-To completely remove the spieli stack and all data:
-
-```bash
-# Stop containers and delete all volumes (database, PBF cache)
-make down
-docker volume rm spieli_pgdata spieli_pgdata2 spieli_pbf_cache 2>/dev/null || true
-
-# Remove the cloned repository
-cd ..
-rm -rf spieli/
-```
-
-To also remove the pulled Docker images:
-
-```bash
-docker image prune -a
-```
-
-!!! warning "Volume names"
-    Volume names are prefixed with the directory name of the project. If you cloned into a directory other than `spieli/`, replace `spieli_` with the appropriate prefix in the `docker volume rm` command.
+To remove the stack, see [Uninstall](uninstall.md).
 

--- a/docs/ops/uninstall.md
+++ b/docs/ops/uninstall.md
@@ -21,14 +21,14 @@ rm -rf spieli-nginx/ install-nginx.sh
 ```bash
 cd spieli
 
-# Stop containers and delete all volumes (database, PBF cache)
-docker compose --profile data-node-ui down -v
+# Stop all containers (all profiles) and delete all volumes (database, PBF cache)
+docker compose down -v
 
 cd ..
 rm -rf spieli/ install.sh
 ```
 
-Replace `data-node-ui` with the profile you chose at install time (`data-node` or `ui`). Check your `.env` for `DEPLOY_MODE` if unsure.
+No `--profile` flag needed — `down` stops all running containers in the project regardless of which profile started them (including watchtower if auto-update was enabled).
 
 ## 3. Remove Docker images (optional)
 

--- a/docs/ops/uninstall.md
+++ b/docs/ops/uninstall.md
@@ -1,0 +1,40 @@
+# Uninstall
+
+Steps to completely remove a spieli deployment from a server.
+
+## 1. Remove the nginx+certbot stack
+
+If you set up the nginx+certbot reverse proxy:
+
+```bash
+cd spieli-nginx
+
+# Stop containers and delete certificate volumes
+docker compose down -v
+
+cd ..
+rm -rf spieli-nginx/ install-nginx.sh
+```
+
+## 2. Remove the spieli stack
+
+```bash
+cd spieli
+
+# Stop containers and delete all volumes (database, PBF cache)
+docker compose --profile data-node-ui down -v
+
+cd ..
+rm -rf spieli/ install.sh
+```
+
+Replace `data-node-ui` with the profile you chose at install time (`data-node` or `ui`). Check your `.env` for `DEPLOY_MODE` if unsure.
+
+## 3. Remove Docker images (optional)
+
+```bash
+docker image prune -a
+```
+
+!!! warning "This removes all unused images"
+    `docker image prune -a` removes every image not referenced by a running container — not just spieli images. Skip this step if other Docker workloads are running on the same host.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Monitoring: ops/monitoring.md
       - Security: ops/security.md
       - Troubleshooting: ops/troubleshooting.md
+      - Uninstall: ops/uninstall.md
   - Contributing:
       - Local Development: contributing/local-dev.md
       - Frontend Guide: contributing/frontend-guide.md


### PR DESCRIPTION
Closes #438. Supersedes the uninstall sections added in the previously merged PR.

## Summary

- New `docs/ops/uninstall.md` — covers nginx+certbot stack removal and spieli stack removal in the correct order
- Added to `mkdocs.yml` under Operations (after Troubleshooting)
- Removed the inline uninstall sections from `quick-start.md` and `manual-deploy.md`
- `manual-deploy.md` now has a brief pointer to the dedicated page

🤖 Generated with [Claude Code](https://claude.com/claude-code)