### PR TITLE
fix(hub): stamp _backendName on deeplink-hydrated features; add E2E tests

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -84,7 +84,7 @@
    * on every source `change` event as more backends populate, but only log the
    * "unknown slug" warning once. Standalone passes `null`, so any slug in the
    * hash is silently ignored.
-   * @type {((slug: string) => string | null) | null}
+   * @type {((slug: string) => {url: string, name: string|null} | null) | null}
    */
   export let resolveSlugToBackendUrl = null;
 
@@ -94,7 +94,7 @@
    * hydration so a slug-less hash can still rewrite to its canonical
    * `#<slug>/W<id>` form once the matching backend is identified.
    * Standalone passes `null`.
-   * @type {(() => Array<{url: string, slug: string|null}>) | null}
+   * @type {(() => Array<{url: string, slug: string|null, name: string|null}>) | null}
    */
   export let getAllBackendUrls = null;
 
@@ -130,15 +130,15 @@
     let candidates = playgroundSource.getFeatures();
 
     if (parsed.slug && resolveSlugToBackendUrl) {
-      const targetUrl = resolveSlugToBackendUrl(parsed.slug);
-      if (!targetUrl) {
+      const resolved = resolveSlugToBackendUrl(parsed.slug);
+      if (!resolved) {
         if (!warnedUnknownSlug) {
           console.warn(`[deeplink] unknown registry slug "${parsed.slug}" — will retry as backends load`);
           warnedUnknownSlug = true;
         }
         return;
       }
-      candidates = candidates.filter(f => f.get('_backendUrl') === targetUrl);
+      candidates = candidates.filter(f => f.get('_backendUrl') === resolved.url);
     }
 
     const matches = candidates.filter(f => f.get('osm_id') === parsed.osmId);
@@ -197,17 +197,17 @@
           console.warn(`[deeplink] osm_id ${parsed.osmId} matched ${matches.length} backends — selecting the first`);
         }
         if (matches.length > 0) {
-          const { feat, url, slug } = matches[0];
+          const { feat, url, slug, name } = matches[0];
           const olFeatures = geojsonFormat.readFeatures(
             { type: 'FeatureCollection', features: [feat] },
             { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' },
           );
-          // Stamp both URL and (when present) slug — the slug is what the
-          // selection store uses to rewrite the hash from `#W<id>` to the
-          // canonical `#<slug>/W<id>` form on broadcast hits.
+          // Stamp URL, slug (for hash canonicalisation), and name (for the
+          // backend subtitle in PlaygroundPanel) on every hydrated feature.
           for (const f of olFeatures) {
             f.set('_backendUrl', url);
             if (slug) f.set('_backendSlug', slug);
+            if (name) f.set('_backendName', name);
           }
           playgroundSource.addFeatures(olFeatures);
           // The standard match path inside `playgroundSource.on('change')`
@@ -231,9 +231,12 @@
     }
 
     let hydrateFromUrl = null;
+    let hydrateFromName = null;
     if (parsed.slug && resolveSlugToBackendUrl) {
-      hydrateFromUrl = resolveSlugToBackendUrl(parsed.slug);
-      if (!hydrateFromUrl) return; // unknown slug — keep waiting (warned above)
+      const resolved = resolveSlugToBackendUrl(parsed.slug);
+      if (!resolved) return; // unknown slug — keep waiting (warned above)
+      hydrateFromUrl = resolved.url;
+      hydrateFromName = resolved.name;
     } else if (!parsed.slug && !resolveSlugToBackendUrl) {
       hydrateFromUrl = defaultBackendUrl;
     } else {
@@ -247,12 +250,13 @@
           { type: 'FeatureCollection', features: [feature] },
           { dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' },
         );
-        // Stamp `_backendUrl` (and `_backendSlug` when present) so the
-        // standard match path's `f.get('_backendUrl') ?? defaultBackendUrl`
-        // routes selection to the right hub backend.
+        // Stamp `_backendUrl`, `_backendSlug` (when present), and `_backendName`
+        // so the standard match path routes to the right hub backend and
+        // PlaygroundPanel can show the backend name subtitle.
         for (const f of olFeatures) {
           f.set('_backendUrl', hydrateFromUrl);
           if (parsed.slug) f.set('_backendSlug', parsed.slug);
+          if (hydrateFromName) f.set('_backendName', hydrateFromName);
         }
         playgroundSource.addFeatures(olFeatures);
       } else {

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -71,16 +71,16 @@
   // list via `get()` so AppShell can call it from its restore loop without
   // taking a store subscription of its own.
   function resolveSlugToBackendUrl(slug) {
-    return get(backends).find(b => b.slug === slug)?.url ?? null;
+    const b = get(backends).find(b => b.slug === slug);
+    return b ? { url: b.url, name: b.name ?? null } : null;
   }
 
   // Sync accessor for the slug-less broadcast deeplink path. AppShell fans
   // `fetchPlaygroundByOsmId` across these URLs in parallel; first hit wins.
-  // Also returns each backend's slug so the broadcast result can stamp
-  // `_backendSlug` on the hydrated feature — preserves the
-  // `#W<id>` → `#<slug>/W<id>` URL canonicalisation.
+  // Returns slug and name so deeplink hydration can stamp both `_backendSlug`
+  // and `_backendName` on the hydrated feature.
   function getAllBackendUrls() {
-    return get(backends).map(b => ({ url: b.url, slug: b.slug ?? null }));
+    return get(backends).map(b => ({ url: b.url, slug: b.slug ?? null, name: b.name ?? null }));
   }
 
   // Hub-only retry hook for AppShell.tryRestoreFromHash. The deeplink

--- a/tests/hub-deeplink.spec.js
+++ b/tests/hub-deeplink.spec.js
@@ -70,4 +70,11 @@ test.describe('Hub deep-link', () => {
     // the warning never triggers. Pinning this would make the test flaky.
     await expect(panel).toContainText(/Shared [AB] copy/);
   });
+
+  test('backend name subtitle shown in panel after hub selection', async ({ page }) => {
+    await page.goto(`/#slug-a/W111`);
+    const panel = page.locator('aside.info-panel');
+    await expect(panel).toBeVisible({ timeout: 8000 });
+    await expect(panel.locator('.backend-name')).toContainText('Instanz A');
+  });
 });

