### PR TITLE
docs(ops): rewrite scheduled-import.md — lead with daemon mode (#474)

### DIFF
--- a/docs/ops/scheduled-import.md
+++ b/docs/ops/scheduled-import.md
@@ -2,70 +2,61 @@
 
 Geofabrik publishes updated OSM extracts daily. Running the importer on a schedule keeps your playground data fresh without manual intervention.
 
-spieli ships systemd unit files in `deploy/` for automated weekly imports on Linux servers.
+## Daemon mode (recommended)
 
-## Using the bundled systemd units
+The importer container has a built-in daemon mode: set `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` in `.env` and the container loops forever, re-importing at a random interval within that range. No host cron, no systemd unit — the container manages its own schedule.
 
-### 1. Copy the unit files
+```env
+REIMPORT_INTERVAL_MIN_DAYS=6
+REIMPORT_INTERVAL_MAX_DAYS=8
+```
+
+A random interval in `[MIN, MAX]` days is chosen after each successful import, spreading load across operators who deploy at similar times. When the importer container restarts (e.g. after a Watchtower image update), it checks the last import timestamp in the database — if a recent import is on record, it sleeps the remaining interval rather than re-importing immediately.
+
+!!! note "When both vars are unset (default)"
+    The importer runs once and exits (one-shot mode). Use this when you manage scheduling externally (systemd, cron).
+
+### Enabling daemon mode
+
+Add the two vars to `.env`:
+
+```env
+REIMPORT_INTERVAL_MIN_DAYS=6
+REIMPORT_INTERVAL_MAX_DAYS=8
+```
+
+Then restart the importer so it picks up the new env:
 
 ```bash
-sudo cp deploy/spieli-import.service /etc/systemd/system/
-sudo cp deploy/spieli-import.timer   /etc/systemd/system/
+docker compose -f compose.prod.yml --profile data-node-ui restart importer
 ```
 
-### 2. Configure the service
-
-Open `/etc/systemd/system/spieli-import.service` and set:
-
-- **`WorkingDirectory=`** — the directory where your `compose.prod.yml` and `.env` live (e.g. `/opt/spieli`)
-- **`EnvironmentFile=`** — path to your `.env` file (should match `WorkingDirectory` + `/.env`)
-- **`User=`** — uncomment and set to the user that owns the deployment directory and is in the `docker` group
-
-The `ExecStart` command runs `docker compose run --rm importer` using whichever `DEPLOY_MODE` is set in your `.env`. Both `data-node` and `data-node-ui` profiles include the importer container.
-
-### 3. Configure the timer
-
-The default timer (`spieli-import.timer`) fires weekly on Sunday at 04:00. To change the schedule, edit `OnCalendar=`:
-
-```ini
-[Timer]
-OnCalendar=Sun 04:00      # weekly, Sunday 4 AM
-# OnCalendar=daily         # every day at midnight
-# OnCalendar=*-*-* 03:30  # every day at 3:30 AM
-```
-
-See `man systemd.time` for the full calendar syntax.
-
-### 4. Enable and start the timer
+Check that it entered daemon mode:
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now spieli-import.timer
+docker compose -f compose.prod.yml logs importer | grep -i daemon
+# [importer] Daemon mode: interval 6–8 days.
 ```
 
-Verify:
+## Automatic image updates with Watchtower
+
+Watchtower complements daemon mode: it pulls updated spieli images daily and restarts the affected containers. The importer's startup grace check (see above) prevents an unplanned re-import on Watchtower-triggered restarts.
+
+Enable Watchtower by including the `auto-update` profile:
 
 ```bash
-systemctl status spieli-import.timer
-systemctl list-timers spieli-import.timer
+docker compose -f compose.prod.yml --profile data-node-ui --profile auto-update up -d
 ```
 
-### 5. Test a manual run
-
-```bash
-sudo systemctl start spieli-import.service
-journalctl -u spieli-import.service -f
-```
-
-The import typically finishes in 20–30 seconds (PBF cached), or 2–5 minutes on the first run.
+Or add `auto-update` to any existing `up` invocation. Watchtower polls Docker Hub every 24 hours and cleans up old images automatically.
 
 ## How long does an import take?
 
 | Scenario | Typical duration |
 |---|---|
-| First run, PBF not cached | 2–5 min (dominated by ~300 MB download) |
-| First run, PBF already cached | 30–60 s |
-| Re-run, both filtered PBFs cached | 20–30 s |
+| First run, PBF not cached | download time + 2–5 min |
+| First run, PBF cached | 2–5 min |
+| Re-run, filtered PBFs cached | 30–60 s for small regions; 30+ min for large (e.g. all of Germany) |
 
 All three files (source PBF, bbox-clipped PBF, tag-filtered PBF) are stored in the `pbf_cache` Docker volume and reused automatically. Only the final osm2pgsql + api.sql step runs every time.
 
@@ -74,22 +65,54 @@ All three files (source PBF, bbox-clipped PBF, tag-filtered PBF) are stored in t
 Geofabrik refreshes most regional extracts daily. The importer stores two timestamps in the database:
 
 - **`last_import_at`** — when the importer script ran (visible via `GET /api/rpc/get_meta`)
-- **`osm_data_timestamp`** — the `osmosis_replication_timestamp` header from the source PBF file, which reflects when Geofabrik last generated that extract (can be up to a week old for less-trafficked regions)
+- **`osm_data_timestamp`** — the `osmosis_replication_timestamp` header from the source PBF, which reflects when Geofabrik generated that extract (can be up to a week old for less-trafficked regions)
 
 Both are surfaced in [Monitoring → `/federation-status.json`](monitoring.md).
 
-## Without systemd (Docker-based scheduler)
+## Without daemon mode (host-managed scheduling)
 
-If your host does not use systemd, you can schedule imports using the host's cron:
+If you prefer external scheduling, leave `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` unset. The importer exits with code 0 after a successful one-shot run.
+
+### systemd timer
+
+spieli ships unit files in `deploy/` for Linux hosts with systemd:
+
+```bash
+sudo cp deploy/spieli-import.service /etc/systemd/system/
+sudo cp deploy/spieli-import.timer   /etc/systemd/system/
+```
+
+Open `/etc/systemd/system/spieli-import.service` and set:
+
+- `WorkingDirectory=` — directory where `compose.prod.yml` and `.env` live (e.g. `/opt/spieli`)
+- `EnvironmentFile=` — path to `.env` (usually `WorkingDirectory/.env`)
+- `User=` — user in the `docker` group that owns the deployment directory
+
+The default timer fires weekly on Sunday at 04:00. Change the schedule in `spieli-import.timer`:
+
+```ini
+[Timer]
+OnCalendar=Sun 04:00      # weekly, Sunday 4 AM
+# OnCalendar=daily         # every day at midnight
+# OnCalendar=*-*-* 03:30  # every day at 3:30 AM
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now spieli-import.timer
+systemctl list-timers spieli-import.timer
+```
+
+### Host cron
 
 ```cron
 0 4 * * 0 cd /opt/spieli && docker compose -f compose.prod.yml --profile data-node-ui run --rm importer >> /var/log/spieli-import.log 2>&1
 ```
 
-Or use a scheduled container (e.g. `mcuadros/ofelia`) within the Compose stack.
-
 ## See also
 
-- [Monitoring](monitoring.md) — how to observe import freshness via federation-status and Prometheus
+- [Monitoring](monitoring.md) — observe import freshness via federation-status and Prometheus
 - [Backup and Restore](backup-restore.md) — database backups before major import runs
-- [Configuration reference](configuration.md) — `OSM_RELATION_ID`, `PBF_URL`, `OSM2PGSQL_THREADS`
+- [Configuration reference](configuration.md) — `OSM_RELATION_ID`, `PBF_URL`, `OSM2PGSQL_THREADS`, `REIMPORT_INTERVAL_MIN_DAYS`, `REIMPORT_INTERVAL_MAX_DAYS`


### PR DESCRIPTION
## Summary

- Lead with daemon mode (`REIMPORT_INTERVAL_MIN_DAYS` / `REIMPORT_INTERVAL_MAX_DAYS`) as the recommended path
- Add Watchtower as a complementary container-native tool alongside daemon mode
- Demote systemd and cron to a "without daemon mode" fallback section
- Fix timing table: small regions 30–60 s, large regions 30+ min (was wrong "20–30 s")

## Test plan

- [ ] Docs build without broken links (`make docs-build`)
- [ ] Daemon mode section accurately reflects `import.sh` behavior (both MIN and MAX must be set)

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)