### PR TITLE
fix(search): use current viewport for Nominatim biasing, bounded=1 with fallback

### DIFF
--- a/app/src/components/SearchBar.svelte
+++ b/app/src/components/SearchBar.svelte
@@ -25,18 +25,33 @@
     }
     searching = true;
     try {
-      let url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&addressdetails=1&limit=10`;
+      const base = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(q)}&format=json&addressdetails=1&limit=10`;
       let viewCenterLon = null;
       let viewCenterLat = null;
+      let hits;
       if (regionExtent) {
         const [minLon, minLat, maxLon, maxLat] = regionExtent;
-        url += `&viewbox=${minLon},${minLat},${maxLon},${maxLat}&bounded=0`;
+        const viewboxParam = `&viewbox=${minLon},${minLat},${maxLon},${maxLat}`;
         viewCenterLon = (minLon + maxLon) / 2;
         viewCenterLat = (minLat + maxLat) / 2;
+        // Phase 1: bounded=1 — only results within the current viewport.
+        // Handles common street names that would otherwise be drowned out by
+        // same-named streets in larger cities.
+        const res1 = await fetch(base + viewboxParam + '&bounded=1');
+        if (!res1.ok) throw new Error(`Nominatim error: ${res1.status}`);
+        hits = await res1.json();
+        // Phase 2: fall back to unbounded if the viewport returned nothing —
+        // preserves the ability to search for a city name to navigate there.
+        if (!hits.length) {
+          const res2 = await fetch(base + viewboxParam + '&bounded=0');
+          if (!res2.ok) throw new Error(`Nominatim error: ${res2.status}`);
+          hits = await res2.json();
+        }
+      } else {
+        const res = await fetch(base);
+        if (!res.ok) throw new Error(`Nominatim error: ${res.status}`);
+        hits = await res.json();
       }
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`Nominatim error: ${res.status}`);
-      let hits = await res.json();
       if (viewCenterLon !== null) {
         hits = hits.slice().sort((a, b) => {
           const da = (parseFloat(a.lon) - viewCenterLon) ** 2 + (parseFloat(a.lat) - viewCenterLat) ** 2;

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -1,7 +1,7 @@
 <script>
   import VectorSource from 'ol/source/Vector.js';
   import { onDestroy, onMount } from 'svelte';
-  import { get } from 'svelte/store';
+  import { get, readable } from 'svelte/store';
   import { transformExtent, fromLonLat } from 'ol/proj';
 
   import AppShell from '../components/AppShell.svelte';
@@ -44,6 +44,25 @@
     aggregatedBbox,
     fetchNearestAcrossBackends,
   } = createRegistry();
+
+  // Track current map viewport in EPSG:4326 for search biasing — same pattern
+  // as StandaloneApp. aggregatedBbox covers all backends and is far too coarse.
+  const viewportExtent = readable(null, (set) => {
+    let detach = null;
+    const unsub = mapStore.subscribe((map) => {
+      if (detach) { detach(); detach = null; }
+      if (!map) return;
+      const update = () => {
+        const size = map.getSize();
+        if (!size) return;
+        set(transformExtent(map.getView().calculateExtent(size), 'EPSG:3857', 'EPSG:4326'));
+      };
+      map.on('moveend', update);
+      detach = () => map.un('moveend', update);
+      update();
+    });
+    return () => { if (detach) detach(); unsub(); };
+  });
 
   const dataContribLinks = { chatUrl: null };
 
@@ -207,7 +226,7 @@
   playgroundSource={polygonSource}
   {clusterSource}
   {macroSource}
-  searchExtent={aggregatedBbox}
+  searchExtent={viewportExtent}
   nearestFetcher={fetchNearestAcrossBackends}
   {resolveSlugToBackendUrl}
   {getAllBackendUrls}


### PR DESCRIPTION
Closes #498

## Summary

- **Hub mode:** `searchExtent` was `aggregatedBbox` (fixed union of all backends) — replaced with a viewport-tracking `readable` that mirrors the pattern already used in standalone. Hub users now get results biased toward what is currently visible on screen.

- **All modes:** switched from `bounded=0` (soft hint, easily overridden by Nominatim's global relevance) to a two-phase strategy:
  1. `bounded=1` — only results within the current viewport. Surfaces the local hit for common street names (e.g. "Turmstraße" in Fulda returns the Fulda street, not hits from Frankfurt/Cologne).
  2. Fall back to `bounded=0` if the viewport returns nothing — preserves the ability to type a city name and navigate there from afar.

Client-side distance sort is kept as a secondary ordering step.

## Test plan

- [ ] Standalone: search for a common street name (e.g. "Hauptstraße") — first results should be within the visible map area
- [ ] Standalone: search for a city name outside the region (e.g. "Hamburg") — should still navigate there (bounded=0 fallback)
- [ ] Hub: pan/zoom to a specific area, search — results should reflect current view, not the full federation footprint
- [ ] Geolocation: use locate button, map re-centres, then search — results should be near the new position

Relates to #294, #316.