### PR TITLE
ci: auto-create GitHub release on tag push

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: "⚠️ Database changes — API_ONLY run required after upgrading"
+      labels:
+        - requires-schema-update
+    - title: "🔴 Full re-import required after upgrading"
+      labels:
+        - requires-reimport
+    - title: "New features"
+      labels:
+        - enhancement
+    - title: "Bug fixes"
+      labels:
+        - bug
+    - title: "Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: VERSION=${{ steps.meta.outputs.version }}
 
+  # ── GitHub Release ───────────────────────────────────────────────────────────
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: [docker, docker-importer]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+
   # ── Importer image (unchanged) ───────────────────────────────────────────────
   docker-importer:
     name: Docker (importer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,9 +109,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          FOOTER=$(cat <<'EOF'
+
+---
+
+## Upgrading
+
+See [Standard update](https://mfuhrmann.github.io/spieli/ops/upgrade/#standard-update) for full instructions.
+
+| Label in release above | Action required |
+|---|---|
+| ⚠️ Database changes | Pull + restart + `docker compose --profile <mode> run --rm -e API_ONLY=1 importer` |
+| 🔴 Full re-import required | Pull + restart + full re-import (no `API_ONLY`) |
+| *(no label)* | Pull + restart is sufficient |
+EOF
+          )
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --generate-notes
+            --generate-notes \
+            --notes-file <(gh api "/repos/${{ github.repository }}/releases/generate-notes" \
+              -f tag_name="${{ github.ref_name }}" \
+              --jq '.body' && printf '%s' "$FOOTER")
 
   # ── Importer image (unchanged) ───────────────────────────────────────────────
   docker-importer:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,12 @@ spieli is an interactive web map for exploring playgrounds based on OpenStreetMa
 ### Release procedure
 
 1. Bump `package.json` version: remove `-rc` (e.g. `0.1.7-rc` → `0.1.7`). Commit: `chore: release v0.1.7`.
-2. Tag: `git tag v0.1.7 && git push origin v0.1.7`. CI publishes `:latest`, `:0.1.7`, `:0.1` images.
+2. Tag: `git tag v0.1.7 && git push origin v0.1.7`. CI publishes `:latest`, `:0.1.7`, `:0.1` images and creates a GitHub release automatically.
 3. Advance `main`: bump to next `-rc` (e.g. `0.1.8-rc`). Commit: `chore: bump version to 0.1.8-rc`.
+
+**PR labels for release notes** — label PRs before merging so the auto-generated release notes show the correct upgrade action:
+- `requires-schema-update` — `api.sql` changed; operators must run `API_ONLY=1` after upgrading.
+- `requires-reimport` — data model changed; operators must run a full re-import.
 
 ## Development commands
 

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -309,3 +309,17 @@ docker compose -f compose.yml --profile <mode> run --rm importer
 **Cause:** `IMPRESSUM_ADDRESS` is also required. The entrypoint skips generation when either of the two required vars is empty.
 
 **Fix:** Set both `IMPRESSUM_NAME` and `IMPRESSUM_ADDRESS` in `.env`, then `make docker-build`.
+
+---
+
+**Symptom:** PostgREST logs `relation "public.playground_stats" does not exist` after an upgrade.
+
+**Cause:** The `API_ONLY=1` importer run dropped the `playground_stats` materialised view but failed before recreating it, leaving the database in a broken state.
+
+**Fix:** Run a full re-import to rebuild everything from scratch:
+
+```bash
+docker compose -f compose.yml --profile <mode> run --rm importer
+```
+
+This re-applies `api.sql` (recreating `playground_stats`) and re-imports OSM data. It takes longer than `API_ONLY=1` but is always safe.

--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -36,6 +36,9 @@ Replace `<mode>` with your `DEPLOY_MODE` (`data-node`, `ui`, or `data-node-ui`).
 !!! note
     The `API_ONLY=1` step is required on every upgrade, not just when the release notes mention SQL changes. The version number visible in the Hub regions panel comes from the database (written by the importer), not the app image — skipping this step leaves the reported version stale.
 
+!!! warning "If API_ONLY fails mid-run"
+    `API_ONLY=1` drops and recreates the `playground_stats` materialised view. If it crashes partway through, the view is gone and PostgREST will log errors like `relation "public.playground_stats" does not exist`. Recovery: run a **full re-import** (see below) — this recreates everything from scratch.
+
 ## When to run a full re-import
 
 A full re-import (without `API_ONLY`) is needed when:


### PR DESCRIPTION
## Summary
- Adds a `release` job to `build.yml` that runs after both Docker images are built
- Only fires on `v*` tag pushes
- Uses `gh release create --generate-notes` to populate release notes from merged PR titles automatically

## Test plan
- [ ] Merge and push next version tag — verify GitHub release is created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)