### PR TITLE
fix(ops): set DOCKER_API_VERSION=1.47 for Watchtower

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -85,6 +85,7 @@ services:
     environment:
       WATCHTOWER_POLL_INTERVAL: 86400
       WATCHTOWER_CLEANUP: "true"
+      DOCKER_API_VERSION: "1.47"
     restart: unless-stopped
 
   # ── PostgREST — auto-generates REST API from the api schema ─────────────────


### PR DESCRIPTION
fix #476 