### PR TITLE
feat(hub): warn in InstancePanel when backend bboxes overlap

### DIFF
--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -42,6 +42,7 @@
     backends,
     registryError,
     aggregatedBbox,
+    overlapWarnings,
     fetchNearestAcrossBackends,
   } = createRegistry();
 
@@ -234,6 +235,6 @@
   {dataContribLinks}
 >
   {#snippet instancePanel()}
-    <InstancePanel {backends} {registryError} />
+    <InstancePanel {backends} {registryError} {overlapWarnings} />
   {/snippet}
 </AppShell>

--- a/app/src/hub/InstancePanel.svelte
+++ b/app/src/hub/InstancePanel.svelte
@@ -8,6 +8,8 @@
   export let backends;
   /** @type {import('svelte/store').Readable<string|null>} */
   export let registryError;
+  /** @type {import('svelte/store').Readable<Map<string,string[]>>} */
+  export let overlapWarnings;
 
   let open = false;
   let pillEl;
@@ -87,6 +89,7 @@
       <InstancePanelDrawer
         backends={$backends}
         registryError={$registryError}
+        overlapWarnings={$overlapWarnings}
         onclose={close}
       />
     </div>

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -7,6 +7,8 @@
   export let backends;
   /** @type {string | null} */
   export let registryError;
+  /** @type {Map<string, string[]>} */
+  export let overlapWarnings = new Map();
   /** @type {() => void} */
   export let onclose;
 
@@ -200,6 +202,12 @@
                 {$_('hub.dataAge', { values: { age: formatDataAge(b.dataAgeSec) } })}
               </div>
             {/if}
+            {#each (overlapWarnings.get(b.url) ?? []) as overlapName}
+              <div class="instance-overlap text-warning">
+                <i class="bi bi-exclamation-triangle me-1"></i>
+                {$_('hub.bboxOverlap', { values: { name: overlapName } })}
+              </div>
+            {/each}
           {/if}
         </li>
       {/each}
@@ -347,6 +355,11 @@
   }
 
   .instance-freshness {
+    font-size: 0.72rem;
+    margin-top: 0.1rem;
+  }
+
+  .instance-overlap {
     font-size: 0.72rem;
     margin-top: 0.1rem;
   }

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -230,6 +230,40 @@ export function createRegistry() {
     }, [Infinity, Infinity, -Infinity, -Infinity]);
   });
 
+  // Map from backend URL to array of overlapping backend names.
+  // Two backends overlap when their bbox intersection area exceeds 25% of the
+  // smaller backend's bbox area — large enough to catch containment (e.g. a
+  // city inside a Bundesland) while ignoring rectangular-bbox border slivers
+  // between adjacent regions. Backends without a bbox are ignored.
+  const overlapWarnings = derived(store, ($backends) => {
+    const withBbox = $backends.filter(b => b.bbox);
+    /** @type {Map<string, string[]>} */
+    const warnings = new Map();
+    for (let i = 0; i < withBbox.length; i++) {
+      for (let j = i + 1; j < withBbox.length; j++) {
+        const a = withBbox[i];
+        const b = withBbox[j];
+        const [aMinLon, aMinLat, aMaxLon, aMaxLat] = a.bbox;
+        const [bMinLon, bMinLat, bMaxLon, bMaxLat] = b.bbox;
+        const iMinLon = Math.max(aMinLon, bMinLon);
+        const iMinLat = Math.max(aMinLat, bMinLat);
+        const iMaxLon = Math.min(aMaxLon, bMaxLon);
+        const iMaxLat = Math.min(aMaxLat, bMaxLat);
+        if (iMaxLon <= iMinLon || iMaxLat <= iMinLat) continue;
+        const intersectArea = (iMaxLon - iMinLon) * (iMaxLat - iMinLat);
+        const aArea = (aMaxLon - aMinLon) * (aMaxLat - aMinLat);
+        const bArea = (bMaxLon - bMinLon) * (bMaxLat - bMinLat);
+        if (intersectArea / Math.min(aArea, bArea) > 0.25) {
+          if (!warnings.has(a.url)) warnings.set(a.url, []);
+          if (!warnings.has(b.url)) warnings.set(b.url, []);
+          warnings.get(a.url).push(b.name);
+          warnings.get(b.url).push(a.name);
+        }
+      }
+    }
+    return warnings;
+  });
+
   // Multi-backend nearest-playground search.
   //
   // Fires `get_nearest_playgrounds` against every registered backend in
@@ -260,6 +294,7 @@ export function createRegistry() {
     backends:                   store,
     registryError,
     aggregatedBbox,
+    overlapWarnings,
     fetchNearestAcrossBackends,
   };
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -407,7 +407,8 @@
     "lastReachableHours": "zuletzt erreichbar: vor {h} Std.",
     "neverReachable": "noch nie erreichbar",
     "observationStale": "Verbindungsstatus veraltet",
-    "importing": "Aktualisierung"
+    "importing": "Aktualisierung",
+    "bboxOverlap": "Überschneidung mit {name}"
   },
   "details": {
     "sizeLabel": "Größe",

--- a/locales/en.json
+++ b/locales/en.json
@@ -407,7 +407,8 @@
     "lastReachableHours": "last reachable: {h} hr ago",
     "neverReachable": "never reachable",
     "observationStale": "Observation status outdated",
-    "importing": "updating"
+    "importing": "updating",
+    "bboxOverlap": "overlaps with {name}"
   },
   "details": {
     "sizeLabel": "Size",


### PR DESCRIPTION
## Summary

- Adds `overlapWarnings` derived store to `registry.js` — pairwise O(n²) bbox intersection check, threshold >25% of smaller bbox area
- Wires the store through `HubApp` → `InstancePanel` → `InstancePanelDrawer`
- Warning row appears below the data-age line for each affected backend, using Bootstrap's `text-warning` colour and a triangle icon
- No extra API calls — all bboxes already available from `get_meta` responses
- Translation keys added in `de.json` and `en.json`

Tested locally with two backends pointing to the same PostgREST instance (identical bboxes → 100% overlap → both show warning).

Closes #251.

## Test plan

- [ ] Set `appMode: 'hub'` in `app/public/config.js`, add two overlapping backends to `registry.json`, run `make docker-build`, open http://localhost:8080 — both backends should show the overlap warning
- [ ] Adjacent non-overlapping backends (e.g. Hessen + Bayern) must NOT show a warning
- [ ] A backend fully contained within another (e.g. a city backend inside its Bundesland) SHOULD show a warning on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)