### PR TITLE
feat(hub): degraded macro ring + troubleshooting popup for offline/no-data backends

### DIFF
--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -47,6 +47,7 @@
 
   let mapContainer;
   let olMap = null;
+  let backendPopup = null; // { x, y, name, offline, degraded }
   let playgroundLayer = null; // polygon tier (zoom > clusterMaxZoom) — exposed for filter reactivity
   let clusterLayer = null;    // cluster tier (zoom ≤ clusterMaxZoom) — §3
   let macroLayer = null;      // macro tier (hub-only, zoom ≤ macroMaxZoom) — P2 §5
@@ -201,6 +202,19 @@
         layerFilter: (l) => l === macroLayer,
       });
       if (macroHit) {
+        const isOffline  = macroHit.get('_offline');
+        const isDegraded = macroHit.get('_degraded');
+        if (isOffline || isDegraded) {
+          backendPopup = {
+            x:        evt.pixel[0],
+            y:        evt.pixel[1],
+            name:     macroHit.get('_name') ?? 'Backend',
+            offline:  isOffline,
+            degraded: isDegraded,
+          };
+          return;
+        }
+        backendPopup = null;
         const bbox4326 = macroHit.get('_bbox');
         if (Array.isArray(bbox4326) && bbox4326.length === 4) {
           view.fit(transformExtent(bbox4326, 'EPSG:4326', 'EPSG:3857'), {
@@ -210,6 +224,7 @@
         }
         return;
       }
+      backendPopup = null;
       selection.clear();
     });
 
@@ -321,7 +336,36 @@
   }
 </script>
 
-<div bind:this={mapContainer} class="map-container"></div>
+<div bind:this={mapContainer} class="map-container">
+  {#if backendPopup}
+    <div
+      class="backend-popup"
+      style="left: {backendPopup.x}px; top: {backendPopup.y}px"
+      role="dialog"
+      aria-label="Backend status"
+    >
+      <button class="backend-popup-close" on:click={() => backendPopup = null} aria-label="Close">×</button>
+      <strong class="backend-popup-name">{backendPopup.name}</strong>
+      {#if backendPopup.offline}
+        <p class="backend-popup-msg">Backend ist nicht erreichbar. Möglicherweise liegt ein Konfigurationsproblem im Hub oder beim Backend vor.</p>
+        <a
+          class="backend-popup-link"
+          href="https://mfuhrmann.github.io/spieli/ops/troubleshooting/#hub-shows-all-backends-as-red--unreachable"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Troubleshooting →</a>
+      {:else}
+        <p class="backend-popup-msg">Backend erreichbar, aber keine Spielplatzdaten vorhanden. Der Import wurde möglicherweise noch nicht ausgeführt.</p>
+        <a
+          class="backend-popup-link"
+          href="https://mfuhrmann.github.io/spieli/ops/troubleshooting/#hub-shows-a-backend-as-reachable-but-with-0-playgrounds"
+          target="_blank"
+          rel="noopener noreferrer"
+        >Troubleshooting →</a>
+      {/if}
+    </div>
+  {/if}
+</div>
 
 <style>
   .map-container {
@@ -329,6 +373,60 @@
     height: 100%;
     position: absolute;
     inset: 0;
+  }
+
+  .backend-popup {
+    position: absolute;
+    z-index: 200;
+    transform: translate(-50%, calc(-100% - 12px));
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+    padding: 12px 14px 10px;
+    width: 240px;
+    font-size: 13px;
+    line-height: 1.4;
+    pointer-events: all;
+  }
+
+  .backend-popup-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: none;
+    border: none;
+    font-size: 16px;
+    line-height: 1;
+    color: #6b7280;
+    cursor: pointer;
+    padding: 0 2px;
+  }
+
+  .backend-popup-close:hover {
+    color: #111827;
+  }
+
+  .backend-popup-name {
+    display: block;
+    font-size: 14px;
+    margin-bottom: 5px;
+    padding-right: 16px;
+    color: #111827;
+  }
+
+  .backend-popup-msg {
+    margin: 0 0 8px;
+    color: #374151;
+  }
+
+  .backend-popup-link {
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .backend-popup-link:hover {
+    text-decoration: underline;
   }
 
   /* Custom scale line styling - bottom left, minimal */

--- a/app/src/components/Map.svelte
+++ b/app/src/components/Map.svelte
@@ -158,6 +158,9 @@
         selection.clear();
         selectionZoom = null;
       }
+      // P1: popup is anchored to a click pixel; dismiss it on any pan/zoom so it
+      // doesn't drift away from its ring.
+      backendPopup = null;
     });
 
     // Click handler: tier-aware.
