### PR TITLE
fix(standalone): wire cluster-filter re-fetch to imperative store subscription

### DIFF
--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -176,7 +176,7 @@
           baseUrl: apiBaseUrl,
           clusterSource,
           polygonSource: playgroundSource,
-          getFilters: () => JSON.parse(clusterFilterFingerprint),
+          getFilters: () => clusterFilterFingerprint ? JSON.parse(clusterFilterFingerprint) : null,
         });
         detachOrchestrator = orchestrator.detach;
 

--- a/app/src/standalone/StandaloneApp.svelte
+++ b/app/src/standalone/StandaloneApp.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
-  import { readable } from 'svelte/store';
+  import { readable, get } from 'svelte/store';
   import VectorSource from 'ol/source/Vector.js';
   import { Vector as VectorLayer } from 'ol/layer.js';
   import GeoJSON from 'ol/format/GeoJSON.js';
@@ -32,7 +32,6 @@
   const playgroundSource = new VectorSource(); // polygon tier (zoom > clusterMaxZoom)
   const clusterSource    = new VectorSource(); // cluster tier (zoom ≤ clusterMaxZoom)
   let detachOrchestrator = null;
-  let rerunOrchestrator  = null;
   let clusterFilterFingerprint = '';
 
   // Deselect the playground when the user zooms out past the cluster threshold.
@@ -180,7 +179,19 @@
           getFilters: () => JSON.parse(clusterFilterFingerprint),
         });
         detachOrchestrator = orchestrator.detach;
-        rerunOrchestrator  = orchestrator.rerun;
+
+        // Subscribe to filter changes imperatively — avoids Svelte $: dependency-tracking
+        // uncertainty for variables set inside async/nested callbacks.
+        // Skip the immediate invocation (filters start all-false, orchestrator just ran).
+        let filterSubReady = false;
+        const unsubFilters = filterStore.subscribe(filters => {
+          const { standalonePitches: _sp, ...cf } = filters;
+          clusterFilterFingerprint = JSON.stringify(cf);
+          if (!filterSubReady) { filterSubReady = true; return; }
+          if (get(activeTierStore) === 'cluster') orchestrator.rerun();
+        });
+        const baseDetach = orchestrator.detach;
+        detachOrchestrator = () => { baseDetach(); unsubFilters(); };
       } else {
         console.info('[standalone] apiBaseUrl empty — tiered orchestrator not attached (local dev without Docker)');
       }
@@ -189,17 +200,6 @@
 
   // Toggle pitch-layer visibility from the filter store.
   $: if (pitchLayer) pitchLayer.setVisible($filterStore.standalonePitches);
-
-  // String fingerprint of cluster-relevant filters — excludes standalonePitches
-  // (layer toggle, not a playground data filter). Svelte only propagates to
-  // the rerun block when the string changes, so toggling standalonePitches alone
-  // doesn't trigger a cluster re-fetch.
-  $: { const { standalonePitches: _sp, ...cf } = $filterStore; clusterFilterFingerprint = JSON.stringify(cf); }
-
-  // Re-fetch clusters when cluster-relevant filters change at cluster zoom.
-  // Polygon tier handles filter changes client-side via matchesFilters() — no refetch needed.
-  // orchestrate() reads the current filter state via getFilters(), so no arg needed here.
-  $: if (rerunOrchestrator && $activeTierStore === 'cluster') rerunOrchestrator();
 
   onDestroy(() => {
     detachTierDeselect();


### PR DESCRIPTION
## Summary

- Replaces two `$:` reactive blocks (fingerprint update + rerun trigger) with a single imperative `filterStore.subscribe` inside `onMount`
- The old approach could fire before `rerunOrchestrator` was assigned, silently dropping filter changes at startup
- Subscribe callback now owns both fingerprint updates and re-fetch triggering, torn down via `detachOrchestrator`

Closes #540

## Test plan

- [ ] Apply a filter (e.g. "water") at cluster zoom (≤ 13) — cluster circles should update to show only matching playgrounds
- [ ] Zoom in to polygon tier — polygon filter via `matchesFilters()` still works as before
- [ ] Toggle filter on/off rapidly — no duplicate re-fetches or stale data

🤖 Generated with [Claude Code](https://claude.com/claude-code)