### PR TITLE
fix(hub): remove Neuhof dev fixture from default registry.json (#478)

### DIFF
--- a/app/public/registry.json
+++ b/app/public/registry.json
@@ -1,14 +1,9 @@
 {
   "instances": [
     {
-      "slug": "fulda",
+      "slug": "local",
       "url":  "/api",
-      "name": "Fulda"
-    },
-    {
-      "slug": "neuhof",
-      "url":  "/api2",
-      "name": "Neuhof"
+      "name": "Local"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Default `registry.json` baked into the image contained both `Fulda (/api)` and `Neuhof (/api2)` — a leftover from local hub dev testing
- Operators switching `APP_MODE=hub` without a custom `registry.json` saw a phantom Neuhof backend appear
- Replace with a single generic `Local` entry pointing at `/api`

## Test plan

- [ ] Build image, set `APP_MODE=hub`, start without custom `registry.json` — only one backend ("Local") should appear in the instance drawer
- [ ] Hub with a bind-mounted `registry.json` still overrides the default correctly

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)