### PR TITLE
feat(hub): show backend name in PlaygroundPanel header

### DIFF
--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -19,7 +19,7 @@
   import { overlayFeaturesStore } from '../stores/overlayLayer.js';
   import { groupEquipment } from '../lib/equipmentGrouping.js';
   import { playgroundCompleteness } from '../lib/completeness.js';
-  import { poiRadiusM } from '../lib/config.js';
+  import { poiRadiusM, appMode } from '../lib/config.js';
   import { getPlaygroundTitle, getPlaygroundLocation } from '../lib/playgroundHelpers.js';
   import { cn } from '../lib/utils.js';
   import EquipmentList from './EquipmentList.svelte';
@@ -35,9 +35,10 @@
   export let embedded = false;
 
   // ── Derived state from selection store ────────────────────────────────────
-  $: feature    = $selection.feature;
-  $: backendUrl = $selection.backendUrl;
-  $: attr       = feature ? feature.getProperties() : null;
+  $: feature     = $selection.feature;
+  $: backendUrl  = $selection.backendUrl;
+  $: attr        = feature ? feature.getProperties() : null;
+  $: backendName = appMode === 'hub' ? (feature?.get('_backendName') ?? null) : null;
 
   // ── Async data ────────────────────────────────────────────────────────────
   let equipmentFeatures = [];
@@ -417,6 +418,9 @@
           {#if getPlaygroundLocation(attr, $_)}
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr, $_)}</p>
           {/if}
+          {#if backendName}
+            <p class="backend-name">{backendName}</p>
+          {/if}
           {#if completeness || dataAgeFormatted}
             <div class="flex items-center gap-2 flex-wrap mt-2">
               {#if completeness}
@@ -457,6 +461,9 @@
           <h2 class="panel-title">{getPlaygroundTitle(attr, $_)}</h2>
           {#if getPlaygroundLocation(attr, $_)}
             <p class="text-sm text-muted-foreground mt-0.5">{getPlaygroundLocation(attr, $_)}</p>
+          {/if}
+          {#if backendName}
+            <p class="backend-name">{backendName}</p>
           {/if}
           {#if completeness || dataAgeFormatted}
             <div class="flex items-center gap-2 flex-wrap mt-2">
@@ -970,6 +977,15 @@
     color: #9ca3af;
     text-transform: uppercase;
     letter-spacing: 0.06em;
+  }
+
+  .backend-name {
+    margin: 0.15rem 0 0;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: #9ca3af;
   }
 
   /* ── Data-age chip + fixed popover ──────────────────────────────────── */

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -396,6 +396,7 @@ function parsePolygonFeatures(geojson, backendUrl, backend) {
     f.set('_backendUrl', backendUrl);
     f.set('_lastImportAt', backend?.lastImportAt ?? null);
     if (backend?.slug) f.set('_backendSlug', backend.slug);
+    if (backend?.name) f.set('_backendName', backend.name);
   });
   return features;
 }

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -109,7 +109,7 @@ export function createRegistry() {
           // pre-#301 backends that don't yet ship api.import_status. Used by
           // the polygon-tier dedup to pick the fresher copy when two backends
           // return the same osm_id.
-          patch.lastImportAt = meta.last_import_at ?? null;
+          patch.lastImportAt = backend.lastImportAt ?? meta.last_import_at ?? null;
           if (!backend.name && patch.region) patch.name = patch.region;
         }
 
@@ -140,7 +140,7 @@ export function createRegistry() {
           bbox:             null,
           playgroundCount:  0,
           completeness:     null,  // populated after get_meta lands; see status-shape JSDoc
-          lastImportAt:     null,  // from get_meta.last_import_at; used by polygon-tier dedup (#202)
+          lastImportAt:     entry.lastImportAt ?? null,  // registry.json override takes priority; else from get_meta.last_import_at
           // Populated from /federation-status.json (hub-side cron poll, this change)
           healthUp:         null,  // null = unknown, true/false = known
           dataAgeSec:       null,  // seconds since the importer last ran (operator-facing)

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -109,7 +109,7 @@ export function createRegistry() {
           // pre-#301 backends that don't yet ship api.import_status. Used by
           // the polygon-tier dedup to pick the fresher copy when two backends
           // return the same osm_id.
-          patch.lastImportAt = backend.lastImportAt ?? meta.last_import_at ?? null;
+          patch.lastImportAt = backend._lastImportAtOverride ?? meta.last_import_at ?? null;
           if (!backend.name && patch.region) patch.name = patch.region;
         }
 
@@ -140,7 +140,8 @@ export function createRegistry() {
           bbox:             null,
           playgroundCount:  0,
           completeness:     null,  // populated after get_meta lands; see status-shape JSDoc
-          lastImportAt:     entry.lastImportAt ?? null,  // registry.json override takes priority; else from get_meta.last_import_at
+          lastImportAt:     null,  // from get_meta.last_import_at; used by polygon-tier dedup (#202)
+          _lastImportAtOverride: entry.lastImportAt ?? null,  // registry.json static override; takes priority over meta on every poll
           // Populated from /federation-status.json (hub-side cron poll, this change)
           healthUp:         null,  // null = unknown, true/false = known
           dataAgeSec:       null,  // seconds since the importer last ran (operator-facing)


### PR DESCRIPTION
Closes #518

## Summary

- `hubOrchestrator.js`: stamps `_backendName` on every polygon feature from `backend.name`
- `PlaygroundPanel.svelte`: reads `_backendName` when `appMode === 'hub'` and renders it as a small uppercase subtitle below the playground title (11 px, bold, `#9ca3af` — same style as PHOTOS/REVIEWS section headers)
- `registry.js`: supports an optional `lastImportAt` field in `registry.json` entries; when present it takes priority over the value from `get_meta()` (useful for local dedup-winner testing without separate DBs)

## Test plan

- [ ] Set `appMode: 'hub'` in `config.js`, add two backends to `registry.json` with different `lastImportAt` values, run `make docker-build`
- [ ] Open a playground — header shows backend name (e.g. "LOCAL") in uppercase below the title
- [ ] Switch to `appMode: 'standalone'` — backend name label is absent
- [ ] Dedup: backend with newer `lastImportAt` wins; its name appears on all shared playgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)