### PR TITLE
fix(hub): wire cluster-filter re-fetch to filterStore subscription (closes #540)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ make db-shell          # psql shell in the running DB container
 make down              # stop all containers
 ```
 
+**Docker build cache pitfall**: `make docker-build` uses Docker's layer cache. If source file changes aren't picked up (all steps say `---> Using cache`), force a full rebuild:
+```bash
+docker compose build --no-cache app && docker compose up -d app
+```
+This happens because Docker sometimes fails to detect that `app/` files changed. Symptom: code changes have no effect despite a successful `make docker-build`.
+
 **Local dev note**: When `apiBaseUrl` is empty in `app/public/config.js`, the frontend falls back to Overpass — no database required for basic frontend dev.
 
 ## Architecture

--- a/app/src/hub/HubApp.svelte
+++ b/app/src/hub/HubApp.svelte
@@ -11,6 +11,8 @@
   import { createRegistry } from './registry.js';
   import { attachHubOrchestrator } from './hubOrchestrator.js';
   import { mapStore } from '../stores/map.js';
+  import { filterStore } from '../stores/filters.js';
+  import { activeTierStore } from '../stores/tier.js';
   import { clusterMaxZoom } from '../lib/config.js';
   import * as osmIdDedup from './osmIdDedup.js';
 
@@ -200,12 +202,22 @@
     // attachment has run.
     detachMapAttach = mapStore.subscribe(map => {
       if (!map || detachOrchestrator) return;
-      detachOrchestrator = attachHubOrchestrator({
+      let clusterFilterFingerprint = '';
+      const orchestrator = attachHubOrchestrator({
         map,
         backendsStore: backends,
         clusterSource,
         polygonSource,
+        getFilters: () => clusterFilterFingerprint ? JSON.parse(clusterFilterFingerprint) : null,
       });
+      let filterSubReady = false;
+      const unsubFilters = filterStore.subscribe(filters => {
+        const { standalonePitches: _sp, ...cf } = filters;
+        clusterFilterFingerprint = JSON.stringify(cf);
+        if (!filterSubReady) { filterSubReady = true; return; }
+        if (get(activeTierStore) === 'cluster') orchestrator.rerun();
+      });
+      detachOrchestrator = () => { orchestrator.detach(); unsubFilters(); };
       // Detach asynchronously so we're not unsubscribing while still inside
       // svelte's subscriber dispatch loop.
       queueMicrotask(() => { detachMapAttach?.(); detachMapAttach = null; });

--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -61,13 +61,15 @@ export function tierForZoom(zoom) {
  * @param {import('svelte/store').Readable<Array>} opts.backendsStore
  * @param {import('ol/source/Vector.js').default} opts.clusterSource
  * @param {import('ol/source/Vector.js').default} opts.polygonSource
- * @returns {() => void} detach function
+ * @param {() => object|null} [opts.getFilters]  Returns current cluster-relevant filter snapshot.
+ * @returns {{ detach: () => void, rerun: () => void }}
  */
 export function attachHubOrchestrator({
   map,
   backendsStore,
   clusterSource,
   polygonSource,
+  getFilters = () => null,
 }) {
   let abort = null;
   let allBackends = [];
@@ -139,6 +141,7 @@ export function attachHubOrchestrator({
 
     const extent3857 = view.calculateExtent(map.getSize());
     const viewportBbox = transformExtent(extent3857, 'EPSG:3857', 'EPSG:4326');
+    const filters = getFilters();
     const selected = filterHealthy(selectBackends(viewportBbox, allBackends));
 
     if (selected.length === 0) {
@@ -197,7 +200,7 @@ export function attachHubOrchestrator({
         },
       });
       await fanOut({
-        fetcher: (url, sig) => clusterFetcherFor(url)(z, extent3857, url, sig),
+        fetcher: (url, sig) => clusterFetcherFor(url)(z, extent3857, url, sig, filters),
         backends: selected,
         signal,
         onResult: (entry) => {
@@ -310,11 +313,16 @@ export function attachHubOrchestrator({
   // doesn't wait on a moveend.
   orchestrate();
 
-  return () => {
-    debounced.cancel?.();
-    if (abort) abort.abort();
-    map.un('moveend', debounced);
-    detachStore();
+  return {
+    detach() {
+      debounced.cancel?.();
+      if (abort) abort.abort();
+      map.un('moveend', debounced);
+      detachStore();
+    },
+    rerun() {
+      orchestrate();
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- PR #550 fixed filter wiring in `StandaloneApp.svelte` / `tieredOrchestrator.js` but left hub mode completely unwired
- `attachHubOrchestrator` had no `getFilters` param and no `rerun` export — `fetchPlaygroundClusters` was always called without filter params
- This PR adds the same imperative `filterStore.subscribe` pattern to `HubApp.svelte` and exposes `getFilters` / `rerun` in the hub orchestrator

## Changes

- `hubOrchestrator.js`: add `getFilters = () => null` option; pass filters to each backend's cluster fetcher; return `{ detach, rerun }` instead of a plain function
- `HubApp.svelte`: import `filterStore` + `activeTierStore`; subscribe to filter changes; call `orchestrator.rerun()` when at cluster zoom
- `CLAUDE.md`: document Docker build-cache pitfall (`--no-cache` required when source changes aren't picked up)

## Test plan

- [ ] Zoom out to cluster view (circles visible)
- [ ] Click any filter (e.g. Wasser, Baby)
- [ ] Network tab shows new `GET /api/rpc/get_playground_clusters?...&filter_water=true` request
- [ ] Circle counts update to reflect filtered results
- [ ] Zooming back to polygon tier still filters correctly (client-side, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)