### PR TITLE
docs: enable copy button on code blocks (#446)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ theme:
     - navigation.top
     - search.highlight
     - content.action.edit
+    - content.code.copy
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary

- Add `content.code.copy` to MkDocs Material features — puts a clipboard icon on every code block

## Why

Without it, users manually select text from code blocks. MkDocs Material wraps long lines visually (no horizontal scroll by default), so the selection includes the visual line break as a real newline — breaking long `curl` commands when pasted into a terminal.

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)