### PR TITLE
fix(importer): check sport column for table_tennis_count

### DIFF
--- a/importer/api.sql
+++ b/importer/api.sql
@@ -169,7 +169,7 @@ CREATE MATERIALIZED VIEW public.playground_stats AS
       COUNT(CASE WHEN e.amenity = 'shelter'      THEN 1 END)::int AS shelter_count,
       COUNT(CASE WHEN e.leisure = 'picnic_table' THEN 1 END)::int AS picnic_count,
       COUNT(CASE WHEN e.leisure = 'pitch'
-                  AND e.tags->'sport' = 'table_tennis' THEN 1 END)::int AS table_tennis_count,
+                  AND (e.sport = 'table_tennis' OR e.tags->'sport' = 'table_tennis') THEN 1 END)::int AS table_tennis_count,
       BOOL_OR(e.leisure = 'pitch'
               AND (e.sport = 'soccer' OR e.tags->'sport' = 'soccer'))          AS has_soccer,
       BOOL_OR(e.leisure = 'pitch'


### PR DESCRIPTION
## Summary

- `table_tennis_count` in `playground_stats` only checked `e.tags->'sport'` (the hstore), but osm2pgsql maps `sport=table_tennis` to the explicit `sport` column
- Result: count was always 0, so the table tennis filter never hid any playgrounds
- Fix mirrors the pattern already used for `has_soccer` / `has_basketball`: check both `e.sport` and `e.tags->'sport'`

After this change, run `make db-apply` (or a full re-import) to rebuild `playground_stats`.

Closes #542

## Test plan

- [ ] `make db-apply` on a DB with table tennis pitches → `table_tennis_count > 0` for affected playgrounds
- [ ] Enable table tennis filter at polygon zoom → playgrounds without table tennis hidden
- [ ] Enable table tennis filter at cluster zoom → cluster circles reflect only matching playgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)