### PR TITLE
fix(installer): fix bold escape codes printing literally in mode confirmation (#448)

### DIFF
--- a/deploy/nginx/install-nginx.sh
+++ b/deploy/nginx/install-nginx.sh
@@ -58,7 +58,7 @@ choose_mode() {
             *) warn "Please enter 1 or 2." ;;
         esac
     done
-    success "Mode: ${NGINX_MODE}"
+    printf "${GREEN}✓${RESET}  Mode: ${BOLD}%s${RESET}\n" "$NGINX_MODE"
 }
 
 # ── Dependency check ───────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ choose_mode() {
             *) warn "Invalid choice — please enter 1, 2, or 3." ;;
         esac
     done
-    success "Deployment mode: ${BOLD}${DEPLOY_MODE}${RESET}"
+    printf "${GREEN}✓${RESET}  Deployment mode: ${BOLD}%s${RESET}\n" "$DEPLOY_MODE"
 }
 
 # ── Dependency check ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `install.sh` and `install-nginx.sh` both pass `${BOLD}${MODE}${RESET}` as a `%s` argument to `printf` via `success()`. `printf %s` treats its arguments literally — escape sequences are only interpreted in the format string itself.
- Fix: use `printf` directly with `${BOLD}%s${RESET}` in the format string and the mode value as the `%s` argument.

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)