### PR TITLE
fix(importer): re-download PBF when Geofabrik publishes a newer extract

### DIFF
--- a/docs/ops/scheduled-import.md
+++ b/docs/ops/scheduled-import.md
@@ -59,9 +59,10 @@ Or add `auto-update` to any existing `up` invocation. Watchtower polls Docker Hu
 |---|---|
 | First run, PBF not cached | download time + 2–5 min |
 | First run, PBF cached | 2–5 min |
-| Re-run, filtered PBFs cached | 30–60 s for small regions; 30+ min for large (e.g. all of Germany) |
+| Re-run, Geofabrik has a newer extract | download time + 2–5 min |
+| Re-run, Geofabrik extract unchanged | 30–60 s for small regions; 30+ min for large (e.g. all of Germany) |
 
-All three files (source PBF, bbox-clipped PBF, tag-filtered PBF) are stored in the `pbf_cache` Docker volume and reused automatically. Only the final osm2pgsql + api.sql step runs every time.
+The source PBF is checked against Geofabrik on every run using HTTP `If-Modified-Since`. When no newer extract is available the download is skipped and the existing bbox and tag-filtered caches are reused — only the final osm2pgsql + api.sql step runs.
 
 ## How fresh is the data?
 

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -127,21 +127,27 @@ run_import() (
     echo "[importer] PostgreSQL is ready."
 
     # --------------------------------------------------------------------------- #
-    # Download PBF (skipped if already cached and intact)
+    # Download PBF — re-download only if Geofabrik has a newer version.
+    # wget -N sends If-Modified-Since using the local file's mtime; the server
+    # returns 304 Not Modified when the extract hasn't changed, skipping the
+    # download. When a newer extract is available wget updates the file and its
+    # mtime, which automatically invalidates the bbox and tag-filter caches
+    # below (they use -nt comparisons against the source PBF).
     # --------------------------------------------------------------------------- #
     if [ -f "$PBF_FILE" ]; then
         if ! osmium fileinfo "$PBF_FILE" > /dev/null 2>&1; then
             echo "[importer] Cached $PBF_FILE is corrupt or incomplete — re-downloading..."
             rm -f "$PBF_FILE"
+            wget --progress=dot:giga -O "$PBF_FILE" "$PBF_URL"
         else
-            echo "[importer] Using cached $PBF_FILE ($(du -sh "$PBF_FILE" | cut -f1))"
+            echo "[importer] Checking for updated PBF at $PBF_URL ..."
+            wget --progress=dot:giga -N -P /data/ "$PBF_URL"
         fi
-    fi
-    if [ ! -f "$PBF_FILE" ]; then
+    else
         echo "[importer] Downloading $PBF_URL ..."
         wget --progress=dot:giga -O "$PBF_FILE" "$PBF_URL"
-        echo "[importer] Download complete: $(du -sh "$PBF_FILE" | cut -f1)"
     fi
+    echo "[importer] PBF ready: $(du -sh "$PBF_FILE" | cut -f1)"
 
     # --------------------------------------------------------------------------- #
     # Step 1 — Bbox pre-filter: clip PBF to region bounding box


### PR DESCRIPTION
## Problem

The importer cached the source PBF and only re-downloaded it if the file was missing or corrupt. No age or timestamp check. Consequence: daemon mode re-ran osm2pgsql on the same extract every cycle — `osm_data_timestamp` never advanced, data stayed permanently stale.

Observed by an operator: `last_import_at` updated correctly, but `osm_data_timestamp` stayed 4 days old after multiple re-imports.

## Fix

Switch to `wget -N` (HTTP `If-Modified-Since`) when a cached PBF already exists:

- Server returns **304 Not Modified** → skip download, existing file unchanged
- Server returns **200** with newer extract → download, file mtime updated

The updated mtime automatically invalidates the bbox and tag-filter caches via the existing `-nt` comparisons — no other changes needed in the pipeline.

For the corrupt-file case and the first-ever download, `wget -O` is still used (no local file to compare against for `-N`).

## Timing table

Updated `scheduled-import.md` to split the re-run row into "extract unchanged" (fast, caches reused) and "new extract available" (download + full pipeline).

Closes #504

## Test plan

- [ ] First run (no cache): downloads PBF, runs full pipeline
- [ ] Re-run same day (Geofabrik unchanged): wget prints "not retrieving" / 304, bbox+tags caches hit, fast run
- [ ] Re-run after Geofabrik publishes new extract: wget downloads, bbox+tags rebuilt, `osm_data_timestamp` advances
- [ ] Corrupt cache: detected, deleted, re-downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)