### PR TITLE
docs(ops): add on-demand OSM data refresh page

### DIFF
--- a/docs/ops/manual-deploy.md
+++ b/docs/ops/manual-deploy.md
@@ -68,6 +68,8 @@ Re-run the importer at any time to refresh from Geofabrik (extracts are updated 
 docker compose --profile data-node run --rm importer
 ```
 
+For daemon mode deployments or troubleshooting a stale import, see [Refresh Data](refresh-data.md).
+
 ## Applying database changes without a full re-import
 
 SQL changes to `importer/api.sql` (PostgREST functions, indexes) can be applied directly to the running database:

--- a/docs/ops/refresh-data.md
+++ b/docs/ops/refresh-data.md
@@ -6,10 +6,10 @@ For setting up automatic re-imports, see [Scheduled Import](scheduled-import.md)
 
 ## Before you start: know your setup
 
-Check which import mode the installer configured:
+Check which import mode the installer configured. Run from your deployment directory (where `compose.yml` and `.env` live):
 
 ```bash
-grep REIMPORT_INTERVAL /opt/spieli/.env
+grep REIMPORT_INTERVAL .env
 ```
 
 | Result | Mode |
@@ -20,17 +20,16 @@ grep REIMPORT_INTERVAL /opt/spieli/.env
 Check your `DEPLOY_MODE` too — you need it for the `--profile` flag:
 
 ```bash
-grep DEPLOY_MODE /opt/spieli/.env
+grep DEPLOY_MODE .env
 ```
 
 Valid values: `data-node`, `data-node-ui`. (Hub-only deployments — `DEPLOY_MODE=ui` — have no database and no importer.)
 
 ## One-shot mode
 
-Run the importer once. It exits when done.
+Run the importer once from your deployment directory. It exits when done.
 
 ```bash
-cd /opt/spieli
 docker compose --profile data-node-ui run --rm importer
 ```
 
@@ -44,10 +43,9 @@ This means **restarting the container does not force an immediate re-import** un
 
 To force a re-import right now:
 
-**Step 1 — Stop the running daemon:**
+**Step 1 — Stop the running daemon** (from your deployment directory):
 
 ```bash
-cd /opt/spieli
 docker compose stop importer
 ```
 

--- a/docs/ops/refresh-data.md
+++ b/docs/ops/refresh-data.md
@@ -1,0 +1,97 @@
+# Refreshing OSM Data On Demand
+
+Geofabrik publishes updated OSM extracts daily. The importer pulls the latest extract, filters it to your region, and loads it into the database. This page explains how to trigger that process right now, outside of any automated schedule.
+
+For setting up automatic re-imports, see [Scheduled Import](scheduled-import.md).
+
+## Before you start: know your setup
+
+Check which import mode the installer configured:
+
+```bash
+grep REIMPORT_INTERVAL /opt/spieli/.env
+```
+
+| Result | Mode |
+|---|---|
+| Both vars absent or empty | **One-shot** — importer runs once and exits |
+| Both vars set (e.g. `MIN=2`, `MAX=10`) | **Daemon** — importer loops; different steps apply |
+
+Check your `DEPLOY_MODE` too — you need it for the `--profile` flag:
+
+```bash
+grep DEPLOY_MODE /opt/spieli/.env
+```
+
+Valid values: `data-node`, `data-node-ui`. (Hub-only deployments — `DEPLOY_MODE=ui` — have no database and no importer.)
+
+## One-shot mode
+
+Run the importer once. It exits when done.
+
+```bash
+cd /opt/spieli
+docker compose --profile data-node-ui run --rm importer
+```
+
+Replace `data-node-ui` with your `DEPLOY_MODE` value.
+
+## Daemon mode
+
+When `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` are set, the importer container runs in a loop. On startup it checks `last_import_at` in the database — if the last import was recent (within a randomly chosen interval), it sleeps until the next scheduled time rather than importing again.
+
+This means **restarting the container does not force an immediate re-import** unless the data is already overdue.
+
+To force a re-import right now:
+
+**Step 1 — Stop the running daemon:**
+
+```bash
+cd /opt/spieli
+docker compose stop importer
+```
+
+**Step 2 — Run a one-shot import (interval vars unset inline):**
+
+```bash
+docker compose run --rm \
+  -e REIMPORT_INTERVAL_MIN_DAYS= \
+  -e REIMPORT_INTERVAL_MAX_DAYS= \
+  importer
+```
+
+Unsetting the vars inline overrides `.env` without editing the file. The container runs once and exits.
+
+**Step 3 — Resume the daemon:**
+
+```bash
+docker compose up -d importer
+```
+
+The daemon restarts, sees the fresh `last_import_at`, and sleeps for the next scheduled interval.
+
+## Verify the import ran
+
+```bash
+curl -s http://localhost:8080/api/rpc/get_meta | python3 -m json.tool | grep last_import_at
+```
+
+Or from outside the host:
+
+```bash
+curl -s https://your-domain.example.com/api/rpc/get_meta | python3 -m json.tool | grep last_import_at
+```
+
+`last_import_at` is the timestamp of when the importer script ran. `osm_data_timestamp` reflects when Geofabrik generated the extract (can be up to a day behind).
+
+## How long does it take?
+
+See the timing table in [Scheduled Import → How long does an import take?](scheduled-import.md#how-long-does-an-import-take)
+
+For most small regions, subsequent imports complete in under a minute once the PBF is cached.
+
+## See also
+
+- [Scheduled Import](scheduled-import.md) — set up automatic re-imports with daemon mode or a systemd timer
+- [Monitoring](monitoring.md) — track import freshness via `federation-status.json` and Prometheus
+- [Upgrading](upgrade.md) — re-importing after a spieli version upgrade

--- a/docs/ops/scheduled-import.md
+++ b/docs/ops/scheduled-import.md
@@ -116,6 +116,7 @@ systemctl list-timers spieli-import.timer
 
 ## See also
 
+- [Refresh Data](refresh-data.md) — trigger an immediate re-import outside of the schedule
 - [Monitoring](monitoring.md) — observe import freshness via federation-status and Prometheus
 - [Backup and Restore](backup-restore.md) — database backups before major import runs
 - [Configuration reference](configuration.md) — `OSM_RELATION_ID`, `PBF_URL`, `OSM2PGSQL_THREADS`, `REIMPORT_INTERVAL_MIN_DAYS`, `REIMPORT_INTERVAL_MAX_DAYS`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Upgrading: ops/upgrade.md
       - Switching Regions: ops/switch-region.md
       - Scheduled Import: ops/scheduled-import.md
+      - Refresh Data: ops/refresh-data.md
       - Backup and Restore: ops/backup-restore.md
       - Monitoring: ops/monitoring.md
       - Security: ops/security.md


### PR DESCRIPTION
## Summary

- No docs existed for triggering a manual re-import outside the automated schedule
- Common operator mistakes (wrong profile, accidentally enabling daemon mode, not knowing how to force a run) had no fix in the docs
- New `docs/ops/refresh-data.md` covers both one-shot and daemon-mode setups with correct commands verified against `importer/import.sh`
- Added to `mkdocs.yml` nav after "Scheduled Import"
- Cross-linked from `scheduled-import.md` (See also) and `manual-deploy.md` (Step 5)

## Key points documented

- How to detect whether daemon mode is active (`grep REIMPORT_INTERVAL .env`)
- One-shot: straightforward `docker compose --profile <mode> run --rm importer`
- Daemon mode: stop daemon → run one-shot with vars unset inline → resume daemon
- Why restarting the daemon container is not enough (startup grace check reads `last_import_at`)
- How to verify with `get_meta → last_import_at`

Closes #502

## Test plan

- [ ] `make docs-build` passes with no broken links
- [ ] Page renders correctly in the nav under "Scheduled Import"
- [ ] One-shot command works on a real deployment
- [ ] Daemon-mode force-refresh sequence works on a deployment with `REIMPORT_INTERVAL_*` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)