### PR TITLE
docs(ops): replace compose.prod.yml with compose.yml in operator docs

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -53,7 +53,7 @@ docker compose --profile data-node-ui up -d db
 gunzip -c spieli-backup-20260501.sql.gz | docker compose exec -T db psql -U osm osm
 
 # Apply the API schema (recreates PostgREST functions + materialised view)
-docker compose -f compose.prod.yml --profile data-node-ui run --rm importer
+docker compose --profile data-node-ui run --rm importer
 
 # Restart the full stack
 docker compose --profile data-node-ui up -d

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -34,7 +34,7 @@ All variables are set in `.env` (copy from `.env.example`). The installer genera
 > every connection — including PostgREST — without restarting the database
 > container. To re-tune, edit `.env` and re-run the importer:
 > ```bash
-> docker compose -f compose.prod.yml --profile <mode> run --rm importer
+> docker compose --profile <mode> run --rm importer
 > ```
 
 ### RAM sizing
@@ -74,11 +74,11 @@ so the budget is the larger of the two plus baseline (~700 MB for
 > **Legal pages — two-step update.** Changing `IMPRESSUM_*` or `SITE_URL` requires two steps to take full effect:
 > 1. Restart the app container — `docker-entrypoint.sh` regenerates `impressum.html` / `datenschutz.html` and updates `config.js`:
 >    ```bash
->    docker compose -f compose.prod.yml --profile <mode> up -d app
+>    docker compose --profile <mode> up -d app
 >    ```
 > 2. Re-run the importer to update `get_meta()` — legal URLs are baked into the database at import time:
 >    ```bash
->    docker compose -f compose.prod.yml --profile <mode> run --rm importer
+>    docker compose --profile <mode> run --rm importer
 >    ```
 
 ## Compose profiles
@@ -112,7 +112,7 @@ If you prefer to manage scheduling outside Docker, leave the interval variables 
 
 ```bash
 # one-shot import
-docker compose -f compose.prod.yml --profile data-node run --rm importer
+docker compose --profile data-node run --rm importer
 ```
 
 Example systemd unit files for timer-based scheduling are available in `deploy/`.

--- a/docs/ops/federated-deployment.md
+++ b/docs/ops/federated-deployment.md
@@ -60,8 +60,8 @@ No `APP_MODE`, no `REGISTRY_URL` — the frontend on a data-node runs in its def
 ### Start the backend and import
 
 ```bash
-docker compose -f compose.prod.yml --profile data-node-ui up -d
-docker compose -f compose.prod.yml --profile data-node-ui run --rm importer
+docker compose --profile data-node-ui up -d
+docker compose --profile data-node-ui run --rm importer
 ```
 
 The first command starts `db`, `postgrest`, and the `app` container (which hosts nginx in front of PostgREST). The second runs the importer once — see [Manual Deploy § Step 4](manual-deploy.md#step-4-start-the-stack-and-import-data) for what the import does and how long it takes.
@@ -136,7 +136,7 @@ The Hub's shipped image bundles a default `registry.json` pointing at `/api` (th
 
 **Option A — bind-mount (recommended, no rebuild)**
 
-Drop your file alongside `compose.prod.yml` as `registry.json`. The `compose.prod.yml` app service already has the bind-mount line — uncomment the `volumes:` block:
+Drop your file alongside `compose.yml` as `registry.json`. The `compose.yml` app service already has the bind-mount line — uncomment the `volumes:` block:
 
 ```yaml
 services:
@@ -145,7 +145,7 @@ services:
       - ./registry.json:/usr/share/nginx/html/registry.json:ro
 ```
 
-Then restart the app service: `docker compose -f compose.prod.yml --profile ui up -d`. No rebuild required; nginx serves the file immediately.
+Then restart the app service: `docker compose --profile ui up -d`. No rebuild required; nginx serves the file immediately.
 
 **Option B — custom image**
 
@@ -156,13 +156,13 @@ Build your own image from source with your `registry.json` placed at `app/public
 With Option A (bind-mount):
 
 ```bash
-docker compose -f compose.prod.yml -f compose.override.yml --profile ui up -d
+docker compose -f compose.yml -f compose.override.yml --profile ui up -d
 ```
 
 With Option B (custom image — just the one file):
 
 ```bash
-docker compose -f compose.prod.yml --profile ui up -d
+docker compose --profile ui up -d
 ```
 
 The Hub has no importer, no database, no `run --rm importer` step.
@@ -214,8 +214,8 @@ POSTGRES_PASSWORD=<strong-random-password>
 ```
 
 ```bash
-docker compose -f compose.prod.yml --profile data-node-ui up -d
-docker compose -f compose.prod.yml --profile data-node-ui run --rm importer
+docker compose --profile data-node-ui up -d
+docker compose --profile data-node-ui run --rm importer
 ```
 
 ### Step 2 — Prepare `registry.json` for the Hub
@@ -253,16 +253,16 @@ REGISTRY_URL=/registry.json
 APP_PORT=8080
 ```
 
-Uncomment the `registry.json` bind-mount in `compose.prod.yml` (see [Replace the bundled registry.json](#replace-the-bundled-registryjson-required)), place your `registry.json` next to `compose.prod.yml`, then start:
+Uncomment the `registry.json` bind-mount in `compose.yml` (see [Replace the bundled registry.json](#replace-the-bundled-registryjson-required)), place your `registry.json` next to `compose.yml`, then start:
 
 ```bash
-docker compose -f compose.prod.yml --profile ui up -d
+docker compose --profile ui up -d
 ```
 
 To update `registry.json` later (add/remove a data-node), edit the file and restart only the app container — no rebuild needed:
 
 ```bash
-docker compose -f compose.prod.yml --profile ui restart app
+docker compose --profile ui restart app
 ```
 
 ### Port layout example

--- a/docs/ops/scheduled-import.md
+++ b/docs/ops/scheduled-import.md
@@ -31,13 +31,13 @@ REIMPORT_INTERVAL_MAX_DAYS=8
 Then restart the importer so it picks up the new env:
 
 ```bash
-docker compose -f compose.prod.yml --profile data-node-ui restart importer
+docker compose --profile data-node-ui restart importer
 ```
 
 Check that it entered daemon mode:
 
 ```bash
-docker compose -f compose.prod.yml logs importer | grep -i daemon
+docker compose logs importer | grep -i daemon
 # [importer] Daemon mode: interval 6–8 days.
 ```
 
@@ -48,7 +48,7 @@ Watchtower complements daemon mode: it pulls updated spieli images daily and res
 Enable Watchtower by including the `auto-update` profile:
 
 ```bash
-docker compose -f compose.prod.yml --profile data-node-ui --profile auto-update up -d
+docker compose --profile data-node-ui --profile auto-update up -d
 ```
 
 Or add `auto-update` to any existing `up` invocation. Watchtower polls Docker Hub every 24 hours and cleans up old images automatically.
@@ -87,7 +87,7 @@ sudo cp deploy/spieli-import.timer   /etc/systemd/system/
 
 Open `/etc/systemd/system/spieli-import.service` and set:
 
-- `WorkingDirectory=` — directory where `compose.prod.yml` and `.env` live (e.g. `/opt/spieli`)
+- `WorkingDirectory=` — directory where `compose.yml` and `.env` live (e.g. `/opt/spieli`)
 - `EnvironmentFile=` — path to `.env` (usually `WorkingDirectory/.env`)
 - `User=` — user in the `docker` group that owns the deployment directory
 
@@ -111,7 +111,7 @@ systemctl list-timers spieli-import.timer
 ### Host cron
 
 ```cron
-0 4 * * 0 cd /opt/spieli && docker compose -f compose.prod.yml --profile data-node-ui run --rm importer >> /var/log/spieli-import.log 2>&1
+0 4 * * 0 cd /opt/spieli && docker compose --profile data-node-ui run --rm importer >> /var/log/spieli-import.log 2>&1
 ```
 
 ## See also

--- a/docs/ops/security.md
+++ b/docs/ops/security.md
@@ -55,10 +55,10 @@ Caddy handles HTTPS automatically with Let's Encrypt.
 
 ## Restrict database port exposure
 
-The `compose.prod.yml` does not publish the PostgreSQL or PostgREST ports to the host — only the app container's `APP_PORT` is published. Verify with:
+The `compose.yml` does not publish the PostgreSQL or PostgREST ports to the host — only the app container's `APP_PORT` is published. Verify with:
 
 ```bash
-docker compose -f compose.prod.yml ps
+docker compose ps
 ```
 
 The `db` and `postgrest` services should show no host port bindings. If you see `0.0.0.0:5432->5432/tcp`, your database is accessible from the network. Remove the `ports:` entry for the `db` service from your compose file.
@@ -100,7 +100,7 @@ Data-nodes (`data-node-ui` mode) respond with `Access-Control-Allow-Origin: *` o
 
 ## Keeping images up to date
 
-Pin a specific version tag in `compose.prod.yml` and update regularly:
+Pin a specific version tag in `compose.yml` and update regularly:
 
 ```yaml
 image: ghcr.io/mfuhrmann/spieli:0.4.1   # pin a version


### PR DESCRIPTION
## Summary

- Installer saves `compose.prod.yml` as `compose.yml` on the operator's machine — operators never see the `compose.prod.yml` filename
- All operator-facing docs under `docs/ops/` still referenced `compose.prod.yml`, causing confusion
- Replaced all occurrences with `compose.yml` (and dropped redundant `-f compose.yml` flags where Docker Compose finds the file automatically)
- Left `contributing/maintaining.md` unchanged — its two references are in maintainer/repo-structure context where both filenames are correct

Closes #500

## Test plan

- [ ] Grep confirms no `compose.prod.yml` remains in `docs/ops/` or `docs/getting-started/`
- [ ] All commands in changed files use `docker compose` without `-f` (relies on default filename resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)