### PR TITLE
fix(importer): bake SPIELI_VERSION into image at CI build time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,3 +131,4 @@ jobs:
           push: true
           tags: ${{ steps.meta-importer.outputs.tags }}
           labels: ${{ steps.meta-importer.outputs.labels }}
+          build-args: VERSION=${{ steps.meta-importer.outputs.version }}

--- a/importer/Dockerfile
+++ b/importer/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
+ARG VERSION=dev
+ENV SPIELI_VERSION=${VERSION}
+
 COPY import.sh /import.sh
 COPY api.sql   /api.sql
 RUN chmod +x /import.sh


### PR DESCRIPTION
## Summary

- Add `ARG VERSION=dev` + `ENV SPIELI_VERSION=${VERSION}` to `importer/Dockerfile` so `import.sh`'s `envsubst` picks up the version without operator intervention
- Pass `build-args: VERSION=...` in the `docker-importer` CI job (mirrors the existing `docker` app job)

Operators no longer need to set `SPIELI_VERSION` in their `.env`.

## Test plan

- [ ] Merge and tag a release → CI importer image built with correct version baked in
- [ ] Run importer + `make db-apply` → `get_meta` returns correct `version` string
- [ ] Hub drawer shows version badge for backends

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)