### PR TITLE
docs(ops): expand add-data-node guide with Impressum, daemon mode, relation ID fixes

### DIFF
--- a/deploy/setup-germany-backends.sh
+++ b/deploy/setup-germany-backends.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Sets up 12 Bundesland data-node backends on a host that already runs
+# the spieli hub + Hessen data-node (~/spieli) and Berlin (~/spieli-berlin).
+#
+# Run from your home directory: bash setup-germany-backends.sh
+#
+# What it does per backend:
+#   1. Creates ~/spieli-<slug>/ with compose.yml + db/init.sql
+#   2. Patches compose.yml (PGRST_DB_URI key-value, POSTGRES_HOST_AUTH_METHOD)
+#   3. Writes .env
+#   4. Creates Traefik dynamic config
+#
+# After this script: start each stack and run the importer manually.
+# See docs/ops/add-data-node.md for details.
+
+set -euo pipefail
+
+TRAEFIK_DYNAMIC_DIR="${HOME}/spieli-traefik/dynamic"
+SOURCE_DIR="${HOME}/spieli"
+DOMAIN_SUFFIX="spieli.osm-fulda.de"
+
+BACKENDS=(
+  "bayern:2145268:europe/germany/bayern-latest.osm.pbf:8083:Bayern"
+  "brandenburg:62504:europe/germany/brandenburg-latest.osm.pbf:8084:Brandenburg"
+  "bremen:62559:europe/germany/bremen-latest.osm.pbf:8085:Bremen"
+  "hamburg:62782:europe/germany/hamburg-latest.osm.pbf:8086:Hamburg"
+  "mv:28322:europe/germany/mecklenburg-vorpommern-latest.osm.pbf:8087:Mecklenburg-Vorpommern"
+  "nrw:62761:europe/germany/nordrhein-westfalen-latest.osm.pbf:8088:Nordrhein-Westfalen"
+  "rlp:62341:europe/germany/rheinland-pfalz-latest.osm.pbf:8089:Rheinland-Pfalz"
+  "saarland:62372:europe/germany/saarland-latest.osm.pbf:8090:Saarland"
+  "sachsen:62467:europe/germany/sachsen-latest.osm.pbf:8091:Sachsen"
+  "sachsen-anhalt:62607:europe/germany/sachsen-anhalt-latest.osm.pbf:8092:Sachsen-Anhalt"
+  "sh:51529:europe/germany/schleswig-holstein-latest.osm.pbf:8093:Schleswig-Holstein"
+  "thueringen:62366:europe/germany/thueringen-latest.osm.pbf:8094:Thueringen"
+)
+
+echo "==> Setting up ${#BACKENDS[@]} Bundesland backends"
+echo ""
+
+for entry in "${BACKENDS[@]}"; do
+  IFS=: read -r slug relation pbf port name <<< "$entry"
+  deploy_dir="${HOME}/spieli-${slug}"
+  domain="${slug}.${DOMAIN_SUFFIX}"
+  password=$(openssl rand -base64 24 | tr -d '/+=')
+
+  echo "--- ${name} (port ${port}) ---"
+
+  # 1. Create deploy dir
+  mkdir -p "${deploy_dir}"
+  cp "${SOURCE_DIR}/compose.yml" "${deploy_dir}/compose.yml"
+  cp -r "${SOURCE_DIR}/db" "${deploy_dir}/db"
+
+  # 2. Patch PGRST_DB_URI to key-value format (safe for any password)
+  sed -i \
+    's|PGRST_DB_URI:.*postgres://osm:.*@db:5432/osm|PGRST_DB_URI: "host=db port=5432 dbname=osm user=osm password=${POSTGRES_PASSWORD}"|' \
+    "${deploy_dir}/compose.yml"
+
+  # 3. Add POSTGRES_HOST_AUTH_METHOD under the db service only (not importer)
+  python3 - "${deploy_dir}/compose.yml" << 'PYEOF'
+import sys, re
+path = sys.argv[1]
+text = open(path).read()
+# Insert after the first occurrence only (db service block)
+patched = text.replace(
+    "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}\n",
+    "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}\n      POSTGRES_HOST_AUTH_METHOD:  scram-sha-256\n",
+    1  # replace first occurrence only
+)
+open(path, 'w').write(patched)
+PYEOF
+
+  # 4. Write .env
+  cat > "${deploy_dir}/.env" << EOF
+COMPOSE_PROJECT_NAME=spieli-${slug}
+DEPLOY_MODE=data-node-ui
+APP_PORT=${port}
+OSM_RELATION_ID=${relation}
+PBF_URL=https://download.geofabrik.de/${pbf}
+POSTGRES_PASSWORD=${password}
+REIMPORT_INTERVAL_MIN_DAYS=1
+REIMPORT_INTERVAL_MAX_DAYS=1
+EOF
+
+  # 5. Create Traefik dynamic config
+  cat > "${TRAEFIK_DYNAMIC_DIR}/${slug}.yml" << EOF
+http:
+  routers:
+    ${slug}:
+      rule: "Host(\`${domain}\`)"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: le
+      service: ${slug}
+      middlewares:
+        - security-headers
+
+  services:
+    ${slug}:
+      loadBalancer:
+        servers:
+          - url: "http://host.docker.internal:${port}"
+EOF
+
+  echo "    dir:    ${deploy_dir}"
+  echo "    domain: https://${domain}/api"
+  echo "    done"
+  echo ""
+done
+
+# 6. Print updated registry.json snippet
+echo "==> Add these entries to ~/spieli/registry.json:"
+echo ""
+echo '{'
+echo '  "instances": ['
+echo '    { "slug": "hessen", "url": "https://spieli.eu/api", "name": "Hessen" },'
+echo '    { "slug": "bawue",  "url": "https://bawue.spieli.eu/api", "name": "Baden-Württemberg" },'
+echo '    { "slug": "berlin", "url": "https://berlin.spieli.osm-fulda.de/api", "name": "Berlin" },'
+for entry in "${BACKENDS[@]}"; do
+  IFS=: read -r slug relation pbf port name <<< "$entry"
+  domain="${slug}.${DOMAIN_SUFFIX}"
+  echo "    { \"slug\": \"${slug}\", \"url\": \"https://${domain}/api\", \"name\": \"${name}\" },"
+done
+echo '  ]'
+echo '}'
+
+echo ""
+echo "==> Done. Next steps:"
+echo "    1. Add DNS A records for all new subdomains → this server's IP"
+echo "    2. For each backend, cd ~/spieli-<slug> && docker compose --profile data-node-ui up -d"
+echo "    3. Run importer: docker compose --profile data-node-ui run --rm importer"
+echo "    4. Update ~/spieli/registry.json with the entries above"
+echo "    5. Restart hub: cd ~/spieli && docker compose --profile ui restart app"
+echo "    Start with small ones (bremen, hamburg, saarland) and check memory before tackling nrw/bayern."

