### PR TITLE
fix(importer): wire REIMPORT_INTERVAL_* vars through compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -56,6 +56,8 @@ services:
       PG_MAINTENANCE_WORK_MEM:             ${PG_MAINTENANCE_WORK_MEM:-512MB}
       PG_WORK_MEM:                         ${PG_WORK_MEM:-128MB}
       SPIELI_VERSION:                      ${SPIELI_VERSION:-unknown}
+      REIMPORT_INTERVAL_MIN_DAYS:          ${REIMPORT_INTERVAL_MIN_DAYS:-}
+      REIMPORT_INTERVAL_MAX_DAYS:          ${REIMPORT_INTERVAL_MAX_DAYS:-}
       IMPRESSUM_NAME:                      ${IMPRESSUM_NAME:-}
       IMPRESSUM_ORG:                       ${IMPRESSUM_ORG:-}
       IMPRESSUM_ADDRESS:                   ${IMPRESSUM_ADDRESS:-}


### PR DESCRIPTION
## Summary

- `REIMPORT_INTERVAL_MIN_DAYS` and `REIMPORT_INTERVAL_MAX_DAYS` were present in `.env.example` but missing from the `importer` service `environment` block in `compose.yml`
- Daemon mode was silently inactive in all Docker Compose deployments — the grace check and scheduled reimport never fired
- This also means the #522 fix (apply `api.sql` on daemon startup) was never exercised in practice

Closes #524

## Test plan

- [ ] Set `REIMPORT_INTERVAL_MIN_DAYS=1` and `REIMPORT_INTERVAL_MAX_DAYS=2` in `.env`
- [ ] Run `docker compose run --rm importer` (with `profiles: [import]` temporarily removed or via daemon profile)
- [ ] Confirm daemon mode activates — importer logs grace-check message and sleeps instead of re-importing immediately after a recent import

🤖 Generated with [Claude Code](https://claude.com/claude-code)