### PR TITLE
docs(ci): publish install.sh checksum as release asset, pin docs to release URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,12 +122,14 @@ jobs:
             | 🔴 Full re-import required | Pull + restart + full re-import (no `API_ONLY`) |
             | *(no label)* | Pull + restart is sufficient |
         run: |
+          sha256sum install.sh > install.sh.sha256
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \
             --notes-file <(gh api "/repos/${{ github.repository }}/releases/generate-notes" \
               -f tag_name="${{ github.ref_name }}" \
-              --jq '.body' && printf '%s' "$RELEASE_FOOTER")
+              --jq '.body' && printf '%s' "$RELEASE_FOOTER") \
+            install.sh install.sh.sha256
 
   # ── Importer image (unchanged) ───────────────────────────────────────────────
   docker-importer:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,10 @@ spieli is an interactive web map for exploring playgrounds based on OpenStreetMa
 
 ### Release procedure
 
-1. Bump `package.json` version: remove `-rc` (e.g. `0.1.7-rc` → `0.1.7`). Commit: `chore: release v0.1.7`.
-2. Tag: `git tag v0.1.7 && git push origin v0.1.7`. CI publishes `:latest`, `:0.1.7`, `:0.1` images and creates a GitHub release automatically.
-3. Advance `main`: bump to next `-rc` (e.g. `0.1.8-rc`). Commit: `chore: bump version to 0.1.8-rc`.
+1. Bump `app/package.json` version: remove `-rc` (e.g. `0.1.7-rc` → `0.1.7`). Commit: `chore: release v0.1.7`.
+2. Update `TAG=` in both `install` blocks in `docs/getting-started/quick-start.md` to the new tag. Commit together with step 1 or separately.
+3. Tag: `git tag v0.1.7 && git push origin v0.1.7`. CI publishes `:latest`, `:0.1.7`, `:0.1` images, creates a GitHub release, and uploads `install.sh` + `install.sh.sha256` as release assets.
+4. Advance `main`: bump to next `-rc` (e.g. `0.1.8-rc`). Commit: `chore: bump version to 0.1.8-rc`.
 
 **PR labels for release notes** — label PRs before merging so the auto-generated release notes show the correct upgrade action:
 - `requires-schema-update` — `api.sql` changed; operators must run `API_ONLY=1` after upgrading.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -7,12 +7,15 @@ The easiest way to deploy spieli is with the interactive installer. It downloads
 - Docker with the Compose plugin
 - `bash`
 - `openssl`
+- `sha256sum` (Linux) or `shasum` (macOS — use `shasum -a 256 --check` instead)
 
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh
-bash install.sh
+TAG=v0.4.13  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
+sha256sum --check install.sh.sha256 && bash install.sh
 ```
 
 ## What the installer does
@@ -90,8 +93,10 @@ If someone is running a spieli Hub and you want your region to appear on it, sta
 **1. Run the installer**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh
-bash install.sh
+TAG=v0.4.13  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
+sha256sum --check install.sh.sha256 && bash install.sh
 ```
 
 When prompted for deployment mode, choose `data-node` or `data-node-ui`. Run the import when asked.


### PR DESCRIPTION
## Summary

- CI: generate `install.sh.sha256` and upload both `install.sh` + `install.sh.sha256` as release assets on every tag push
- Docs: replace mutable `main`-branch raw URLs with release-pinned download URLs + sha256 verification step (both `install` blocks in quick-start)
- CLAUDE.md: extend release procedure with step to update the `TAG=` variable in quick-start.md

Checksums on `main` are security theater — an attacker who controls the repo updates both files simultaneously. Release assets are tag-pinned and immutable after publish.

The Traefik installer (`install-traefik.sh`) is left on `main` for now — separate script, separate PR.

## Test plan

- [ ] Verify CI `release` job uploads `install.sh` and `install.sh.sha256` on next tag push
- [ ] Verify `sha256sum --check install.sh.sha256` passes after downloading both files
- [ ] Verify docs render correctly (`make docs-build`)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)