### PR TITLE
feat(shade): include natural=tree_row in playground shade hint

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -14,7 +14,7 @@
     playgroundStyleFn,
     selectionStyle,
     equipmentLayerStyleFn,
-    treeStyle,
+    treeStyleFn,
     clusterTierStyleFn,
   } from '../lib/vectorStyles.js';
   import { macroRingStyleFn } from '../hub/macroRingStyle.js';
@@ -144,7 +144,7 @@
           { type: 'FeatureCollection', features: trees },
           { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' }
         ));
-        treeLayer = new VectorLayer({ source: src, zIndex: 15, style: () => treeStyle });
+        treeLayer = new VectorLayer({ source: src, zIndex: 15, style: treeStyleFn });
         olMap.addLayer(treeLayer);
       }
     });

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -44,6 +44,7 @@
   let equipmentFeatures = [];
   let equipmentGroups = [];
   let pois = [];
+  let treeRows = [];
   let equipmentLoading = false;
   let poisLoading = false;
 
@@ -177,6 +178,7 @@
     equipmentFeatures = [];
     equipmentGroups = [];
     pois = [];
+    treeRows = [];
     overlayFeaturesStore.set({ equipment: [], trees: [] });
   }
 
@@ -225,6 +227,7 @@
       if (gen === loadGen) {
         equipmentFeatures = [];
         equipmentGroups = [];
+        treeRows = [];
         // Clear stale equipment from the previous selection's overlay so
         // the map doesn't keep showing wrong dots on the new playground.
         overlayFeaturesStore.set({ equipment: [], trees: [] });
@@ -235,7 +238,12 @@
 
     try {
       const treeGeojson = await fetchTrees(ext, url);
-      if (gen === loadGen) localTrees = treeGeojson.features ?? [];
+      if (gen === loadGen) {
+        localTrees = treeGeojson.features ?? [];
+        treeRows = localTrees
+          .filter(f => f.properties?.feature_type === 'tree_row' && f.properties?.length_m != null)
+          .map(f => f.properties.length_m);
+      }
     } catch (err) {
       // Trees silently ignored on error (e.g. Overpass/dev mode)
     }
@@ -545,10 +553,15 @@
           </div>
         {/if}
 
-        {#if attr.tree_count > 0}
+        {#if attr.tree_count > 0 || treeRows.length > 0}
           <div class="fact-item">
-            <span class="info-label">{$_('hover.tagTrees')}</span>
-            <span class="fact-value">{attr.tree_count}</span>
+            <span class="info-label">{$_('details.treeShadow')}{treeRows.length > 0 ? ` (${treeRows.length})` : ''}</span>
+            <span class="fact-value">
+              {[
+                attr.tree_count > 0 ? `${attr.tree_count} ${$_('hover.tagTrees')}` : null,
+                treeRows.length > 0 ? treeRows.map(m => `${m} m`).join(', ') : null,
+              ].filter(Boolean).join(' / ')}
+            </span>
           </div>
         {/if}
 

--- a/app/src/lib/vectorStyles.js
+++ b/app/src/lib/vectorStyles.js
@@ -128,6 +128,15 @@ export const treeStyle = new Style({
     })
 });
 
+const treeRowStyle = new Style({
+    stroke: new Stroke({ color: '#155215', width: 2 })
+});
+
+export function treeStyleFn(feature) {
+    const type = feature.getGeometry()?.getType();
+    return type === 'LineString' || type === 'MultiLineString' ? treeRowStyle : treeStyle;
+}
+
 // ── Tiered-delivery styles (P1 §3 / §4) ───────────────────────────────────────
 
 // Cluster tier (zoom ≤ clusterMaxZoom) — canvas-rendered stacked ring with

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -1057,7 +1057,10 @@ GRANT EXECUTE ON FUNCTION api.get_pois(float8, float8, integer) TO web_anon;
 
 -- =========================================================================
 -- 4. get_trees(min_lon, min_lat, max_lon, max_lat)
---    Returns natural=tree nodes within a WGS84 bounding box as GeoJSON.
+--    Returns natural=tree nodes and natural=tree_row lines within a WGS84
+--    bounding box as GeoJSON. Each feature carries a `feature_type` property
+--    ('tree' or 'tree_row'). Tree rows also carry `length_m` (rounded metres)
+--    so the frontend can display row lengths without a fake tree-count estimate.
 -- =========================================================================
 DROP FUNCTION IF EXISTS api.get_trees(float8, float8, float8, float8);
 
@@ -1076,6 +1079,29 @@ AS $$
       ST_MakeEnvelope(min_lon, min_lat, max_lon, max_lat, 4326),
       3857
     ) AS geom
