### PR TITLE
fix(about): move hub privacy notice to datenschutz page, redesign About modal

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -66,9 +66,6 @@
    */
   export let dataContribLinks;
 
-  /** Show hub-specific third-party privacy note in the About modal. */
-  export let isHub = false;
-
   /** Fallback backend URL applied to features that don't carry `_backendUrl`. */
   export let defaultBackendUrl = '';
 
@@ -535,7 +532,6 @@
     chatUrl={dataContribLinks.chatUrl}
     {impressumUrl}
     {privacyUrl}
-    {isHub}
   />
 </div>
 

--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -9,8 +9,6 @@
   export let impressumUrl = null;
   /** Privacy policy URL; hidden when null/falsy. */
   export let privacyUrl = null;
-  /** Show hub-specific third-party data note. */
-  export let isHub = false;
 
   function close() { open = false; }
 
@@ -39,35 +37,41 @@
         <button type="button" class="close-btn" onclick={close} aria-label={$_('info.closeBtn')}>✕</button>
       </div>
       <div class="modal-body">
-        <p class="small">
+        <p class="intro">
           {@html $_('modal.addData.introText', { values: {
             osmLink: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>',
             mapcompleteLink: '<a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>'
           } })}
         </p>
 
-        <div class="links">
-          <a href={osmWikiUrl} target="_blank" rel="noopener">{$_('modal.addData.wikiLinkText')} ↗</a>
+        <div class="link-grid">
+          <a class="link-card" href={osmWikiUrl} target="_blank" rel="noopener">
+            <span class="link-icon">🗺️</span>
+            <span>{$_('modal.addData.wikiLinkText')}</span>
+          </a>
           {#if chatUrl}
-            <a href={chatUrl} target="_blank" rel="noopener">{$_('modal.addData.community.simpleChatLabel')} ↗</a>
+            <a class="link-card" href={chatUrl} target="_blank" rel="noopener">
+              <span class="link-icon">💬</span>
+              <span>{$_('modal.addData.community.simpleChatLabel')}</span>
+            </a>
           {/if}
-          <a href="https://github.com/mfuhrmann/spieli" target="_blank" rel="noopener">{$_('modal.addData.githubLabel')} ↗</a>
+          <a class="link-card" href="https://github.com/mfuhrmann/spieli" target="_blank" rel="noopener">
+            <span class="link-icon">⚙️</span>
+            <span>{$_('modal.addData.githubLabel')}</span>
+          </a>
           {#if impressumUrl}
-            <a href={impressumUrl} target="_blank" rel="noopener">{$_('legal.impressum')} ↗</a>
+            <a class="link-card" href={impressumUrl} target="_blank" rel="noopener">
+              <span class="link-icon">📋</span>
+              <span>{$_('legal.impressum')}</span>
+            </a>
           {/if}
           {#if privacyUrl}
-            <a href={privacyUrl} target="_blank" rel="noopener">{$_('legal.datenschutz')} ↗</a>
+            <a class="link-card" href={privacyUrl} target="_blank" rel="noopener">
+              <span class="link-icon">🔒</span>
+              <span>{$_('legal.datenschutz')}</span>
+            </a>
           {/if}
         </div>
-
-        {#if isHub}
-          <p class="small hub-privacy">
-            {@html $_('modal.addData.hubPrivacyNote', { values: {
-              osmLink: '<a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>',
-              panoramaxLink: '<a href="https://panoramax.openstreetmap.fr/" target="_blank" rel="noopener">Panoramax</a>'
-            } })}
-          </p>
-        {/if}
 
         <p class="version">v{version}</p>
       </div>
@@ -91,62 +95,82 @@
 
   .modal-box {
     background: #fff;
-    border-radius: 6px;
-    width: min(90vw, 440px);
+    border-radius: 10px;
+    width: min(92vw, 420px);
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 4px 24px rgba(0,0,0,0.2);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.22);
   }
 
   .modal-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid #dee2e6;
+    padding: 1rem 1.125rem 0.75rem;
+    border-bottom: 1px solid #f0f0f0;
   }
 
-  .modal-title { margin: 0; font-size: 1rem; font-weight: 600; }
+  .modal-title { margin: 0; font-size: 1rem; font-weight: 700; color: #1a1a1a; }
 
   .close-btn {
     background: none;
     border: none;
     font-size: 1rem;
     line-height: 1;
-    color: #6c757d;
+    color: #9ca3af;
     cursor: pointer;
     padding: 0.25rem;
     border-radius: 4px;
   }
-  .close-btn:hover { color: #000; background: #f0f0f0; }
+  .close-btn:hover { color: #111; background: #f3f4f6; }
 
-  .modal-body { padding: 1rem; }
+  .modal-body { padding: 1rem 1.125rem; }
 
-  .small { font-size: 0.875rem; color: #495057; margin: 0 0 1rem; }
-  .hub-privacy { border-top: 1px solid #dee2e6; padding-top: 0.75rem; color: #6c757d; }
-
-  .links {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-    margin-bottom: 1rem;
-  }
-
-  .links a {
+  .intro {
     font-size: 0.875rem;
-    color: #6c757d;
+    color: #374151;
+    margin: 0 0 1.125rem;
+    line-height: 1.55;
   }
-  .links a:hover { color: #343a40; }
+
+  .link-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin-bottom: 1.125rem;
+  }
+
+  .link-card {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    border-radius: 7px;
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    font-size: 0.8125rem;
+    color: #374151;
+    text-decoration: none;
+    transition: background 0.12s, border-color 0.12s;
+  }
+  .link-card:hover {
+    background: #fff3e8;
+    border-color: #ed7014;
+    color: #c05e0f;
+  }
+
+  .link-icon { font-size: 1rem; flex-shrink: 0; }
 
   .version {
-    font-size: 0.75rem;
-    color: #adb5bd;
+    font-size: 0.7rem;
+    color: #9ca3af;
     margin: 0;
+    text-align: right;
   }
 
   .modal-footer {
-    padding: 0.5rem 1rem;
-    border-top: 1px solid #dee2e6;
+    padding: 0.625rem 1.125rem;
+    border-top: 1px solid #f0f0f0;
     display: flex;
     justify-content: flex-end;
   }
@@ -155,10 +179,12 @@
     background: #ed7014;
     color: #fff;
     border: none;
-    border-radius: 4px;
-    padding: 0.25rem 0.75rem;
+    border-radius: 6px;
+    padding: 0.375rem 1rem;
     font-size: 0.875rem;
+    font-weight: 600;
     cursor: pointer;
+    transition: background 0.12s;
   }
   .ok-btn:hover { background: #d16212; }
 </style>

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -213,7 +213,6 @@
   {getAllBackendUrls}
   onBackendsUpdate={subscribeBackendsForHashRetry}
   {dataContribLinks}
-  isHub={true}
 >
   {#snippet instancePanel()}
     <InstancePanel {backends} {registryError} />

--- a/locales/de.json
+++ b/locales/de.json
@@ -338,8 +338,7 @@
         "chatLabel": "lokalen OSM-Community-Chat",
         "simpleText": "Fragen und Austausch im",
         "simpleChatLabel": "regionalen Chat"
-      },
-      "hubPrivacyNote": "Im Hub-Modus werden Daten von mehreren unabhängigen Instanzen geladen. Die jeweiligen Betreiber, {osmLink} sowie {panoramaxLink} können dabei Zugriffsdaten protokollieren."
+      }
     },
     "about": {
       "history": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -338,8 +338,7 @@
         "chatLabel": "local OSM community chat",
         "simpleText": "Questions and discussion in the",
         "simpleChatLabel": "local chat"
-      },
-      "hubPrivacyNote": "In hub mode, data is loaded from multiple independent instances. Their operators, {osmLink}, and {panoramaxLink} may each log access data."
+      }
     },
     "about": {
       "history": {

--- a/oci/app/datenschutz.template.html
+++ b/oci/app/datenschutz.template.html
@@ -30,6 +30,7 @@
   <h2>Fotos (Panoramax)</h2>
   <p>Sofern zu einem Spielplatz Fotos verfügbar sind, werden diese vom Dienst <a href="https://panoramax.xyz/" target="_blank" rel="noopener">Panoramax</a> geladen. Beim Aufruf dieser Inhalte gelten die Datenschutzbestimmungen von Panoramax.</p>
 
+{{HUB_PRIVACY_SECTION}}
   <h2>Standortbestimmung</h2>
   <p>Die Standortfunktion des Browsers wird nur auf ausdrücklichen Wunsch der Nutzenden aktiviert. Der ermittelte Standort wird nicht gespeichert und nicht an Dritte weitergegeben.</p>
 

--- a/oci/app/docker-entrypoint.sh
+++ b/oci/app/docker-entrypoint.sh
@@ -112,13 +112,32 @@ fi
 
 if [ -z "${PRIVACY_URL:-}" ]; then
     if [ -n "$SAFE_IMP_NAME" ] && [ -n "$SAFE_IMP_EMAIL" ] && [ -f /datenschutz.template.html ]; then
+        # Build hub privacy section into a temp file; awk inlines it at
+        # {{HUB_PRIVACY_SECTION}} — avoids sed multiline / & escaping issues.
+        HUB_SECTION_FILE=$(mktemp)
+        if [ "$APP_MODE" = "hub" ]; then
+            cat > "$HUB_SECTION_FILE" <<'HUB_HTML'
+  <h2>Hub-Modus: Mehrere Instanzen</h2>
+  <p>Diese Instanz betreibt einen Hub, der Daten von mehreren unabhängigen Backends lädt. Die jeweiligen Betreiber der eingebundenen Instanzen sowie die Dienste <a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a> und <a href="https://panoramax.xyz/" target="_blank" rel="noopener">Panoramax</a> können dabei Zugriffsdaten protokollieren. Die Datenschutzerklärungen der jeweiligen Betreiber sind maßgeblich.</p>
+
+HUB_HTML
+        fi
         # Escape & and / so they are literal in the sed replacement position.
         SAFE_IMP_NAME_FOR_SED=$(printf '%s'  "$SAFE_IMP_NAME"  | sed 's/[\/&]/\\&/g')
         SAFE_IMP_EMAIL_FOR_SED=$(printf '%s' "$SAFE_IMP_EMAIL" | sed 's/[\/&]/\\&/g')
         sed \
             -e "s/{{IMPRESSUM_NAME}}/$SAFE_IMP_NAME_FOR_SED/g" \
             -e "s/{{IMPRESSUM_EMAIL}}/$SAFE_IMP_EMAIL_FOR_SED/g" \
-            /datenschutz.template.html > "$WEBROOT/datenschutz.html"
+            /datenschutz.template.html | \
+        awk -v hubfile="$HUB_SECTION_FILE" '
+            /\{\{HUB_PRIVACY_SECTION\}\}/ {
+                while ((getline line < hubfile) > 0) print line
+                close(hubfile)
+                next
+            }
+            { print }
+        ' > "$WEBROOT/datenschutz.html"
+        rm -f "$HUB_SECTION_FILE"
     else
         {
             printf '<!DOCTYPE html>\n<html lang="de">\n<head>\n'


### PR DESCRIPTION
## Summary

- Removes hub-specific third-party data notice from the About/DataContributionModal — it belongs in the privacy policy, not the about dialog
- Adds `{{HUB_PRIVACY_SECTION}}` placeholder to `datenschutz.template.html`; `docker-entrypoint.sh` fills it with a German-language hub notice when `APP_MODE=hub`, leaves it empty otherwise
- Drops the `isHub` prop chain: `HubApp.svelte` → `AppShell.svelte` → `DataContributionModal.svelte`
- Removes now-unused `modal.addData.hubPrivacyNote` from both locale files
- Redesigns the About modal: plain text link list → 2-column card grid with emoji icons, softer border-radius, stronger box-shadow, bolder title

## Test plan

- [ ] Build passes (`npm run build` in `app/`)
- [ ] About modal shows card grid (OSM wiki, GitHub, community chat, Impressum, Datenschutz)
- [ ] Hub privacy notice absent from About modal in both standalone and hub mode
- [ ] Datenschutz page shows hub privacy section when `APP_MODE=hub`; section absent for `APP_MODE=standalone`

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)