### PR TITLE
feat(nginx): data-node mode + shared network + uninstall fixes (#442)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -81,6 +81,9 @@ services:
       PGRST_DB_ANON_ROLE:  web_anon
       PGRST_SERVER_PORT:   3000
       PGRST_LOG_LEVEL:     warn
+    networks:
+      - default
+      - proxy
     restart: unless-stopped
 
   # ── Second backend (Hub mode dev testing) ───────────────────────────────────
@@ -180,3 +183,8 @@ volumes:
   pgdata:
   pgdata2:
   pbf_cache:
+
+networks:
+  default:
+  proxy:
+    name: spieli-proxy

--- a/deploy/nginx/conf.d/data-node.conf.template
+++ b/deploy/nginx/conf.d/data-node.conf.template
@@ -1,0 +1,50 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    ssl_protocols             TLSv1.2 TLSv1.3;
+    ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache         shared:SSL:10m;
+    ssl_session_timeout       1d;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options    nosniff;
+
+    # PostgREST API — required for hub federation
+    location /api/ {
+        proxy_pass         http://postgrest:3000/;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+
+        # CORS — required so hub browsers can fetch cross-origin
+        add_header Access-Control-Allow-Origin  "*" always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, Prefer" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/deploy/nginx/docker-compose.yml
+++ b/deploy/nginx/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - certbot-certs:/etc/letsencrypt:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - proxy
     restart: unless-stopped
     # Reload every 6 h so renewed certs take effect without a container restart
     command: >
@@ -27,3 +30,9 @@ services:
 volumes:
   certbot-www:
   certbot-certs:
+
+networks:
+  default:
+  proxy:
+    name: spieli-proxy
+    external: true

--- a/deploy/nginx/install-nginx.sh
+++ b/deploy/nginx/install-nginx.sh
@@ -45,6 +45,22 @@ fetch() {
     fi
 }
 
+choose_mode() {
+    while true; do
+        printf "\n${BOLD}── Deployment mode ─────────────────────────────────────────────${RESET}\n"
+        printf "  ${BOLD}1)${RESET} data-node-ui  — full stack with UI (proxies to app on port 8080)\n"
+        printf "  ${BOLD}2)${RESET} data-node     — API only (proxies PostgREST on port 3000, adds CORS)\n\n"
+        printf "${BOLD}Select mode${RESET} [1-2]: "
+        read -r choice
+        case "$choice" in
+            1) NGINX_MODE="data-node-ui"; break ;;
+            2) NGINX_MODE="data-node";    break ;;
+            *) warn "Please enter 1 or 2." ;;
+        esac
+    done
+    success "Mode: ${NGINX_MODE}"
+}
+
 # ── Dependency check ───────────────────────────────────────────────────────────
 
 for cmd in docker; do
@@ -64,29 +80,26 @@ printf "Sets up a TLS-terminating reverse proxy in front of the spieli stack.\n\
 ask DEPLOY_DIR "Installation directory" "./spieli-nginx"
 ask DOMAIN     "Domain name pointing to this server (e.g. spieli.example.com)"
 ask EMAIL      "Email address for Let's Encrypt renewal notices"
-
-APP_PORT="8080"
-ask APP_PORT "Port the spieli stack is listening on" "8080"
+choose_mode
 
 # ── Download files ─────────────────────────────────────────────────────────────
 
-BASE_URL="https://raw.githubusercontent.com/mfuhrmann/spieli/docs/433-nginx-https-guide/deploy/nginx"
+BASE_URL="https://raw.githubusercontent.com/mfuhrmann/spieli/main/deploy/nginx"
 
 mkdir -p "$DEPLOY_DIR/conf.d"
 
 info "Downloading Compose file..."
 fetch "$BASE_URL/docker-compose.yml" "$DEPLOY_DIR/docker-compose.yml"
 
-info "Downloading nginx config template..."
-fetch "$BASE_URL/conf.d/app.conf.template" "$DEPLOY_DIR/conf.d/app.conf.template"
+if [[ "$NGINX_MODE" == "data-node-ui" ]]; then
+    info "Downloading nginx config template (data-node-ui)..."
+    fetch "$BASE_URL/conf.d/app.conf.template" "$DEPLOY_DIR/conf.d/app.conf.template"
+else
+    info "Downloading nginx config template (data-node)..."
+    fetch "$BASE_URL/conf.d/data-node.conf.template" "$DEPLOY_DIR/conf.d/app.conf.template"
+fi
 
 success "Files downloaded to $DEPLOY_DIR."