--- a/tests/hub-pill.spec.js
+++ b/tests/hub-pill.spec.js
@@ -172,3 +172,68 @@ test.describe('Hub instance pill + drawer', () => {
     await expect(itemA.locator('.instance-badge--importing')).toHaveCount(0, { timeout: 5000 });
   });
 });
+
+test.describe('Hub bbox overlap warning', () => {
+  // instanceA has a large bbox; instanceB's bbox is fully contained within it.
+  // Intersection area / smaller area = 1.0 > 0.25 → warning must appear for both.
+  const outer = {
+    slug: 'slug-outer', url: '/api-outer', name: 'Outer Region',
+    playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 10, name: 'P outer', lon: 9.5, lat: 50.5 })] },
+    meta: { name: 'Outer Region', bbox: [9.0, 50.0, 10.0, 51.0], playground_count: 1, complete: 1, partial: 0, missing: 0 },
+  };
+  const inner = {
+    slug: 'slug-inner', url: '/api-inner', name: 'Inner Region',
+    playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 20, name: 'P inner', lon: 9.5, lat: 50.5 })] },
+    meta: { name: 'Inner Region', bbox: [9.2, 50.2, 9.8, 50.8], playground_count: 1, complete: 0, partial: 1, missing: 0 },
+  };
+
+  test('overlap warning shown in drawer when backend bboxes overlap significantly', async ({ page }) => {
+    await injectHubConfig(page);
+    await stubHubRegistry(page, { instanceA: outer, instanceB: inner });
+    await page.goto('/');
+
+    const pill = page.locator('.instance-slot .pill');
+    await expect(pill).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+
+    await pill.click();
+    const drawer = page.locator('.drawer[role="dialog"]');
+    await expect(drawer).toBeVisible();
+
+    // Both backends share significant bbox overlap → each must carry a warning row.
+    await expect(drawer.locator('.instance-overlap')).toHaveCount(2);
+    // The outer backend's warning names the inner backend, and vice-versa.
+    // Use .instance-name to avoid matching the other backend's warning text.
+    const outerItem = drawer.locator('.instance-item').filter({
+      has: page.locator('.instance-name', { hasText: 'Outer Region' }),
+    });
+    await expect(outerItem.locator('.instance-overlap')).toContainText('Inner Region');
+    const innerItem = drawer.locator('.instance-item').filter({
+      has: page.locator('.instance-name', { hasText: 'Inner Region' }),
+    });
+    await expect(innerItem.locator('.instance-overlap')).toContainText('Outer Region');
+  });
+
+  test('no overlap warning when backend bboxes are non-overlapping', async ({ page }) => {
+    const west = {
+      slug: 'slug-west', url: '/api-west', name: 'West Region',
+      playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 30, name: 'P west', lon: 8.5, lat: 50.5 })] },
+      meta: { name: 'West Region', bbox: [8.0, 50.0, 9.0, 51.0], playground_count: 1, complete: 1, partial: 0, missing: 0 },
+    };
+    const east = {
+      slug: 'slug-east', url: '/api-east', name: 'East Region',
+      playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 40, name: 'P east', lon: 10.5, lat: 50.5 })] },
+      meta: { name: 'East Region', bbox: [10.0, 50.0, 11.0, 51.0], playground_count: 1, complete: 0, partial: 1, missing: 0 },
+    };
+
+    await injectHubConfig(page);
+    await stubHubRegistry(page, { instanceA: west, instanceB: east });
+    await page.goto('/');
+
+    const pill = page.locator('.instance-slot .pill');
+    await expect(pill).toContainText(/2\s+(Regionen|regions)/, { timeout: 8000 });
+
+    await pill.click();
+    await expect(page.locator('.drawer[role="dialog"]')).toBeVisible();
+    await expect(page.locator('.instance-overlap')).toHaveCount(0);
+  });
+});

