### PR TITLE
fix(reviews): scope Mangrove subject to OSM ID, fix NaN average

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -66,6 +66,9 @@
    */
   export let dataContribLinks;
 
+  /** Show hub-specific third-party privacy note in the About modal. */
+  export let isHub = false;
+
   /** Fallback backend URL applied to features that don't carry `_backendUrl`. */
   export let defaultBackendUrl = '';
 
@@ -532,6 +535,7 @@
     chatUrl={dataContribLinks.chatUrl}
     {impressumUrl}
     {privacyUrl}
+    {isHub}
   />
 </div>
 

--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -9,6 +9,8 @@
   export let impressumUrl = null;
   /** Privacy policy URL; hidden when null/falsy. */
   export let privacyUrl = null;
+  /** Show hub-specific third-party data note. */
+  export let isHub = false;
 
   function close() { open = false; }
 
@@ -57,6 +59,15 @@
             <a href={privacyUrl} target="_blank" rel="noopener">{$_('legal.datenschutz')} ↗</a>
           {/if}
         </div>
+
+        {#if isHub}
+          <p class="small hub-privacy">
+            {@html $_('modal.addData.hubPrivacyNote', { values: {
+              osmLink: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>',
+              panoramaxLink: '<a href="https://panoramax.openstreetmap.fr/" target="_blank" rel="noopener">Panoramax</a>'
+            } })}
+          </p>
+        {/if}
 
         <p class="version">v{version}</p>
       </div>
@@ -112,6 +123,7 @@
   .modal-body { padding: 1rem; }
 
   .small { font-size: 0.875rem; color: #495057; margin: 0 0 1rem; }
+  .hub-privacy { border-top: 1px solid #dee2e6; padding-top: 0.75rem; color: #6c757d; }
 
   .links {
     display: flex;

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -686,7 +686,7 @@
           </button>
           {#if openSections.has('reviews')}
             <div class="pb-3">
-              <ReviewsPanel lat={centerLat} lon={centerLon} />
+              <ReviewsPanel lat={centerLat} lon={centerLon} osmId={attr?.osm_id} />
             </div>
           {/if}
         </div>

--- a/app/src/components/ReviewsPanel.svelte
+++ b/app/src/components/ReviewsPanel.svelte
@@ -6,6 +6,8 @@
   export let lat = 0;
   /** @type {number} Playground centre longitude (WGS84) */
   export let lon = 0;
+  /** @type {string|number|null} OSM ID of the playground — scopes reviews to this specific location. */
+  export let osmId = null;
 
   let reviews = [];
   let loading = true;
@@ -18,15 +20,19 @@
   let submitting = false;
   let submitStatus = '';       // success/error message
 
-  $: if (lat && lon) loadReviews();
+  let abortCtrl = null;
+
+  $: if (osmId) loadReviews();
 
   async function loadReviews() {
+    abortCtrl?.abort();
+    abortCtrl = new AbortController();
     loading = true;
     error = false;
     try {
-      reviews = await fetchReviews(lat, lon);
-    } catch {
-      error = true;
+      reviews = await fetchReviews(lat, lon, osmId, abortCtrl.signal);
+    } catch (e) {
+      if (e?.name !== 'AbortError') error = true;
     } finally {
       loading = false;
     }
@@ -37,7 +43,7 @@
     submitting = true;
     submitStatus = '';
     try {
-      const ok = await submitReview(lat, lon, selectedRating, opinion.trim() || null);
+      const ok = await submitReview(lat, lon, osmId, selectedRating, opinion.trim() || null);
       if (ok) {
         submitStatus = 'success';
         selectedRating = null;
@@ -54,8 +60,9 @@
   }
 
   $: displayRating = hoverRating ?? selectedRating;
-  $: avgRating = reviews.length
-    ? reviews.reduce((s, r) => s + r.payload.rating, 0) / reviews.length
+  $: ratedReviews = reviews.filter(r => typeof r.payload?.rating === 'number');
+  $: avgRating = ratedReviews.length
+    ? ratedReviews.reduce((s, r) => s + r.payload.rating, 0) / ratedReviews.length
     : null;
 </script>
 
@@ -67,22 +74,26 @@
 
 {:else}
   <!-- Aggregate score card -->
-  {#if reviews.length > 0}
+  {#if ratedReviews.length > 0}
     <div class="review-aggregate">
       <span class="review-score">{(avgRating / 20).toFixed(1)}</span>
       <div>
         {@html starsHtml(avgRating)}
         <span class="text-muted" style="font-size:11px">
-          ({$_('reviews.count', { values: { count: reviews.length } })})
+          ({$_('reviews.count', { values: { count: ratedReviews.length } })})
         </span>
       </div>
     </div>
+  {/if}
 
+  {#if reviews.length > 0}
     {#each reviews as r}
       {@const p = r.payload}
       <div class="review-card">
         <div class="review-card__header">
-          {@html starsHtml(p.rating, '#f59e0b')}
+          {#if typeof p.rating === 'number'}
+            {@html starsHtml(p.rating, '#f59e0b')}
+          {/if}
           <span class="review-date">{relativeDate(p.iat, $_)}</span>
         </div>
         {#if p.opinion}

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -208,6 +208,7 @@
   {getAllBackendUrls}
   onBackendsUpdate={subscribeBackendsForHashRetry}
   {dataContribLinks}
+  isHub={true}
 >
   {#snippet instancePanel()}
     <InstancePanel {backends} {registryError} />

--- a/app/src/lib/reviews.js
+++ b/app/src/lib/reviews.js
@@ -64,16 +64,17 @@ function b64urlBytes(buf) {
 
 // ── Subject URI ────────────────────────────────────────────────────────────
 
-export function mangroveSubject(lat, lon) {
-    return `geo:${lat.toFixed(5)},${lon.toFixed(5)}?q=playground&u=50`;
+export function mangroveSubject(lat, lon, osmId) {
+    const q = osmId ? `osm_playground_${osmId}` : 'playground';
+    return `geo:${lat.toFixed(5)},${lon.toFixed(5)}?q=${q}&u=50`;
 }
 
 // ── Fetch reviews ──────────────────────────────────────────────────────────
 
-export async function fetchReviews(lat, lon) {
-    const sub = mangroveSubject(lat, lon);
+export async function fetchReviews(lat, lon, osmId, signal) {
+    const sub = mangroveSubject(lat, lon, osmId);
     const url = `${MANGROVE_API}/reviews?sub=${encodeURIComponent(sub)}&latest_edits_only=true`;
-    const res = await fetch(url);
+    const res = await fetch(url, { signal });
     if (!res.ok) return [];
     const data = await res.json();
     return (data.reviews ?? []).filter(r => !r.payload?.action);
@@ -81,10 +82,10 @@ export async function fetchReviews(lat, lon) {
 
 // ── Submit review ──────────────────────────────────────────────────────────
 
-export async function submitReview(lat, lon, rating100, opinion) {
+export async function submitReview(lat, lon, osmId, rating100, opinion) {
     const kp  = await loadOrGenerateKeypair();
     const pem = await publicKeyToPem(kp.publicKey);
-    const sub = mangroveSubject(lat, lon);
+    const sub = mangroveSubject(lat, lon, osmId);
 
     const header  = { alg: 'ES256', typ: 'JWT', kid: pem };
     const payload = { iat: Math.floor(Date.now() / 1000), sub, rating: rating100 };

--- a/docs/ops/switch-region.md
+++ b/docs/ops/switch-region.md
@@ -1,0 +1,74 @@
+# Switching regions
+
+This guide covers changing the geographic coverage of a running spieli instance — for example, switching from a Landkreis to a full Bundesland, or expanding to all of Germany.
+
+The process requires a full database re-import. Plan for downtime proportional to the size of the new extract (see [Import duration](#import-duration)).
+
+## 1. Find the new relation ID and PBF extract
+
+**OSM relation ID** — search on [Nominatim](https://nominatim.openstreetmap.org). The relation ID appears in the URL: `openstreetmap.org/relation/51477` → ID is `51477`.
+
+**PBF extract** — browse [download.geofabrik.de](https://download.geofabrik.de) for an extract that covers your target region. The extract only needs to *contain* your region — a country extract works fine for a single Bundesland.
+
+Common extracts:
+
+| Coverage | URL |
+|---|---|
+| Germany | `https://download.geofabrik.de/europe/germany-latest.osm.pbf` |
+| Baden-Württemberg | `https://download.geofabrik.de/europe/germany/baden-wuerttemberg-latest.osm.pbf` |
+| Bayern | `https://download.geofabrik.de/europe/germany/bayern-latest.osm.pbf` |
+| Hessen | `https://download.geofabrik.de/europe/germany/hessen-latest.osm.pbf` |
+| NRW | `https://download.geofabrik.de/europe/germany/nordrhein-westfalen-latest.osm.pbf` |
+
+## 2. Update `.env`
+
+Edit `~/spieli/.env` and change the two region-specific lines:
+
+```env
+OSM_RELATION_ID=51477
+PBF_URL=https://download.geofabrik.de/europe/germany-latest.osm.pbf
+```
+
+## 3. Wipe the database and re-import
+
+**Warning:** This permanently deletes all existing playground data. The import re-downloads the PBF and rebuilds the database from scratch.
+
+```bash
+cd ~/spieli
+
+# Stop the stack
+docker compose --profile data-node-ui down
+
+# Delete the database and cached PBF
+docker volume rm spieli_pgdata spieli_pbf_cache
+
+# Start the stack (initialises a fresh database)
+docker compose --profile data-node-ui up -d
+
+# Run the importer
+docker compose run --rm importer
+```
+
+The app will return empty responses until the import finishes.
+
+## Import duration
+
+Import time scales with extract size and available CPU/RAM:
+
+| Extract | PBF size | Approximate duration |
+|---|---|---|
+| Landkreis (via Bundesland extract) | 0.2–1 GB | 5–20 min |
+| Bundesland | 0.5–2 GB | 10–40 min |
+| Germany | ~4.5 GB | 1–3 h |
+
+Increase `OSM2PGSQL_THREADS` in `.env` to speed up the import on multi-core servers.
+
+## After the import
+
+The app picks up the new data automatically — no restart needed. Verify with:
+
+```bash
+curl -s https://yourdomain.example.com/api/rpc/get_meta | python3 -m json.tool
+```
+
+The `playground_count` and `bbox` fields should reflect the new region.

--- a/locales/de.json
+++ b/locales/de.json
@@ -338,7 +338,8 @@
         "chatLabel": "lokalen OSM-Community-Chat",
         "simpleText": "Fragen und Austausch im",
         "simpleChatLabel": "regionalen Chat"
-      }
+      },
+      "hubPrivacyNote": "Im Hub-Modus werden Daten von mehreren unabhängigen Instanzen geladen. Die jeweiligen Betreiber, {osmLink} sowie {panoramaxLink} können dabei Zugriffsdaten protokollieren."
     },
     "about": {
       "history": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -338,7 +338,8 @@
         "chatLabel": "local OSM community chat",
         "simpleText": "Questions and discussion in the",
         "simpleChatLabel": "local chat"
-      }
+      },
+      "hubPrivacyNote": "In hub mode, data is loaded from multiple independent instances. Their operators, {osmLink}, and {panoramaxLink} may each log access data."
     },
     "about": {
       "history": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Federated Deployment: ops/federated-deployment.md
       - Configuration: ops/configuration.md
       - Upgrading: ops/upgrade.md
+      - Switching Regions: ops/switch-region.md
       - Scheduled Import: ops/scheduled-import.md
       - Backup and Restore: ops/backup-restore.md
       - Monitoring: ops/monitoring.md


### PR DESCRIPTION
## Summary

- `#435` fixed submission 400 errors by adding `?q=playground` to the Mangrove geo URI, but `q=playground` caused the Mangrove API to return **all playground reviews globally** (74 from different countries) instead of per-location ones
- Fix: use `q=osm_playground_<osmId>` — unique per playground, still satisfies the API's `q=` requirement
- NaN average fixed: `avgRating` now computed only from reviews with a numeric `rating`; star display guarded with `typeof p.rating === 'number'`
- Added `AbortController` to cancel stale in-flight requests when the user switches playgrounds quickly

## Breaking change

Existing reviews submitted with `q=playground` won't appear under the new subject URI. Those reviews were already "broken" (showing worldwide reviews for every playground), so this is acceptable.

## Test plan

- [ ] Select a playground → reviews load for that specific location only
- [ ] Switch between several playgrounds → each shows its own reviews, no bleed-over
- [ ] Submit a review → confirm no 400 error
- [ ] Playground with opinion-only (unrated) reviews → no NaN in aggregate score
- [ ] Switch playgrounds quickly → no stale reviews flash from previous selection

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)