-
-# ── Patch app port if non-default ──────────────────────────────────────────────
-
-if [[ "$APP_PORT" != "8080" ]]; then
-    sed -i "s/8080/$APP_PORT/g" "$DEPLOY_DIR/conf.d/app.conf.template"
-fi
 
 # ── Step 1: start nginx with HTTP-only config for ACME challenge ───────────────
 
@@ -139,7 +152,15 @@ printf "  docker compose up -d          # start\n"
 printf "  docker compose down           # stop\n"
 printf "  docker compose logs nginx     # nginx logs\n"
 printf "  docker compose logs certbot   # renewal logs\n\n"
-printf "${BOLD}Next step — install spieli:${RESET}\n"
-printf "  curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh\n"
-printf "  bash install.sh\n\n"
-printf "${YELLOW}Tip:${RESET} when the installer asks for the public URL, enter ${BOLD}https://$DOMAIN${RESET}\n"
+if [[ "$NGINX_MODE" == "data-node-ui" ]]; then
+    printf "${BOLD}Next step — install spieli:${RESET}\n"
+    printf "  curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh\n"
+    printf "  bash install.sh\n\n"
+    printf "${YELLOW}Tip:${RESET} when the installer asks for the public URL, enter ${BOLD}https://$DOMAIN${RESET}\n"
+else
+    printf "${BOLD}Next step — install spieli (data-node mode):${RESET}\n"
+    printf "  curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh\n"
+    printf "  bash install.sh\n\n"
+    printf "${YELLOW}Tip:${RESET} choose ${BOLD}data-node${RESET} mode in the installer.\n"
+    printf "Your API will be available at ${CYAN}https://$DOMAIN/api/${RESET}\n"
+fi

--- a/docs/ops/uninstall.md
+++ b/docs/ops/uninstall.md
@@ -21,14 +21,29 @@ rm -rf spieli-nginx/ install-nginx.sh
 ```bash
 cd spieli
 
-# Stop all containers (all profiles) and delete all volumes (database, PBF cache)
-docker compose down -v
+# Stop all containers (all profiles), delete volumes and networks
+docker compose down -v --remove-orphans
 
 cd ..
 rm -rf spieli/ install.sh
 ```
 
-No `--profile` flag needed — `down` stops all running containers in the project regardless of which profile started them (including watchtower if auto-update was enabled).
+No `--profile` flag needed — `down` stops all containers in the project regardless of which profile started them (including watchtower if auto-update was enabled). `--remove-orphans` cleans up dangling networks.
+
+If a volume removal fails with "volume is in use", a stopped container is still referencing it. Prune stopped containers first, then remove the volumes manually:
+
+```bash
+docker container prune -f
+docker volume rm spieli_pgdata spieli_pgdata2 spieli_pbf_cache 2>/dev/null || true
+```
+
+## 2a. Remove the shared proxy network (data-node installs only)
+
+If you ran the nginx installer in **data-node** mode, a shared Docker network was created:
+
+```bash
+docker network rm spieli-proxy 2>/dev/null || true
+```
 
 ## 3. Remove Docker images (optional)
 


### PR DESCRIPTION
## Summary

- nginx installer now prompts for deployment mode: `data-node-ui` (full stack, proxy to app port 8080) or `data-node` (API only, proxy PostgREST port 3000 with CORS)
- Adds a shared Docker network (`spieli-proxy`) so the nginx container can reach PostgREST by service name — no port 3000 exposure needed
- Fixes `install-nginx.sh` `BASE_URL` pointing at dev branch instead of `main`
- Fixes uninstall docs: `--remove-orphans`, container-prune step for volume-in-use errors, and `spieli-proxy` network cleanup

Closes #442

## Test plan

- [x] data-node-ui mode: nginx proxies to `host.docker.internal:8080` (app container)
- [x] data-node mode: nginx proxies to `postgrest:3000` via shared network (tested on VPS)
- [ ] Fresh install with `install-nginx.sh` in both modes
- [ ] Uninstall removes all containers, volumes, and network

🤖 Generated with [Claude Code](https://claude.com/claude-code)