--- a/tests/selection.spec.js
+++ b/tests/selection.spec.js
@@ -13,6 +13,15 @@ async function loadWithSelection(page) {
   await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
 }
 
+const TREE_ROW_FC = {
+  type: 'FeatureCollection',
+  features: [{
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates: [[9.675, 50.551], [9.676, 50.552]] },
+    properties: { osm_id: -1, feature_type: 'tree_row', length_m: 42 },
+  }],
+};
+
 test.describe('Playground selection', () => {
   test('info panel opens when playground is pre-selected via URL hash', async ({ page }) => {
     await loadWithSelection(page);
@@ -42,5 +51,28 @@ test.describe('Playground selection', () => {
     await stubApiRoutes(page);
     await page.goto(`/#irrelevant-slug/W${OSM_ID}`);
     await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
+  });
+});
+
+test.describe('Shade hint (tree_row)', () => {
+  test('panel shows row length when get_trees returns a tree_row feature', async ({ page }) => {
+    await injectApiConfig(page);
+    await stubApiRoutes(page);
+    // Override the default empty get_trees stub (LIFO — this wins).
+    await page.route('**/rpc/get_trees**', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TREE_ROW_FC) })
+    );
+    await page.goto(`/#W${OSM_ID}`);
+    await expect(page.locator('aside.info-panel')).toBeVisible({ timeout: 8000 });
+
+    // The shade hint row is keyed by the "Reihen"/"rows" label substring.
+    const shadeRow = page.locator('.fact-item').filter({
+      has: page.locator('.info-label', { hasText: /Reihen|rows/i }),
+    });
+    await expect(shadeRow).toBeVisible({ timeout: 5000 });
+    // Row count in parentheses after label.
+    await expect(shadeRow.locator('.info-label')).toContainText('(1)');
+    // Length in metres in the value cell.
+    await expect(shadeRow.locator('.fact-value')).toContainText('42 m');
   });
 });


### PR DESCRIPTION
## Summary

- `resolveSlugToBackendUrl` in `HubApp.svelte` now returns `{ url, name }` instead of a bare URL string
- `getAllBackendUrls` now includes `name` in each entry
- Both broadcast and slug-scoped hydration paths in `AppShell.svelte` stamp `_backendName` on the hydrated OL features — the backend subtitle in `PlaygroundPanel` was blank for any playground opened via URL hash in hub mode

Closes #526

## Tests added (3 new E2E tests)

| File | Test |
|---|---|
| `selection.spec.js` | Shade hint shows row count + lengths when `get_trees` returns `tree_row` features |
| `hub-deeplink.spec.js` | `.backend-name` subtitle visible after slug-scoped hub selection |
| `hub-pill.spec.js` | Overlap warning appears for significantly overlapping bboxes; absent for disjoint backends |

## Test plan

- [ ] CI passes
- [ ] Hub: open playground via `#slug/W<id>` URL — backend name subtitle visible in panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)