### PR TITLE
fix(nginx): create spieli-proxy network if missing before starting stack (#450)

### DIFF
--- a/deploy/nginx/install-nginx.sh
+++ b/deploy/nginx/install-nginx.sh
@@ -101,6 +101,12 @@ fi
 
 success "Files downloaded to $DEPLOY_DIR."
 
+# ── Ensure shared proxy network exists ────────────────────────────────────────
+
+if [[ "$NGINX_MODE" == "data-node" ]]; then
+    docker network create spieli-proxy 2>/dev/null || true
+fi
+
 # ── Step 1: start nginx with HTTP-only config for ACME challenge ───────────────
 
 info "Starting nginx (HTTP only) for certificate issuance..."


### PR DESCRIPTION
## Summary

- In data-node mode, `docker-compose.yml` declares `spieli-proxy` as an external network
- If the spieli stack hasn't been started yet when `install-nginx.sh` runs, the network doesn't exist → `docker compose up` fails with "network could not be found"
- Fix: `install-nginx.sh` creates the network before starting nginx in data-node mode — whichever stack runs first creates it, the other just joins

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)