--- a/docs/ops/add-data-node.md
+++ b/docs/ops/add-data-node.md
@@ -1,0 +1,253 @@
+# Adding a Data-node to an Existing Hub
+
+This page is for operators who already have a running **hub + data-node-ui** setup on one host and want to add more regional backends without touching the existing stack.
+
+If you are setting up from scratch, see [Federated Deployment](federated-deployment.md) instead.
+
+## How it works
+
+The hub is client-side: browsers fetch playground data directly from each data-node URL listed in `registry.json`. Every data-node must therefore be reachable over **public HTTPS** — a backend accessible only on `localhost` cannot be reached by a user's browser.
+
+## Prerequisites
+
+- Existing hub + at least one data-node-ui running on the host.
+- A reverse proxy (Traefik or nginx) that can front additional backends on new ports or subdomains.
+- A public domain / subdomain for the new backend (e.g. `berlin.example.com`).
+- OSM relation ID and Geofabrik PBF URL for the new region — see [Manual Deploy § Step 1](manual-deploy.md#step-1-find-your-regions-osm-relation-id).
+
+## Step 1 — Create the backend directory
+
+Each backend is an independent Compose project in its own directory.
+
+```bash
+mkdir ~/spieli-berlin
+cd ~/spieli-berlin
+cp ~/spieli/compose.yml .   # copy from your existing deploy dir
+cp -r ~/spieli/db .          # copy db/init.sql — required for DB initialisation
+```
+
+!!! note "Why copy db/init.sql?"
+    The PostgreSQL image runs every file in `/docker-entrypoint-initdb.d/` on first start.
+    `compose.yml` bind-mounts `./db/init.sql` into that directory. Without the file, Docker
+    creates a directory at the mount target instead of a file, the init script silently fails,
+    and PostgREST cannot connect.
+
+## Step 2 — Write `.env`
+
+```env
+COMPOSE_PROJECT_NAME=spieli-berlin   # unique per backend — avoids Docker name collisions
+DEPLOY_MODE=data-node-ui
+APP_PORT=8082                         # unique port — increment for each new backend
+OSM_RELATION_ID=62422
+PBF_URL=https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+POSTGRES_PASSWORD=<strong-random-password>
+REIMPORT_INTERVAL_MIN_DAYS=1
+REIMPORT_INTERVAL_MAX_DAYS=1
+```
+
+Generate a strong password: `openssl rand -base64 24`
+
+!!! warning "Special characters in POSTGRES_PASSWORD"
+    `compose.yml` uses the password in a PostgreSQL URI
+    (`postgres://osm:${POSTGRES_PASSWORD}@db:5432/osm`).
+    URI-special characters (`/`, `+`, `=`, `@`, `#`) break the URI parser, causing PostgREST
+    to fail with `could not look up local user ID`. Fix: change `PGRST_DB_URI` in `compose.yml`
+    to the key-value format (see Step 3).
+
+## Step 3 — Patch `compose.yml`
+
+Two changes are needed before the first start. Edit `~/spieli-berlin/compose.yml`:
+
+### 3a — Fix PGRST_DB_URI (key-value format)
+
+Find the `postgrest` service and replace the URI-format connection string:
+
+```yaml
+# Before (URI format — breaks with special-char passwords):
+PGRST_DB_URI: postgres://osm:${POSTGRES_PASSWORD}@db:5432/osm
+
+# After (key-value format — safe for any password):
+PGRST_DB_URI: "host=db port=5432 dbname=osm user=osm password=${POSTGRES_PASSWORD}"
+```
+
+### 3b — Add POSTGRES_HOST_AUTH_METHOD to the db service
+
+Without this, PostgreSQL only allows loopback connections and PostgREST (in a separate container) cannot connect.
+
+```yaml
+  db:
+    environment:
+      POSTGRES_DB:                osm
+      POSTGRES_USER:              osm
+      POSTGRES_PASSWORD:          ${POSTGRES_PASSWORD:-change-me}
+      POSTGRES_HOST_AUTH_METHOD:  scram-sha-256   # ← add this line
+```
+
+## Step 4 — Start the stack
+
+```bash
+cd ~/spieli-berlin
+docker compose --profile data-node-ui up -d
+```
+
+!!! warning "Do not add --profile auto-update"
+    Your existing Watchtower instance (in the first backend's stack) already watches **all**
+    containers on the Docker host. Adding a second Watchtower via `--profile auto-update`
+    causes both instances to fight over the same containers, killing each other on startup.
+
+Wait for the DB to become healthy before running the importer:
+
+```bash
+docker ps | grep spieli-berlin-db
+# wait for (healthy) to appear
+```
+
+## Step 5 — Import OSM data
+
+```bash
+docker compose --profile data-node-ui run --rm importer
+```
+
+Berlin (~93 MB PBF) takes a few minutes. Watch progress:
+
+```bash
+docker logs -f spieli-berlin-importer-1
+```
+
+The import is complete when you see `[importer] Import completed successfully.`
+
+### Forcing a re-import (corrupt cache)
+
+If `get_meta` returns `playground_count: 0` after the import, the bbox/tags cache in `pbf_cache`
+may be corrupt (this can happen when the importer ran against a broken DB and cached empty
+osmium output). Fix:
+
+```bash
+# Replace berlin-latest with your region's PBF basename
+docker run --rm -v spieli-berlin_pbf_cache:/cache alpine \
+  sh -c "rm -f /cache/*_${OSM_RELATION_ID}.pbf /cache/*_${OSM_RELATION_ID}_tags.pbf"
+
+docker exec -u postgres spieli-berlin-db-1 psql -U osm osm \
+  -c "DELETE FROM api.import_status WHERE id = 1;"
+
+docker restart spieli-berlin-importer-1
+docker logs -f spieli-berlin-importer-1
+```
+
+## Step 6 — Expose via reverse proxy
+
+The browser must reach the backend at a stable public HTTPS URL. If you use Traefik with the file provider (as set up by `install-traefik.sh`), drop a new file in the `dynamic/` directory — Traefik picks it up immediately without a restart.
+
+### Subdomain approach (recommended)
+
+**`~/spieli-traefik/dynamic/berlin.yml`:**
+
+```yaml
+http:
+  routers:
+    berlin:
+      rule: "Host(`berlin.example.com`)"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: le
+      service: berlin
+      middlewares:
+        - security-headers
+
+  services:
+    berlin:
+      loadBalancer:
+        servers:
+          - url: "http://host.docker.internal:8082"
+```
+
+`security-headers` is defined in your existing `app.yml` and is shared across all files in the same `dynamic/` directory.
+
+### Path-prefix approach (same domain)
+
+Use this when you cannot add a new DNS subdomain.
+
+**`~/spieli-traefik/dynamic/berlin.yml`:**
+
+```yaml
+http:
+  routers:
+    berlin-api:
+      rule: "Host(`your-domain.example.com`) && PathPrefix(`/berlin/api/`)"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: le
+      service: berlin
+      middlewares:
+        - strip-berlin
+        - security-headers
+
+  middlewares:
+    strip-berlin:
+      stripPrefix:
+        prefixes:
+          - "/berlin"
+
+  services:
+    berlin:
+      loadBalancer:
+        servers:
+          - url: "http://host.docker.internal:8082"
+```
+
+With the path-prefix approach the registry URL must include the prefix:
+`"url": "https://your-domain.example.com/berlin/api"`.
+
+### Verify
+
+```bash
+curl -i -H "Origin: https://your-hub-domain.example.com" \
+  https://berlin.example.com/api/rpc/get_meta
+# expect: 200 OK, Access-Control-Allow-Origin: *
+```
+
+## Step 7 — Update `registry.json` and restart hub
+
+Edit `~/spieli/registry.json` (or wherever your hub's `registry.json` lives):
+
+```json
+{
+  "instances": [
+    { "slug": "hessen", "url": "https://your-domain.example.com/api", "name": "Hessen" },
+    { "slug": "berlin", "url": "https://berlin.example.com/api",      "name": "Berlin" }
+  ]
+}
+```
+
+The file is bind-mounted — editing it takes effect on the next hub poll. Restart the app
+container to pick it up immediately:
+
+```bash
+cd ~/spieli
+docker compose --profile ui restart app
+```
+
+## Verify end-to-end
+
+Open the hub in a browser. The instance pill should show the new region. If a backend appears
+red ("unreachable"), open DevTools → Network and check the `get_meta` request — the URL in the
+request must match the backend's actual public path.
+
+## Port layout reference
+
+| Stack | `APP_PORT` | `COMPOSE_PROJECT_NAME` |
+|---|---|---|
+| Hub | 8080 | `spieli` (or `spieli-hub`) |
+| First data-node (e.g. Hessen) | 8080 | `spieli` |
+| Second data-node (e.g. Berlin) | 8082 | `spieli-berlin` |
+| Third data-node | 8083 | `spieli-<region>` |
+
+Keep ports consecutive and project names unique.
+
+## See also
+
+- [Federated Deployment](federated-deployment.md) — full from-scratch walkthrough
+- [`registry.json` reference](../reference/registry-json.md) — schema and slug rules
+- [Troubleshooting](troubleshooting.md)

--- a/docs/ops/add-data-node.md
+++ b/docs/ops/add-data-node.md
@@ -59,9 +59,11 @@ Generate a strong password: `openssl rand -base64 24`
     can surface legal links. Omitting these leaves the backend with `has_legal: false` in
     `get_meta()`.
 
-    To apply legal content without a full re-import (e.g. after updating the `.env`):
+    Legal content is written by `run_import`, not `API_ONLY`. After updating the `.env`,
+    the content is applied on the next scheduled reimport (within 24 h in daemon mode).
+    To apply immediately, trigger a full re-import:
     ```bash
-    docker compose --profile data-node-ui run --rm -e API_ONLY=true importer
+    docker compose --profile data-node-ui run --rm importer
     ```
 
 !!! warning "Special characters in POSTGRES_PASSWORD"

--- a/docs/ops/add-data-node.md
+++ b/docs/ops/add-data-node.md
@@ -43,9 +43,26 @@ PBF_URL=https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
 POSTGRES_PASSWORD=<strong-random-password>
 REIMPORT_INTERVAL_MIN_DAYS=1
 REIMPORT_INTERVAL_MAX_DAYS=1
+
+# Legal / Impressum (required under German law for public instances)
+IMPRESSUM_NAME=Max Mustermann
+IMPRESSUM_ADDRESS=Musterstraße 1, 12345 Berlin
+IMPRESSUM_EMAIL=kontakt@example.com
 ```
 
 Generate a strong password: `openssl rand -base64 24`
+
+!!! warning "Legal requirement (Germany)"
+    Public instances in Germany require an Impressum. Set at minimum `IMPRESSUM_NAME`,
+    `IMPRESSUM_ADDRESS`, and `IMPRESSUM_EMAIL`. The importer writes the generated HTML to
+    `api.legal_content` and `get_meta()` exposes `impressum_url` / `privacy_url` so the Hub
+    can surface legal links. Omitting these leaves the backend with `has_legal: false` in
+    `get_meta()`.
+
+    To apply legal content without a full re-import (e.g. after updating the `.env`):
+    ```bash
+    docker compose --profile data-node-ui run --rm -e API_ONLY=true importer
+    ```
 
 !!! warning "Special characters in POSTGRES_PASSWORD"
     `compose.yml` uses the password in a PostgreSQL URI
@@ -95,26 +112,24 @@ docker compose --profile data-node-ui up -d
     containers on the Docker host. Adding a second Watchtower via `--profile auto-update`
     causes both instances to fight over the same containers, killing each other on startup.
 
-Wait for the DB to become healthy before running the importer:
-
-```bash
-docker ps | grep spieli-berlin-db
-# wait for (healthy) to appear
-```
-
 ## Step 5 — Import OSM data
 
-```bash
-docker compose --profile data-node-ui run --rm importer
-```
-
-Berlin (~93 MB PBF) takes a few minutes. Watch progress:
+The importer started automatically in Step 4 (daemon mode). Watch progress:
 
 ```bash
 docker logs -f spieli-berlin-importer-1
 ```
 
-The import is complete when you see `[importer] Import completed successfully.`
+Berlin (~93 MB PBF) takes a few minutes. The import is complete when you see `[importer] Import completed successfully.` The importer then sleeps until the next scheduled run.
+
+### Verify playground count
+
+```bash
+curl -s https://berlin.example.com/api/rpc/get_meta | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); print(d['playground_count'], d['relation_id'])"
+```
+
+`playground_count` must be greater than zero. If it returns `0` despite a successful import, see [Wrong relation ID](#wrong-relation-id-playground_count-0) below.
 
 ### Forcing a re-import (corrupt cache)
 
@@ -130,9 +145,34 @@ docker run --rm -v spieli-berlin_pbf_cache:/cache alpine \
 docker exec -u postgres spieli-berlin-db-1 psql -U osm osm \
   -c "DELETE FROM api.import_status WHERE id = 1;"
 
-docker restart spieli-berlin-importer-1
+docker compose --profile data-node-ui up -d --force-recreate importer
 docker logs -f spieli-berlin-importer-1
 ```
+
+### Wrong relation ID (`playground_count: 0`)
+
+If `get_meta` returns `playground_count: 0` after a successful import (osm2pgsql ran, no errors), the most likely cause is a wrong `OSM_RELATION_ID`. The `playground_stats` view filters playgrounds by the state boundary polygon — if the relation ID doesn't match any polygon in the database, no playgrounds are counted.
+
+**Diagnose:** check which admin boundary was actually imported:
+
+```bash
+docker exec spieli-berlin-db-1 psql -U osm osm \
+  -c "SELECT osm_id, name FROM planet_osm_polygon WHERE boundary='administrative' AND admin_level='4';"
+```
+
+If the returned `osm_id` is `-62423` but your `.env` has `OSM_RELATION_ID=62422`, fix the `.env` and re-apply the API schema without a full re-import:
+
+```bash
+sed -i 's/OSM_RELATION_ID=62422/OSM_RELATION_ID=62423/' .env
+docker compose --profile data-node-ui run --rm -e API_ONLY=true importer
+```
+
+The `API_ONLY` run rebuilds `playground_stats` with the corrected relation ID in under a minute.
+
+!!! note "OSM relation IDs for German Bundesländer"
+    Several commonly-cited relation IDs are off. Confirmed correct values:
+    Mecklenburg-Vorpommern → **28322**, Sachsen-Anhalt → **62607**, Schleswig-Holstein → **51529**.
+    After any new import, run the boundary check above to confirm.
 
 ## Step 6 — Expose via reverse proxy
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Manual Deploy: ops/manual-deploy.md
       - HTTPS Setup: ops/https-setup.md
       - Federated Deployment: ops/federated-deployment.md
+      - Add a Data-node: ops/add-data-node.md
       - Configuration: ops/configuration.md
       - Upgrading: ops/upgrade.md
       - Switching Regions: ops/switch-region.md


### PR DESCRIPTION
## Summary

Follow-up to #512. Expands the add-data-node guide based on lessons from the 15-region Germany deployment:

- Adds Impressum / legal vars to the `.env` example with a `!!! warning` admonition
- Fixes legal content note: `API_ONLY` does not write legal content — only a full reimport does
- Removes the manual DB-healthy wait block from Step 4 (unnecessary in daemon mode)
- Fixes Step 5: importer starts automatically in daemon mode — no manual `run --rm importer` needed
- Adds `### Verify playground count` curl one-liner after import
- Fixes corrupt-cache recovery command (`docker restart` → `docker compose up -d --force-recreate`)
- Adds `### Wrong relation ID (playground_count: 0)` troubleshooting section with boundary diagnosis query and `API_ONLY` fix
- Adds `!!! note "OSM relation IDs for German Bundesländer"` with confirmed correct values (MV 28322, SA 62607, SH 51529)

## Test plan

- [ ] `make docs-build` passes (no broken links)
- [ ] Review updated `docs/ops/add-data-node.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)