### PR TITLE
fix(docs): clarify mode terminology — dev mode and daemon mode

### DIFF
--- a/docs/ops/scheduled-import.md
+++ b/docs/ops/scheduled-import.md
@@ -4,6 +4,9 @@ Geofabrik publishes updated OSM extracts daily. Running the importer on a schedu
 
 ## Daemon mode (recommended)
 
+!!! note "Terminology"
+    "Daemon mode" here refers to the importer container's **scheduling behaviour** — whether it loops and re-imports automatically or exits after one run. This is separate from `DEPLOY_MODE` (which services start) and `APP_MODE` (standalone vs hub frontend).
+
 The importer container has a built-in daemon mode: set `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` in `.env` and the container loops forever, re-importing at a random interval within that range. No host cron, no systemd unit — the container manages its own schedule.
 
 ```env

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -237,7 +237,7 @@ curl 'https://example.com/api/rpc/get_equipment?min_lon=9.70&min_lat=50.53&max_l
 
 Returns pitches, benches, shelters, picnic tables, and fitness stations that do **not** lie within any `leisure=playground` polygon. Used by the standalone pitch layer (`filterStore.standalonePitches`).
 
-Same parameter and response shape as `get_equipment`. Returns an empty `FeatureCollection` when `apiBaseUrl` is empty (Overpass/dev mode).
+Same parameter and response shape as `get_equipment`. Returns an empty `FeatureCollection` when `apiBaseUrl` is empty (Overpass fallback, used in local frontend dev without a database).
 
 **Example**
 
@@ -395,7 +395,7 @@ curl 'https://example.com/api/rpc/get_legal?type=impressum'
 
 ## `get_nearest_playgrounds(lat, lon)`
 
-Returns the nearest playgrounds to a WGS84 point, ordered by distance ascending. Used by the `NearbyPlaygrounds` component. Returns an empty array when `apiBaseUrl` is empty (Overpass/dev mode).
+Returns the nearest playgrounds to a WGS84 point, ordered by distance ascending. Used by the `NearbyPlaygrounds` component. Returns an empty array when `apiBaseUrl` is empty (Overpass fallback, used in local frontend dev without a database).
 
 **Parameters**
 

--- a/install.sh
+++ b/install.sh
@@ -361,7 +361,7 @@ success "Files downloaded."
 
         if [[ "$AUTO_UPDATE" == "true" ]]; then
             printf "# ── Auto-update: re-import interval ─────────────────────────────\n"
-            printf "# The importer will re-run every 2–10 days (randomised) in daemon mode.\n"
+            printf "# The importer will re-run every 2–10 days (randomised) using its built-in daemon scheduling.\n"
             printf "# Watchtower pulls updated images daily (requires --profile auto-update).\n"
             printf "REIMPORT_INTERVAL_MIN_DAYS=2\n"
             printf "REIMPORT_INTERVAL_MAX_DAYS=10\n\n"
@@ -429,7 +429,7 @@ if confirm "Start the stack now?"; then
     if [[ "$DEPLOY_MODE" != "ui" ]]; then
         printf "\n"
         if [[ "$AUTO_UPDATE" == "true" ]]; then
-            success "The importer is running in daemon mode and will begin the first import automatically."
+            success "The importer is running with daemon scheduling and will begin the first import automatically."
             printf "  Monitor progress with: ${CYAN}docker compose -f %s/compose.yml logs -f importer${RESET}\n" \
                 "$DEPLOY_DIR"
         else


### PR DESCRIPTION
## Summary

Three minor terminology ambiguities from the #487 audit. The DEPLOY_MODE vs APP_MODE distinction is already well-documented — only these colloquial terms needed clarification:

- **`api.md` (×2)**: Replace `(Overpass/dev mode)` → `(Overpass fallback, used in local frontend dev without a database)` — "dev mode" is not a defined concept in spieli
- **`install.sh` (×2)**: Replace `daemon mode` → `daemon scheduling` in installer output and generated `.env` comments — avoids confusion with `DEPLOY_MODE`/`APP_MODE`
- **`scheduled-import.md`**: Add a terminology note at the top of the Daemon mode section explicitly stating this refers to importer scheduling behaviour, not `DEPLOY_MODE` or `APP_MODE`

Closes #488, closes #487

## Test plan

- [ ] Docs build cleanly (`make docs-build`)
- [ ] No remaining unqualified "dev mode" references in docs