### PR TITLE
docs(ops): replace make commands with docker compose equivalents (#475)

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -53,8 +53,7 @@ docker compose --profile data-node-ui up -d db
 gunzip -c spieli-backup-20260501.sql.gz | docker compose exec -T db psql -U osm osm
 
 # Apply the API schema (recreates PostgREST functions + materialised view)
-docker compose --profile data-node-ui run --rm importer
-# or: make db-apply  (if running from a source clone)
+docker compose -f compose.prod.yml --profile data-node-ui run --rm importer
 
 # Restart the full stack
 docker compose --profile data-node-ui up -d

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -9,7 +9,7 @@ All variables are set in `.env` (copy from `.env.example`). The installer genera
 | `DEPLOY_MODE` | — | — | Deployment mode: `data-node`, `ui`, or `data-node-ui`. Written by the installer. |
 | `APP_MODE` | `standalone` | both | App mode: `standalone` (regional map) or `hub` (aggregation map). `hub` requires `REGISTRY_URL` and must be paired with `DEPLOY_MODE=ui`. See [Federated Deployment](federated-deployment.md). |
 | `OSM_RELATION_ID` | `62700` | data-node, data-node-ui | OSM relation ID of the region to display |
-| `OSM_RELATION_ID2` | `454881` | dev only | OSM relation ID for the second local backend (`db2`); used by `make import2` / `make seed-load2` |
+| `OSM_RELATION_ID2` | `454881` | dev only | OSM relation ID for the second local backend (`db2`); used by `make import2` / `make seed-load2` (source clone only) |
 | `PBF_URL` | Hessen extract | data-node, data-node-ui | Geofabrik `.osm.pbf` download URL |
 | `REGISTRY_URL` | `/registry.json` | hub | URL of the registry JSON listing backends. Default is same-origin; bind-mount or bake in a custom file. See [Federated Deployment](federated-deployment.md) and [`registry.json` reference](../reference/registry-json.md). |
 | `API_BASE_URL` | `/api` | ui, data-node-ui | Base URL of the PostgREST API. Set to the remote URL for `ui` mode (e.g. `https://data.example.com/api`). |
@@ -28,11 +28,14 @@ All variables are set in `.env` (copy from `.env.example`). The installer genera
 | `PG_MAINTENANCE_WORK_MEM` | `256MB` | data-node, data-node-ui | Memory per maintenance operation (index builds etc.). Total peak ≈ `value × (PG_MAX_PARALLEL_MAINTENANCE_WORKERS + 1)`. **Must include a unit suffix** (`kB`, `MB`, `GB`, `TB`); a bare integer is interpreted as kilobytes by PostgreSQL. |
 | `PG_WORK_MEM` | `32MB` | data-node, data-node-ui | Memory per sort/hash operation inside parallel workers. Total peak per query ≈ `value × (PG_MAX_PARALLEL_WORKERS_PER_GATHER + 1) × hash/sort nodes`. **Must include a unit suffix** (`kB`, `MB`, `GB`, `TB`); a bare integer is interpreted as kilobytes by PostgreSQL. |
 
-> **How `PG_*` values are applied.** `make db-apply` (and `make import`) runs
-> `ALTER SYSTEM SET …` at the top of `api.sql`, then `SELECT pg_reload_conf()`.
-> The values are persisted to `postgresql.auto.conf` inside the data volume
-> and apply to every connection — including PostgREST — without restarting
-> the database container. To re-tune, edit `.env` and run `make db-apply`.
+> **How `PG_*` values are applied.** The importer runs `ALTER SYSTEM SET …`
+> at the top of `api.sql`, then `SELECT pg_reload_conf()`. The values are
+> persisted to `postgresql.auto.conf` inside the data volume and apply to
+> every connection — including PostgREST — without restarting the database
+> container. To re-tune, edit `.env` and re-run the importer:
+> ```bash
+> docker compose -f compose.prod.yml --profile <mode> run --rm importer
+> ```
 
 ### RAM sizing
 
@@ -69,8 +72,14 @@ so the budget is the larger of the two plus baseline (~700 MB for
 | `PRIVACY_URL` | *(unset)* | ui, data-node-ui | Override URL for an existing Datenschutzerklärung page. When set, the generated `datenschutz.html` is skipped. |
 
 > **Legal pages — two-step update.** Changing `IMPRESSUM_*` or `SITE_URL` requires two steps to take full effect:
-> 1. `make docker-build` — rebuilds the app container; `docker-entrypoint.sh` regenerates `impressum.html` / `datenschutz.html` and updates `config.js`.
-> 2. `make db-apply` — re-applies `api.sql` so `get_meta()` returns the updated `impressum_url` / `privacy_url`. Run with the vars exported: `set -a && source .env && set +a && make db-apply`.
+> 1. Restart the app container — `docker-entrypoint.sh` regenerates `impressum.html` / `datenschutz.html` and updates `config.js`:
+>    ```bash
+>    docker compose -f compose.prod.yml --profile <mode> up -d app
+>    ```
+> 2. Re-run the importer to update `get_meta()` — legal URLs are baked into the database at import time:
+>    ```bash
+>    docker compose -f compose.prod.yml --profile <mode> run --rm importer
+>    ```
 
 ## Compose profiles
 

--- a/docs/ops/federated-deployment.md
+++ b/docs/ops/federated-deployment.md
@@ -149,7 +149,7 @@ Compose **does not** auto-merge `compose.override.yml` when you pass `-f compose
 
 **Option B — custom image**
 
-Build your own image from source with your `registry.json` placed at `app/public/registry.json` before `make docker-build`. No override file needed in this case.
+Build your own image from source with your `registry.json` placed at `app/public/registry.json` before building. No override file needed in this case. (Source clone required — skip if using pre-built images.)
 
 ### Start the Hub
 

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Port 8080 is already in use
 
-**Symptom:** `make up` fails with `address already in use` or `port is already allocated`.
+**Symptom:** `docker compose up` fails with `address already in use` or `port is already allocated`.
 
 **Fix:** Stop whatever is using port 8080, or change the port in `.env`:
 
@@ -10,7 +10,11 @@
 APP_PORT=8081
 ```
 
-Then run `make up` again.
+Then restart the stack:
+
+```bash
+docker compose -f compose.prod.yml --profile <mode> up -d
+```
 
 ---
 
@@ -36,9 +40,12 @@ If you are using the local development setup, `make import` is equivalent. If th
 
 **Possible causes:**
 
-1. **Import not run** — Run the importer after starting the stack (`docker compose --profile <mode> run --rm importer`, or `make import` for local dev). Playground data is not loaded automatically.
+1. **Import not run** — Run the importer after starting the stack. Playground data is not loaded automatically:
+   ```bash
+   docker compose -f compose.prod.yml --profile <mode> run --rm importer
+   ```
 2. **Wrong relation ID** — Check `OSM_RELATION_ID` in `.env`. An incorrect ID filters out all playgrounds. Verify at [nominatim.openstreetmap.org](https://nominatim.openstreetmap.org).
-3. **Docker stack not running** — The app requires a live PostgREST backend. Confirm the stack is running and healthy before starting `make dev`.
+3. **Docker stack not running** — The app requires a live PostgREST backend. Confirm the stack is running and healthy (`docker compose ps`).
 4. **Browser cache** — Try a hard reload: `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac).
 
 ---
@@ -59,6 +66,9 @@ If you are using the local development setup, `make import` is equivalent. If th
 
 ## Dev server starts but changes don't appear
 
+!!! note "Source-clone / local dev only"
+    This section applies when running the Vite dev server (`make dev`) from a source clone. Skip if using pre-built images.
+
 **Symptom:** You edited a JS or CSS file, but the browser still shows the old version.
 
 **Fix:** Vite hot-reload should pick up changes automatically. If it doesn't:
@@ -67,14 +77,20 @@ If you are using the local development setup, `make import` is equivalent. If th
 2. Try a hard reload: `Ctrl+Shift+R` / `Cmd+Shift+R`.
 3. If you changed `index.html` or a file in `public/`, stop and restart `make dev`.
 
-!!! note
-    When testing via `make docker-build` (the Docker stack), you must run `make docker-build` again after every change — there is no hot-reload in that mode.
+When testing against the Docker stack, rebuild and restart the app container after changes:
+
+```bash
+docker compose -f compose.prod.yml --profile <mode> up -d --build app
+```
 
 ---
 
-## `make lan-url` prints "Could not detect LAN IP"
+## LAN IP for mobile testing
 
-**Fix:** Run this command directly and use the output as your LAN IP:
+!!! note "Source-clone / local dev only"
+    `make lan-url` is only available from a source clone. Skip if using pre-built images.
+
+Run this command to find your LAN IP:
 
 ```bash
 ip route get 1 | awk '{print $7; exit}'
@@ -92,7 +108,7 @@ Then open `http://<that-ip>:8080` on your phone.
 
 1. **PostgREST container not running** — Check `docker compose ps`. The `postgrest` service should be running and healthy.
 2. **Database not ready** — PostgREST starts before PostgreSQL finishes initialising on first launch. It retries automatically, but a `docker compose restart postgrest` usually resolves it.
-3. **Schema cache stale** — After running `make db-apply`, PostgREST needs a schema reload. The apply script sends `NOTIFY pgrst, 'reload schema'` automatically, but if that notification was missed, restart PostgREST: `docker compose restart postgrest`.
+3. **Schema cache stale** — After applying schema changes, PostgREST needs a schema reload. The importer sends `NOTIFY pgrst, 'reload schema'` automatically, but if that notification was missed, restart PostgREST: `docker compose restart postgrest`.
 4. **`web_anon` role missing** — `db/init.sql` creates this role on first init. If you deleted and recreated the `pgdata` volume without re-running init.sql (e.g. by running `docker volume rm` but not recreating via `docker compose up`), the role is missing. Run `docker compose up -d` to let init.sql re-run, or run it manually.
 
 ---
@@ -129,20 +145,25 @@ The importer validates the source PBF with `osmium fileinfo` before using it and
 
 ---
 
-## `make db-apply` fails with "permission denied"
+## Importer fails with "permission denied" on schema apply
 
-**Symptom:** `psql` reports `permission denied` when running `api.sql`.
+**Symptom:** `psql` reports `permission denied` when the importer runs `api.sql`.
 
-**Cause:** The SQL runs as the database user configured in `.env`. This user needs `SUPERUSER` or at minimum `pg_signal_backend` (to terminate PostgREST connections) and `CREATE` on the `public` schema. The default `compose.yml` user (`osm`) is a superuser — if you changed `POSTGRES_USER`, verify the role has these privileges.
+**Cause:** The SQL runs as the database user configured in `.env`. This user needs `SUPERUSER` or at minimum `pg_signal_backend` (to terminate PostgREST connections) and `CREATE` on the `public` schema. The default user (`osm`) is a superuser — if you changed `POSTGRES_USER`, verify the role has these privileges.
 
 **Fix:**
 
 ```bash
-make db-shell
+docker compose -f compose.prod.yml exec db psql -U osm osm
 # in psql:
 ALTER ROLE your_user SUPERUSER;
 \q
-make db-apply
+```
+
+Then re-run the importer:
+
+```bash
+docker compose -f compose.prod.yml --profile <mode> run --rm importer
 ```
 
 ---
@@ -156,10 +177,7 @@ make db-apply
 **Fix:** Run VACUUM FULL (briefly locks the table):
 
 ```bash
-make db-shell
-# in psql:
-VACUUM FULL public.playground_stats;
-\q
+docker compose -f compose.prod.yml exec db psql -U osm osm -c "VACUUM FULL public.playground_stats;"
 ```
 
 Or simply recreate the data volume after a re-import — the volume will start clean.
@@ -198,16 +216,16 @@ The Hub will pick up the corrected value on its next poll cycle (within 60 secon
 
 **Cause:** The HTML files are generated by `docker-entrypoint.sh` at container startup. A rebuild is required to pick up changed env vars.
 
-**Fix:**
+**Fix:** Restart the app container to regenerate legal pages from current env vars:
 
 ```bash
-make docker-build   # rebuilds and restarts the app container
+docker compose -f compose.prod.yml --profile <mode> up -d app
 ```
 
-If `get_meta()` still returns the old `impressum_url` / `privacy_url` after the rebuild, also re-apply the DB schema (legal URLs are baked in at import time via envsubst):
+If `get_meta()` still returns the old `impressum_url` / `privacy_url`, the legal URLs are baked into the database at import time. Re-run the importer to apply them:
 
 ```bash
-set -a && source .env && set +a && make db-apply
+docker compose -f compose.prod.yml --profile <mode> run --rm importer
 ```
 
 **Symptom:** `/impressum` returns 404 despite `IMPRESSUM_NAME` being set.

--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -25,33 +25,21 @@ docker compose -f compose.prod.yml pull
 # Restart app container (zero-database-downtime)
 docker compose -f compose.prod.yml --profile <mode> up -d app
 
-# If the API SQL changed (check the release notes):
+# If the API SQL changed (check the release notes), re-run the importer:
 docker compose -f compose.prod.yml --profile <mode> run --rm importer
-# or just apply the schema change without a full re-import:
-make db-apply    # only if running from source clone
 ```
 
 Replace `<mode>` with your `DEPLOY_MODE` (`data-node`, `ui`, or `data-node-ui`).
 
 ## When to run a full re-import
 
-A full re-import (`docker compose run --rm importer`) is needed when:
+A full re-import (`docker compose -f compose.prod.yml --profile <mode> run --rm importer`) is needed when:
 
-- The release notes say "run `make db-apply` or re-import after upgrading"
+- The release notes say "re-import after upgrading"
 - `importer/api.sql` changed in a way that requires rebuilding the `playground_stats` materialised view
-- A new OSM tag type was added to `processing/lua/osm_import.lua` — the new columns won't exist in the existing data until a fresh import
+- A new OSM tag type was added to `processing/lua/osm_import.lua` — the new columns won't exist in existing data until a fresh import
 
-A schema-only update (`make db-apply` / the `db-apply` step of the importer) is safe and fast (seconds) when only PostgREST functions changed, since it drops and recreates functions without touching the `planet_osm_*` tables.
-
-## Applying SQL changes without a full re-import
-
-If you are running from a source clone and only API functions changed:
-
-```bash
-make db-apply
-```
-
-This runs `envsubst < importer/api.sql | psql` against the running database and sends `NOTIFY pgrst, 'reload schema'` to PostgREST. The app continues to serve requests during the apply; PostgREST picks up the new schema within a second of the reload.
+Re-running the importer applies `api.sql` automatically and is safe — it drops and recreates PostgREST functions without touching the `planet_osm_*` tables when OSM data hasn't changed.
 
 ## Upgrading the Docker Compose file
 


### PR DESCRIPTION
## Summary

Ops docs are read by production operators who have no Makefile. Audit and fix all violations in 5 files:

| File | Changes |
|---|---|
| `troubleshooting.md` | Replace `make up/import/db-apply/db-shell/docker-build`; add "source-clone only" callouts for `make dev` / `make lan-url` sections |
| `configuration.md` | Replace `make db-apply` and `make docker-build` in callout notes with `docker compose run --rm importer` and `docker compose up -d app` |
| `backup-restore.md` | Remove `make db-apply (source clone)` comment from restore example |
| `upgrade.md` | Remove standalone `make db-apply` section; consolidate to importer re-run |
| `federated-deployment.md` | Mark `make docker-build` Option B as source-clone-only |

Rule applied: ops context → `docker compose` only. Source-clone-only steps get a `!!! note` callout.

## Test plan

- [ ] `make docs-build` passes with no broken links
- [ ] All `docker compose` commands in the changed files use the correct `compose.prod.yml` and profile flags

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)