### PR TITLE
fix(hub): raise bbox overlap threshold to 50% to suppress false positives

### DIFF
--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -232,10 +232,11 @@ export function createRegistry() {
   });
 
   // Map from backend URL to array of overlapping backend names.
-  // Two backends overlap when their bbox intersection area exceeds 25% of the
+  // Two backends overlap when their bbox intersection area exceeds 50% of the
   // smaller backend's bbox area — large enough to catch containment (e.g. a
-  // city inside a Bundesland) while ignoring rectangular-bbox border slivers
-  // between adjacent regions. Backends without a bbox are ignored.
+  // Kreis inside a Bundesland, ratio ~1.0) while ignoring the rectangular-bbox
+  // border clips that occur between neighbouring regions (typically 10–30%).
+  // Backends without a bbox are ignored.
   const overlapWarnings = derived(store, ($backends) => {
     const withBbox = $backends.filter(b => b.bbox);
     /** @type {Map<string, string[]>} */
@@ -254,7 +255,7 @@ export function createRegistry() {
         const intersectArea = (iMaxLon - iMinLon) * (iMaxLat - iMinLat);
         const aArea = (aMaxLon - aMinLon) * (aMaxLat - aMinLat);
         const bArea = (bMaxLon - bMinLon) * (bMaxLat - bMinLat);
-        if (intersectArea / Math.min(aArea, bArea) > 0.25) {
+        if (intersectArea / Math.min(aArea, bArea) > 0.5) {
           if (!warnings.has(a.url)) warnings.set(a.url, []);
           if (!warnings.has(b.url)) warnings.set(b.url, []);
           warnings.get(a.url).push(b.name);

--- a/tests/hub-pill.spec.js
+++ b/tests/hub-pill.spec.js
@@ -175,7 +175,7 @@ test.describe('Hub instance pill + drawer', () => {
 
 test.describe('Hub bbox overlap warning', () => {
   // instanceA has a large bbox; instanceB's bbox is fully contained within it.
-  // Intersection area / smaller area = 1.0 > 0.25 → warning must appear for both.
+  // Intersection area / smaller area = 1.0 > 0.5 → warning must appear for both.
   const outer = {
     slug: 'slug-outer', url: '/api-outer', name: 'Outer Region',
     playgrounds: { type: 'FeatureCollection', features: [makePlayground({ osmId: 10, name: 'P outer', lon: 9.5, lat: 50.5 })] },


### PR DESCRIPTION
## Summary

- Raises the bbox overlap threshold from `> 0.25` to `> 0.5`
- Neighbouring regions (e.g. German Bundesländer) have rectangular bboxes that clip each other at shared borders (~10–30% ratio) — the old 25% threshold flagged all of them as warnings
- Genuine containment (a Kreis fully inside a Bundesland) still fires at ~100%

Closes #528

## Test plan

- [ ] CI passes
- [ ] Hub with Germany Bundesländer registry shows no spurious overlap warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)