### PR TITLE
fix(importer): apply api.sql on every daemon-mode startup

### DIFF
--- a/importer/import.sh
+++ b/importer/import.sh
@@ -467,6 +467,12 @@ elif [ -n "$REIMPORT_INTERVAL_MIN_DAYS" ] && [ -n "$REIMPORT_INTERVAL_MAX_DAYS" 
     # reliable fallback. Ignored if the DB isn't up yet (|| true).
     _clear_importing
 
+    # Always apply api.sql on startup so schema changes from a new image take
+    # effect immediately — even when the PBF reimport is deferred by the grace
+    # check below. Without this, a Watchtower image update would leave the app
+    # running against the old schema for up to REIMPORT_INTERVAL days.
+    run_api_apply
+
     # Startup grace check: if a recent import is on record in the DB, sleep
     # until the next scheduled time rather than importing immediately. This
     # prevents an unplanned full re-import every time the container is


### PR DESCRIPTION
Closes #522

## Summary

- Adds a `run_api_apply` call in the daemon-mode startup path, right after `_clear_importing` and before the grace-period sleep
- Schema changes in a new image now take effect within seconds of container restart, even when the next full PBF reimport is hours away
- The subsequent `run_import` in the loop also applies `api.sql` — the double application is idempotent and harmless

## Test plan

- [ ] Start importer in daemon mode with a recent `last_import_at` (grace check will sleep) — verify `api.sql` is applied and PostgREST is reloaded before the sleep
- [ ] Confirm one-shot mode (`API_ONLY` unset, no interval vars) is unchanged
- [ ] Confirm `API_ONLY=true` mode is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)