@@ -310,6 +313,8 @@
         macroLayer.setVisible(false);
         return;
       }
+      // P2: dismiss the popup whenever we leave macro tier.
+      if (tier !== 'macro') backendPopup = null;
       playgroundLayer.setVisible(tier === 'polygon');
       clusterLayer.setVisible(tier === 'cluster');
       macroLayer.setVisible(tier === 'macro');
@@ -336,13 +341,15 @@
   }
 </script>
 
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape' && backendPopup) backendPopup = null; }} />
 <div bind:this={mapContainer} class="map-container">
   {#if backendPopup}
     <div
       class="backend-popup"
       style="left: {backendPopup.x}px; top: {backendPopup.y}px"
-      role="dialog"
+      role="status"
       aria-label="Backend status"
+      aria-live="polite"
     >
       <button class="backend-popup-close" on:click={() => backendPopup = null} aria-label="Close">×</button>
       <strong class="backend-popup-name">{backendPopup.name}</strong>
@@ -355,7 +362,7 @@
           rel="noopener noreferrer"
         >Troubleshooting →</a>
       {:else}
-        <p class="backend-popup-msg">Backend erreichbar, aber keine Spielplatzdaten vorhanden. Der Import wurde möglicherweise noch nicht ausgeführt.</p>
+        <p class="backend-popup-msg">Backend erreichbar, aber keine Spielplatzdaten vorhanden.</p>
         <a
           class="backend-popup-link"
           href="https://mfuhrmann.github.io/spieli/ops/troubleshooting/#hub-shows-a-backend-as-reachable-but-with-0-playgrounds"
@@ -412,6 +419,9 @@
     margin-bottom: 5px;
     padding-right: 16px;
     color: #111827;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .backend-popup-msg {

--- a/app/src/hub/MacroView.svelte
+++ b/app/src/hub/MacroView.svelte
@@ -46,8 +46,9 @@
     const offline = !isBackendHealthy(backend);
     // Pre-P1 backends → unknown completeness; map the count into the
     // restricted bucket so the renderer draws a flat gray ring.
-    const c = backend.completeness;
+    const c     = backend.completeness;
     const count = backend.playgroundCount ?? 0;
+    const degraded = !offline && count === 0;
     const props = c
       ? {
           count,
@@ -70,6 +71,7 @@
       _backendSlug: backend.slug ?? null,
       _bbox:        backend.bbox,
       _offline:     offline,
+      _degraded:    degraded,
       _name:        backend.name ?? backend.region ?? backend.slug ?? backend.url,
       ...props,
     });

--- a/app/src/hub/macroRingStyle.js
+++ b/app/src/hub/macroRingStyle.js
@@ -5,8 +5,9 @@
 //
 //   1. Always rendered as rings, never as the cluster-tier single-child dot
 //      (a backend with one playground is still a "region", not a singleton).
-//   2. Two visual variants — healthy (filled segments + count) and offline
-//      (dashed outline, muted, "offline" label, last known count).
+//   2. Three visual variants — healthy (filled segments + count), offline
+//      (dashed outline, muted, "offline" label, last known count), and
+//      degraded (amber ring, "no data" label — backend reachable but empty).
 //
 // The bitmap cache from clusterStyle.js isn't reused here: macro features are
 // at most one per registered backend (typically <20), so per-frame redraws
@@ -25,9 +26,12 @@ const RING_WIDTH      = 14; // slightly thicker than cluster (12) for country-sc
 const CENTER_FILL     = 'rgba(255, 255, 255, 0.95)';
 const CENTER_STROKE   = '#1f2937';
 const CENTER_TEXT     = '#1f2937';