+  ),
+  features AS (
+    SELECT
+      p.osm_id,
+      p.name,
+      p.way,
+      'tree'::text    AS feature_type,
+      NULL::int       AS length_m,
+      hstore_to_jsonb(p.tags) AS tags
+    FROM planet_osm_point p, bbox b
+    WHERE p.way && b.geom
+      AND p.natural = 'tree'
+    UNION ALL
+    SELECT
+      l.osm_id,
+      l.name,
+      l.way,
+      'tree_row'::text                            AS feature_type,
+      round(ST_Length(ST_Transform(l.way, 4326)::geography))::int AS length_m,
+      hstore_to_jsonb(l.tags)                     AS tags
+    FROM planet_osm_line l, bbox b
+    WHERE l.way && b.geom
+      AND l.natural = 'tree_row'
   )
   SELECT json_build_object(
     'type', 'FeatureCollection',
@@ -1083,19 +1109,19 @@ AS $$
       json_agg(
         json_build_object(
           'type', 'Feature',
-          'geometry', ST_AsGeoJSON(ST_Transform(p.way, 4326))::json,
+          'geometry', ST_AsGeoJSON(ST_Transform(f.way, 4326))::json,
           'properties', jsonb_build_object(
-            'osm_id', p.osm_id,
-            'name',   p.name
-          ) || COALESCE(hstore_to_jsonb(p.tags), '{}'::jsonb)
+            'osm_id',       f.osm_id,
+            'name',         f.name,
+            'feature_type', f.feature_type,
+            'length_m',     f.length_m
+          ) || COALESCE(f.tags, '{}'::jsonb)
         )
       ),
       '[]'::json
     )
   )
-  FROM planet_osm_point p, bbox b
-  WHERE p.way && b.geom
-    AND p.natural = 'tree';
+  FROM features f;
 $$;
 
 GRANT EXECUTE ON FUNCTION api.get_trees(float8, float8, float8, float8) TO web_anon;

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -224,6 +224,7 @@ run_import() (
             "$IMPORT_PBF" \
             --overwrite \
             n/natural=tree \
+            w/natural=tree_row \
             n/leisure=playground \
             n/leisure=pitch \
             n/leisure=fitness_station \

--- a/locales/de.json
+++ b/locales/de.json
@@ -415,6 +415,7 @@
     "sizeUnknown": "unbekannt",
     "surfaceLabel": "Bodenbelag",
     "treesLabel": "Bäume mind.",
+    "treeShadow": "Bäume / Reihen",
     "accessLabel": "Zugänglichkeit",
     "ageLabel": "Alter",
     "ageRange": "{min}–{max} Jahre",

--- a/locales/en.json
+++ b/locales/en.json
@@ -415,6 +415,7 @@
     "sizeUnknown": "unknown",
     "surfaceLabel": "Surface",
     "treesLabel": "Trees (min.)",
+    "treeShadow": "Trees / rows",
     "accessLabel": "Accessibility",
     "ageLabel": "Age",
     "ageRange": "{min}–{max} years",


### PR DESCRIPTION
Closes #520

## Summary

- `import.sh`: adds `w/natural=tree_row` to the osmium tag filter so tree row ways survive the pre-filter step
- `api.sql`: `get_trees()` now UNIONs `natural=tree` points with `natural=tree_row` lines; rows carry a `feature_type` and `length_m` (rounded metres via `ST_Length`)
- `vectorStyles.js`: adds `treeStyleFn` — returns a dark green line style for LineString/MultiLineString features, existing dot style for points
- `Map.svelte`: switches tree layer to `treeStyleFn` so rows render as lines on the map
- `PlaygroundPanel.svelte`: merges trees and rows into one fact-item — label `BÄUME / REIHEN (N)`, value `3 Bäume / 29 m` — avoids a misleading fake tree count from row length

## Test plan

- [ ] Run `make import` after pulling (tag filter cache must be invalidated — delete `/data/*_tags.pbf` or the cache auto-invalidates on PBF change)
- [ ] Open a playground with nearby tree rows (e.g. Spielplatz Rhönblickstraße, Fulda) — panel shows combined "BÄUME / REIHEN (1) / 3 Bäume / 29 m"
- [ ] Tree row renders as a dark green line on the map when the playground is selected
- [ ] Playgrounds with only individual trees: label shows "BÄUME / REIHEN" without count suffix, value shows only tree count
- [ ] Playgrounds with neither: fact-item hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)