### PR TITLE
fix(ux): move active filter chips below filter buttons

### DIFF
--- a/app/src/components/AppShell.svelte
+++ b/app/src/components/AppShell.svelte
@@ -440,7 +440,6 @@
   {#if !(isMobile && $hasSelection)}
     <div class="search-area">
       <SearchBar regionExtent={$searchExtent} onlocation={handleLocation} />
-      <FilterChips />
       {#if nearbyLocation}
         <NearbyPlaygrounds
           lat={nearbyLocation.lat}
@@ -457,15 +456,18 @@
 
     <!-- On mobile: pencil (info) on top, filter below — avoids clashing with search bar -->
     <div class="controls-top-right">
-      <button
-        class="control-btn"
-        onclick={() => dataModalOpen = true}
-        title={$_('nav.about')}
-        aria-label={$_('nav.about')}
-      >
-        <Info class="h-5 w-5" />
-      </button>
-      <FilterPanel />
+      <div class="controls-row">
+        <button
+          class="control-btn"
+          onclick={() => dataModalOpen = true}
+          title={$_('nav.about')}
+          aria-label={$_('nav.about')}
+        >
+          <Info class="h-5 w-5" />
+        </button>
+        <FilterPanel />
+      </div>
+      <FilterChips />
     </div>
 
     <div class="controls-bottom-right">
@@ -562,6 +564,13 @@
     top: 1rem;
     right: 1rem;
     z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-end;
+  }
+
+  .controls-row {
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
@@ -735,6 +744,9 @@
     .controls-top-right {
       top: 0.75rem;
       right: 0.75rem;
+    }
+
+    .controls-row {
       /* Stack vertically on mobile so they don't overlap the search bar. */
       flex-direction: column;
     }

--- a/app/src/components/FilterChips.svelte
+++ b/app/src/components/FilterChips.svelte
@@ -25,6 +25,12 @@
 
 {#if hasFilters}
   <div class="chips-container">
+    {#if activeFilters.length > 1}
+      <button class="clear-all" onclick={clearAll}>
+        {$_('filter.clearChips')}
+      </button>
+    {/if}
+
     {#each activeFilters as filter (filter.key)}
       <span class="chip">
         <span class="chip-label">{filter.label}</span>
@@ -37,12 +43,6 @@
         </button>
       </span>
     {/each}
-
-    {#if activeFilters.length > 1}
-      <button class="clear-all" onclick={clearAll}>
-        {$_('filter.clearChips')}
-      </button>
-    {/if}
   </div>
 {/if}
 
@@ -53,6 +53,8 @@
     gap: 8px;
     flex-wrap: wrap;
     padding: 8px 0;
+    justify-content: flex-end;
+    max-width: 220px;
   }
 
   .chip {
@@ -92,16 +94,19 @@
   }
 
   .clear-all {
-    font-size: 12px;
-    color: #1a73e8;
-    background: none;
+    font-size: 13px;
+    font-weight: 600;
+    color: #c62828;
+    background: white;
     border: none;
+    border-radius: 16px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
     cursor: pointer;
-    padding: 6px 8px;
+    padding: 6px 12px;
     white-space: nowrap;
   }
 
   .clear-all:hover {
-    text-decoration: underline;
+    background: #ffebee;
   }
 </style>

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -55,6 +55,14 @@
 
   $: observationStaleAny = backends.some(b => b.observationStale);
 
+  function completenessRatio(b) {
+    if (b.loading || b.error) return -2;
+    if (!b.completeness) return -1;
+    const total = b.completeness.complete + b.completeness.partial + b.completeness.missing;
+    return total > 0 ? b.completeness.complete / total : 0;
+  }
+  $: sortedBackends = [...backends].sort((a, b) => completenessRatio(b) - completenessRatio(a));
+
   let legalModalOpen = false;
   let legalContent = null;
   let legalError = null;
@@ -138,7 +146,7 @@
       </p>
     {/if}
     <ul class="instance-list">
-      {#each backends as b (b.url)}
+      {#each sortedBackends as b (b.url)}
         <li class="instance-item">
           <div class="instance-row">
             <span class="instance-name">{b.name}</span>
@@ -196,10 +204,14 @@
                 <span class="cdot cdot--missing"></span>{missing} {$_('completeness.missing')}
               </div>
               {#if total > 0}
-                <div class="completeness-bar" title="{Math.round(complete / total * 100)} %">
-                  <div class="completeness-bar__seg completeness-bar__seg--complete" style="width: {complete / total * 100}%"></div>
-                  <div class="completeness-bar__seg completeness-bar__seg--partial"  style="width: {partial  / total * 100}%"></div>
-                  <div class="completeness-bar__seg completeness-bar__seg--missing"  style="width: {missing  / total * 100}%"></div>
+                {@const pct = Math.round(complete / total * 100)}
+                <div class="completeness-bar-row">
+                  <div class="completeness-bar" title="{pct} %">
+                    <div class="completeness-bar__seg completeness-bar__seg--complete" style="width: {complete / total * 100}%"></div>
+                    <div class="completeness-bar__seg completeness-bar__seg--partial"  style="width: {partial  / total * 100}%"></div>
+                    <div class="completeness-bar__seg completeness-bar__seg--missing"  style="width: {missing  / total * 100}%"></div>
+                  </div>
+                  <span class="completeness-pct">{pct} %</span>
                 </div>
               {/if}
             {/if}
@@ -395,13 +407,29 @@
   .cdot--partial  { background: #d97706; }
   .cdot--missing  { background: #dc2626; }
 
+  .completeness-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.2rem;
+  }
+
+  .completeness-pct {
+    font-size: 0.68rem;
+    color: #6b7280;
+    white-space: nowrap;
+    flex-shrink: 0;
+    min-width: 2.5rem;
+    text-align: right;
+  }
+
   .completeness-bar {
+    flex: 1;
     display: flex;
     height: 4px;
     border-radius: 2px;
     overflow: hidden;
     background: #e5e7eb;
-    margin-top: 0.2rem;
   }
 
   .completeness-bar__seg {

--- a/app/src/hub/InstancePanelDrawer.svelte
+++ b/app/src/hub/InstancePanelDrawer.svelte
@@ -187,6 +187,22 @@
               <i class="bi bi-geo-alt-fill me-1"></i>
               {$_('hub.playgroundCount', { values: { count: b.playgroundCount } })}
             </div>
+            {#if b.completeness}
+              {@const { complete, partial, missing } = b.completeness}
+              {@const total = complete + partial + missing}
+              <div class="instance-completeness">
+                <span class="cdot cdot--complete"></span>{complete} {$_('completeness.complete')}
+                <span class="cdot cdot--partial"></span>{partial} {$_('completeness.partial')}
+                <span class="cdot cdot--missing"></span>{missing} {$_('completeness.missing')}
+              </div>
+              {#if total > 0}
+                <div class="completeness-bar" title="{Math.round(complete / total * 100)} %">
+                  <div class="completeness-bar__seg completeness-bar__seg--complete" style="width: {complete / total * 100}%"></div>
+                  <div class="completeness-bar__seg completeness-bar__seg--partial"  style="width: {partial  / total * 100}%"></div>
+                  <div class="completeness-bar__seg completeness-bar__seg--missing"  style="width: {missing  / total * 100}%"></div>
+                </div>
+              {/if}
+            {/if}
             {#if b.osmDataAgeSec != null}
               <!-- Prefer the OSM source-data age (user-facing: "the data
                    you are looking at is N old") over the import-run age
@@ -358,6 +374,44 @@
     font-size: 0.72rem;
     margin-top: 0.1rem;
   }
+
+  .instance-completeness {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.72rem;
+    color: #6b7280;
+    margin-top: 0.15rem;
+  }
+
+  .cdot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .cdot--complete { background: #16a34a; }
+  .cdot--partial  { background: #d97706; }
+  .cdot--missing  { background: #dc2626; }
+
+  .completeness-bar {
+    display: flex;
+    height: 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    background: #e5e7eb;
+    margin-top: 0.2rem;
+  }
+
+  .completeness-bar__seg {
+    height: 100%;
+    min-width: 0;
+    transition: width 0.3s ease;
+  }
+  .completeness-bar__seg--complete { background: #16a34a; }
+  .completeness-bar__seg--partial  { background: #d97706; }
+  .completeness-bar__seg--missing  { background: #dc2626; }
 
   .instance-overlap {
     font-size: 0.72rem;

--- a/app/src/hub/registry.js
+++ b/app/src/hub/registry.js
@@ -191,7 +191,7 @@ export function createRegistry() {
       for (const b of backends) {
         const entry = entriesByUrl.get(b.url);
         if (!entry) continue;
-        patchBackend(b.url, {
+        const patch = {
           healthUp:           entry.up ?? null,
           // dataAgeSec       — when the importer last ran (operator concern)
           dataAgeSec:         entry.data_age_seconds ?? null,
@@ -207,7 +207,17 @@ export function createRegistry() {
           privacyUrl:         entry.privacy_url  ?? null,
           hasLegal:           entry.has_legal     ?? false,
           version:            entry.version       ?? null,
-        });
+        };
+        // Completeness counts added to federation-status in #545. Absent on
+        // older hub releases — skip the patch so the direct get_meta path
+        // (registry.js loadBackend) isn't overwritten with undefined.
+        // When present, this path is faster on first load: federation-status.json
+        // is served from the hub itself vs. N parallel get_meta calls to remotes.
+        const hasEntryCompleteness = ['complete', 'partial', 'missing'].every(k => Number.isFinite(entry[k]));
+        if (hasEntryCompleteness) {
+          patch.completeness = { complete: entry.complete, partial: entry.partial, missing: entry.missing };
+        }
+        patchBackend(b.url, patch);
       }
     });
 

--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -22,7 +22,11 @@ Both are written atomically every 60 seconds by a cron job inside the hub contai
       "latency_seconds": 0.043,
       "last_success": "2026-04-26T12:00:00Z",
       "last_import_at": "2026-04-25T03:12:00Z",
-      "data_age_seconds": 118080
+      "data_age_seconds": 118080,
+      "playground_count": 42,
+      "complete": 28,
+      "partial": 10,
+      "missing": 4
     }
   }
 }
@@ -39,6 +43,10 @@ Both are written atomically every 60 seconds by a cron job inside the hub contai
 | `backends.<slug>.last_success` | ISO 8601 timestamp of the last successful probe, preserved across failures. `null` if the backend was never reachable. |
 | `backends.<slug>.last_import_at` | Value of `api.import_status.last_import_at` from the backend DB. `null` if no import has run or backend is down. |
 | `backends.<slug>.data_age_seconds` | Seconds since `last_import_at`. `null` if `last_import_at` is `null`. |
+| `backends.<slug>.playground_count` | Total playgrounds in the region. `null` on pre-P1 backends or when backend is down. |
+| `backends.<slug>.complete` | Playgrounds with complete equipment data. `null` on pre-P1 backends. |
+| `backends.<slug>.partial` | Playgrounds with partial equipment data. `null` on pre-P1 backends. |
+| `backends.<slug>.missing` | Playgrounds with no equipment data. `null` on pre-P1 backends. |
 
 The hub UI reads this endpoint every 60 seconds and surfaces freshness labels in the instance drawer. It also shows a "stale observation" banner when `generated_at` is older than `2 × poll_interval_seconds` (i.e. the hub cron has stopped writing).
 
@@ -59,12 +67,28 @@ spielplatz_backend_latency_seconds{backend="fulda",url="https://fulda.example.co
 # TYPE spielplatz_backend_data_age_seconds gauge
 spielplatz_backend_data_age_seconds{backend="fulda",url="https://fulda.example.com/api"} 118080
 
+# HELP spielplatz_backend_playgrounds_total Total number of playgrounds in the region.
+# TYPE spielplatz_backend_playgrounds_total gauge
+spielplatz_backend_playgrounds_total{backend="fulda",url="https://fulda.example.com/api"} 42
+
+# HELP spielplatz_backend_playgrounds_complete Playgrounds with complete equipment data.
+# TYPE spielplatz_backend_playgrounds_complete gauge
+spielplatz_backend_playgrounds_complete{backend="fulda",url="https://fulda.example.com/api"} 28
+
+# HELP spielplatz_backend_playgrounds_partial Playgrounds with partial equipment data.
+# TYPE spielplatz_backend_playgrounds_partial gauge
+spielplatz_backend_playgrounds_partial{backend="fulda",url="https://fulda.example.com/api"} 10
+
+# HELP spielplatz_backend_playgrounds_missing Playgrounds with no equipment data.
+# TYPE spielplatz_backend_playgrounds_missing gauge
+spielplatz_backend_playgrounds_missing{backend="fulda",url="https://fulda.example.com/api"} 4
+
 # HELP spielplatz_poll_generated_timestamp Unix timestamp when this scrape was generated.
 # TYPE spielplatz_poll_generated_timestamp gauge
 spielplatz_poll_generated_timestamp 1745668800
 ```
 
-`spielplatz_backend_data_age_seconds` is omitted for a backend when `last_import_at` is `null` (backend down or no import yet).
+`spielplatz_backend_data_age_seconds` and the four completeness gauges are omitted for a backend when the field is `null` (backend down, pre-P1 backend, or no import yet).
 
 ## Recipes
 
@@ -106,6 +130,15 @@ spielplatz_backend_data_age_seconds > 172800
 
 # Alert if the hub poll has stopped writing (cron died)
 time() - spielplatz_poll_generated_timestamp > 300
+
+# Completeness ratio per backend (fraction of playgrounds with full data)
+spielplatz_backend_playgrounds_complete / spielplatz_backend_playgrounds_total
+
+# Total playgrounds with missing data across all backends
+sum(spielplatz_backend_playgrounds_missing)
+
+# Alert if completeness ratio drops below 50 % for any backend
+spielplatz_backend_playgrounds_complete / spielplatz_backend_playgrounds_total < 0.5
 ```
 
 ### Recipe 3 — Frontend error monitoring (Sentry)

--- a/oci/app/poll-federation.sh
+++ b/oci/app/poll-federation.sh
@@ -96,6 +96,10 @@ while IFS="	" read -r SLUG URL; do
     PRIVACY_URL_VAL="null"
     HAS_LEGAL_VAL="false"
     VERSION_VAL="null"
+    PLAYGROUND_COUNT_VAL="null"
+    COMPLETE_VAL="null"
+    PARTIAL_VAL="null"
+    MISSING_VAL="null"
     if [ "$UP" = "1" ] && [ -f "$META_TMP" ]; then
         RAW=$(cat "$META_TMP")
         # api.get_meta returns a JSON object directly (PostgREST scalar-RPC),
@@ -126,6 +130,16 @@ while IFS="	" read -r SLUG URL; do
         if [ -n "$OSM_DATA_AGE_RAW" ]; then
             OSM_DATA_AGE_SECONDS="$OSM_DATA_AGE_RAW"
         fi
+        # Completeness counts — absent on pre-P1 backends; emit null in that case
+        # so consumers can distinguish "unknown" from "zero".
+        PLAYGROUND_COUNT_RAW=$(printf '%s' "$RAW" | jq -r '.playground_count // empty' 2>/dev/null)
+        COMPLETE_RAW=$(printf '%s' "$RAW" | jq -r '.complete // empty' 2>/dev/null)
+        PARTIAL_RAW=$(printf '%s' "$RAW" | jq -r '.partial // empty' 2>/dev/null)
+        MISSING_RAW=$(printf '%s' "$RAW" | jq -r '.missing // empty' 2>/dev/null)
+        [ -n "$PLAYGROUND_COUNT_RAW" ] && PLAYGROUND_COUNT_VAL="$PLAYGROUND_COUNT_RAW"
+        [ -n "$COMPLETE_RAW" ]         && COMPLETE_VAL="$COMPLETE_RAW"
+        [ -n "$PARTIAL_RAW" ]          && PARTIAL_VAL="$PARTIAL_RAW"
+        [ -n "$MISSING_RAW" ]          && MISSING_VAL="$MISSING_RAW"
     fi
 
     # Preserve last_success from previous run if backend is currently down.
@@ -157,7 +171,11 @@ while IFS="	" read -r SLUG URL; do
     BACKENDS_JSON="${BACKENDS_JSON}\"impressum_url\":${IMPRESSUM_URL_VAL},"
     BACKENDS_JSON="${BACKENDS_JSON}\"privacy_url\":${PRIVACY_URL_VAL},"
     BACKENDS_JSON="${BACKENDS_JSON}\"has_legal\":${HAS_LEGAL_VAL},"
-    BACKENDS_JSON="${BACKENDS_JSON}\"version\":${VERSION_VAL}"
+    BACKENDS_JSON="${BACKENDS_JSON}\"version\":${VERSION_VAL},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"playground_count\":${PLAYGROUND_COUNT_VAL},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"complete\":${COMPLETE_VAL},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"partial\":${PARTIAL_VAL},"
+    BACKENDS_JSON="${BACKENDS_JSON}\"missing\":${MISSING_VAL}"
     BACKENDS_JSON="${BACKENDS_JSON}}"
 
     # Append Prometheus metrics. Prometheus disallows `"` and `\` inside
@@ -174,6 +192,18 @@ while IFS="	" read -r SLUG URL; do
             fi
             if [ "$OSM_DATA_AGE_SECONDS" != "null" ] && [ -n "$OSM_DATA_AGE_SECONDS" ]; then
                 METRICS_LINES="${METRICS_LINES}spielplatz_backend_osm_data_age_seconds{${LABEL}} ${OSM_DATA_AGE_SECONDS}\n"
+            fi
+            if [ "$PLAYGROUND_COUNT_VAL" != "null" ] && [ -n "$PLAYGROUND_COUNT_VAL" ]; then
+                METRICS_LINES="${METRICS_LINES}spielplatz_backend_playgrounds_total{${LABEL}} ${PLAYGROUND_COUNT_VAL}\n"
+            fi
+            if [ "$COMPLETE_VAL" != "null" ] && [ -n "$COMPLETE_VAL" ]; then
+                METRICS_LINES="${METRICS_LINES}spielplatz_backend_playgrounds_complete{${LABEL}} ${COMPLETE_VAL}\n"
+            fi
+            if [ "$PARTIAL_VAL" != "null" ] && [ -n "$PARTIAL_VAL" ]; then
+                METRICS_LINES="${METRICS_LINES}spielplatz_backend_playgrounds_partial{${LABEL}} ${PARTIAL_VAL}\n"
+            fi
+            if [ "$MISSING_VAL" != "null" ] && [ -n "$MISSING_VAL" ]; then
+                METRICS_LINES="${METRICS_LINES}spielplatz_backend_playgrounds_missing{${LABEL}} ${MISSING_VAL}\n"
             fi
             ;;
     esac
@@ -193,6 +223,14 @@ printf '{"generated_at":"%s","poll_interval_seconds":%d,"backends":{%s}}\n' \
     printf '# TYPE spielplatz_backend_data_age_seconds gauge\n'
     printf '# HELP spielplatz_backend_osm_data_age_seconds Seconds since the OSM source data the backend serves was snapshotted (PBF replication timestamp).\n'
     printf '# TYPE spielplatz_backend_osm_data_age_seconds gauge\n'
+    printf '# HELP spielplatz_backend_playgrounds_total Total number of playgrounds in the region.\n'
+    printf '# TYPE spielplatz_backend_playgrounds_total gauge\n'
+    printf '# HELP spielplatz_backend_playgrounds_complete Playgrounds with complete equipment data.\n'
+    printf '# TYPE spielplatz_backend_playgrounds_complete gauge\n'
+    printf '# HELP spielplatz_backend_playgrounds_partial Playgrounds with partial equipment data.\n'
+    printf '# TYPE spielplatz_backend_playgrounds_partial gauge\n'
+    printf '# HELP spielplatz_backend_playgrounds_missing Playgrounds with no equipment data.\n'
+    printf '# TYPE spielplatz_backend_playgrounds_missing gauge\n'
     printf '# HELP spielplatz_poll_generated_timestamp Unix timestamp when this scrape was generated.\n'
     printf '# TYPE spielplatz_poll_generated_timestamp gauge\n'
     printf '%b' "$METRICS_LINES"

--- a/tests/hub-federation-health.spec.js
+++ b/tests/hub-federation-health.spec.js
@@ -196,8 +196,8 @@ test.describe('Hub federation health drawer', () => {
     const drawer = await openDrawer(page);
 
     // Wait for the drawer to receive completeness data from the get_meta stub
-    await expect(drawer.locator('.instance-completeness')).toBeVisible({ timeout: 5000 });
-    await expect(drawer.locator('.completeness-bar')).toBeVisible({ timeout: 5000 });
+    await expect(drawer.locator('.instance-completeness').first()).toBeVisible({ timeout: 5000 });
+    await expect(drawer.locator('.completeness-bar').first()).toBeVisible({ timeout: 5000 });
 
     // Verify each count is rendered (instanceWithCompleteness has 4/1/1)
     const completeness = drawer.locator('.instance-completeness').first();

--- a/tests/hub-federation-health.spec.js
+++ b/tests/hub-federation-health.spec.js
@@ -173,6 +173,67 @@ test.describe('Hub federation health drawer', () => {
 
     await expect(drawer).toContainText(/2\s*(Tage|days)/, { timeout: 5000 });
   });
+
+  // #544: completeness breakdown (colored dots + progress bar) should appear
+  // in the drawer for backends whose get_meta carries complete/partial/missing.
+  test('shows completeness breakdown for a backend with completeness data', async ({ page }) => {
+    const instanceWithCompleteness = {
+      ...instanceA,
+      meta: {
+        ...instanceA.meta,
+        playground_count: 6,
+        complete: 4,
+        partial: 1,
+        missing: 1,
+      },
+    };
+
+    await injectHubConfig(page);
+    await stubHubRegistry(page, { instanceA: instanceWithCompleteness, instanceB });
+    await stubFederationStatus(page);
+
+    await page.goto('/');
+    const drawer = await openDrawer(page);
+
+    // Wait for the drawer to receive completeness data from the get_meta stub
+    await expect(drawer.locator('.instance-completeness')).toBeVisible({ timeout: 5000 });
+    await expect(drawer.locator('.completeness-bar')).toBeVisible({ timeout: 5000 });
+
+    // Verify each count is rendered (instanceWithCompleteness has 4/1/1)
+    const completeness = drawer.locator('.instance-completeness').first();
+    await expect(completeness).toContainText('4');
+    await expect(completeness).toContainText('1');
+  });
+
+  // #545: completeness fields arriving via federation-status.json should also
+  // patch the backend and render in the drawer.
+  test('shows completeness breakdown sourced from federation-status.json', async ({ page }) => {
+    await injectHubConfig(page);
+    await stubHubRegistry(page, { instanceA, instanceB });
+
+    await stubFederationStatus(page, {
+      backends: {
+        'slug-a': {
+          url: instanceA.url,
+          up: true,
+          latency_seconds: 0.02,
+          last_success: new Date().toISOString(),
+          last_import_at: null,
+          data_age_seconds: null,
+          playground_count: 3,
+          complete: 2,
+          partial: 1,
+          missing: 0,
+        },
+      },
+    });
+
+    await page.goto('/');
+    const drawer = await openDrawer(page);
+
+    await expect(drawer.locator('.instance-completeness').first()).toBeVisible({ timeout: 5000 });
+    await expect(drawer.locator('.completeness-bar').first()).toBeVisible({ timeout: 5000 });
+  });
 });
 
 // TODO: filterHealthy skip-down-backend test


### PR DESCRIPTION
## Summary

- Moves active filter chips from between the search bar and data availability box to the right side, below the Info/Filter button row
- "Clear all" button repositioned to appear first (top of chips) and restyled as a prominent red pill to be easily visible on the map
- Chips right-aligned with max-width to prevent map overlap

Closes #541

## Test plan

- [ ] Activate one or more filters
- [ ] Verify chips appear on right side below the Info + Filter buttons
- [ ] Verify "Clear all" appears at the top of the chips row when >1 filter active
- [ ] Verify individual chip × buttons still remove single filters
- [ ] Test on mobile: chips appear below stacked buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)