-const OFFLINE_STROKE  = '#9ca3af';
-const OFFLINE_FILL    = 'rgba(255, 255, 255, 0.85)';
-const OFFLINE_TEXT    = '#6b7280';
+const OFFLINE_STROKE   = '#9ca3af';
+const OFFLINE_FILL     = 'rgba(255, 255, 255, 0.85)';
+const OFFLINE_TEXT     = '#6b7280';
+const DEGRADED_STROKE  = '#d97706'; // amber-600
+const DEGRADED_FILL    = 'rgba(255, 251, 235, 0.92)'; // amber-50
+const DEGRADED_TEXT    = '#92400e'; // amber-800
 const COUNT_FONT      = 'bold 22px ui-monospace, "SF Mono", Menlo, system-ui, -apple-system, sans-serif';
 const LABEL_FONT      = '600 11px system-ui, -apple-system, "Helvetica Neue", sans-serif';
 
@@ -124,6 +128,33 @@ function renderOfflineMacroRing(pixelCoords, state) {
   ctx.fillText('offline', x, y + 11);
 }
 
+function renderDegradedMacroRing(pixelCoords, state) {
+  const [x, y] = pixelCoords;
+  const ctx    = state.context;
+  const radius = 26; // minimum — count is 0
+
+  ctx.lineWidth   = RING_WIDTH;
+  ctx.lineCap     = 'butt';
+  ctx.strokeStyle = DEGRADED_STROKE;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(x, y, radius - RING_WIDTH / 2 - 1, 0, Math.PI * 2);
+  ctx.fillStyle   = DEGRADED_FILL;
+  ctx.strokeStyle = DEGRADED_STROKE;
+  ctx.lineWidth   = 1;
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle    = DEGRADED_TEXT;
+  ctx.font         = LABEL_FONT;
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText('no data', x, y);
+}
+
 // Compact display: 65000 → "65k", 1500 → "1.5k", <1000 unchanged. Spec
 // scenario uses 65000 directly but at radius 44 the digit string blows
 // outside the inner disc; the "k" suffix keeps it inside.
@@ -133,9 +164,12 @@ function formatCount(n) {
   return `${Math.round(n / 1000)}k`;
 }
 
-const healthyStyle = new Style({ renderer: renderHealthyMacroRing });
-const offlineStyle = new Style({ renderer: renderOfflineMacroRing });
+const healthyStyle  = new Style({ renderer: renderHealthyMacroRing });
+const offlineStyle  = new Style({ renderer: renderOfflineMacroRing });
+const degradedStyle = new Style({ renderer: renderDegradedMacroRing });
 
 export function macroRingStyleFn(feature) {
-  return feature.get('_offline') ? offlineStyle : healthyStyle;
+  if (feature.get('_offline'))  return offlineStyle;
+  if (feature.get('_degraded')) return degradedStyle;
+  return healthyStyle;
 }


### PR DESCRIPTION
## Summary

- Adds a third macro ring visual state: **degraded** (backend reachable but `playground_count === 0`) — amber solid ring, "no data" label. Distinct from the dashed gray offline ring and the healthy coloured ring.
- Clicking an **offline** or **degraded** ring no longer zooms to bbox (unhelpful when there is nothing to see). Instead shows a small popup with a short diagnosis and a direct link to the relevant troubleshooting section.

| State | Ring | Popup message | Docs link |
|---|---|---|---|
| Offline | dashed gray, "offline" (existing) | Backend nicht erreichbar | `…/troubleshooting/#hub-shows-all-backends-as-red--unreachable` |
| Degraded | amber solid, "no data" (new) | Backend erreichbar, keine Daten | `…/troubleshooting/#hub-shows-a-backend-as-reachable-but-with-0-playgrounds` |
| Healthy | coloured segments (unchanged) | — |

## Files changed

- `app/src/hub/macroRingStyle.js` — amber colour constants, `renderDegradedMacroRing`, updated `macroRingStyleFn`
- `app/src/hub/MacroView.svelte` — `_degraded` flag on feature
- `app/src/components/Map.svelte` — popup state + template + styles, branched click handler

## Test plan

- [ ] Hub mode: backend with `playground_count > 0` shows healthy coloured ring, click zooms to bbox
- [ ] Hub mode: offline backend (set `up: false` in federation-status.json) shows dashed gray ring, click shows popup with offline message + correct docs link
- [ ] Hub mode: backend with `playground_count === 0` and `healthUp !== false` shows amber "no data" ring, click shows popup with degraded message + correct docs link
- [ ] Popup close button dismisses popup
- [ ] Clicking empty map area dismisses popup

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)