### PR TITLE
chore: add breaking-change labels and versioning policy

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,12 @@ changelog:
     - title: "🔴 Full re-import required after upgrading"
       labels:
         - requires-reimport
+    - title: "🔧 Environment variables changed — update .env before starting"
+      labels:
+        - requires-env-update
+    - title: "🔧 Compose file changed — re-run install.sh or update compose.yml manually"
+      labels:
+        - requires-compose-update
     - title: "New features"
       labels:
         - enhancement

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,8 @@ jobs:
             |---|---|
             | ⚠️ Database changes | Pull + restart + `docker compose --profile <mode> run --rm -e API_ONLY=1 importer` |
             | 🔴 Full re-import required | Pull + restart + full re-import (no `API_ONLY`) |
+            | 🔧 Environment variables changed | Update `.env` first, then pull + restart |
+            | 🔧 Compose file changed | Re-run `install.sh` or update `compose.yml` manually, then pull + restart |
             | *(no label)* | Pull + restart is sufficient |
         run: |
           sha256sum install.sh > install.sh.sha256

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,12 @@ spieli is an interactive web map for exploring playgrounds based on OpenStreetMa
 **PR labels for release notes** — label PRs before merging so the auto-generated release notes show the correct upgrade action:
 - `requires-schema-update` — `api.sql` changed; operators must run `API_ONLY=1` after upgrading.
 - `requires-reimport` — data model changed; operators must run a full re-import.
+- `requires-env-update` — new or removed env var in `.env`; operators must update their `.env` before starting.
+- `requires-compose-update` — `compose.yml` changed structurally (new service, renamed service, removed volume); operators must re-run `install.sh` or update manually.
+
+**Versioning rule** — breaking = "pull + restart is NOT sufficient":
+- Any merged PR carries a breaking label → next release bumps **minor** (e.g. `0.4.x` → `0.5.0`).
+- No breaking labels → **patch** bump (e.g. `0.5.0` → `0.5.1`).
 
 ## Development commands
 


### PR DESCRIPTION
## Summary

- Adds `requires-env-update` and `requires-compose-update` PR labels to `.github/release.yml` release note categories
- Adds corresponding rows to the upgrade footer table in `build.yml` so operators see the required action in every GitHub release
- Documents versioning rule in `CLAUDE.md`: any PR with a breaking label triggers a minor version bump

## Test plan

- [ ] Verify `release.yml` categories render correctly in next release auto-notes
- [ ] Verify footer table rows appear in next GitHub release body
- [ ] No CI changes — docs/config only

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)