### PR TITLE
fix(equipment): show MapComplete link for each device in collapsed group

### DIFF
--- a/app/src/components/EquipmentList.svelte
+++ b/app/src/components/EquipmentList.svelte
@@ -221,9 +221,13 @@
               <div class="device-detail">
                 {#if uuids.length}
                   <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
-                {:else}
-                  <MapCompleteLink href={firstDetail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
+                {#each items as f (f.properties.osm_id)}
+                  {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
+                  {#if !detail.panoramaxUuid}
+                    <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                  {/if}
+                {/each}
               </div>
             {/if}
           </li>
@@ -273,9 +277,13 @@
               <div class="device-detail">
                 {#if uuids.length}
                   <PanoramaxViewer {uuids} mcUrl={firstDetail.mcUrl} />
-                {:else}
-                  <MapCompleteLink href={firstDetail.mcUrl} label={$_('popup.addPhoto')} />
                 {/if}
+                {#each items as f (f.properties.osm_id)}
+                  {@const detail = getEquipmentAttributesFromProps(f.properties, $_)}
+                  {#if !detail.panoramaxUuid}
+                    <MapCompleteLink href={detail.mcUrl} label={$_('popup.addPhoto')} />
+                  {/if}
+                {/each}
               </div>
             {/if}
           </li>


### PR DESCRIPTION
Closes #496

## Summary

- Grouped devices (e.g. **3× Rutsche**) now render one MapComplete "add photo" link per device that lacks a photo, instead of a single link pointing to `items[0]` only
- If any photos exist, `PanoramaxViewer` is shown first; MC links are rendered only for devices still missing one
- Same fix applied to the `fitnessByType` collapsed branch

## Test plan

- [ ] Find a playground with 2+ identical devices (e.g. multiple slides) — expand the group — verify one "add photo" link per device
- [ ] Find a playground where some devices have photos, others don't — verify viewer shows + MC links only for those without photos
- [ ] Single devices (non-collapsed path) unchanged
- [ ] Fitness station group behaves the same way

Tested against full Fulda import via Docker stack (port 8080).