### PR TITLE
docs(ops): multi-stack VPS upgrade guide + upgrade-stacks.sh

### DIFF
--- a/docs/ops/single-host-federation.md
+++ b/docs/ops/single-host-federation.md
@@ -1,0 +1,174 @@
+# Single-host Federation
+
+A single-host federation runs a **pure hub** (no database) and multiple regional **data-nodes** on one VPS. It is a valid alternative to the [distributed topology](federated-deployment.md) and suits operators who want full-country coverage without coordinating multiple machines.
+
+## Topology
+
+```
+                 spieli (hub)
+                 DEPLOY_MODE=ui
+                 port 8080
+                      │
+      ┌───────────────┼───────────────┐
+      ▼               ▼               ▼
+spieli-hessen    spieli-berlin    spieli-nrw  …
+DEPLOY_MODE=     DEPLOY_MODE=     DEPLOY_MODE=
+data-node-ui     data-node-ui     data-node-ui
+port 8081        port 8082        port 8088
+```
+
+The hub serves the frontend and `registry.json`. Browsers fetch playground data cross-origin from each data-node's `/api/`. The hub itself has no database and no importer.
+
+## When to use this topology
+
+- One operator wants to cover a large region (e.g. all of Germany) without a multi-hour single import.
+- You want a live test bed for hub federation features.
+- You don't (yet) have other operators to host regional backends.
+
+## Prerequisites
+
+### Hardware
+
+| Resource | Minimum | Recommended |
+|---|---|---|
+| RAM | 6 GiB | 8 GiB |
+| Swap | **4 GiB** | 4 GiB |
+| Disk | 20 GiB | 40 GiB+ |
+
+**Swap is required.** Without swap, the Linux OOM killer fires when multiple importers run near-simultaneously, killing whichever process is largest at that moment. Even if each individual import fits in RAM, two medium-sized backends starting at the same time can exhaust available memory. 4 GiB of swap gives the kernel room to page out idle data and survive the overlap.
+
+```bash
+sudo fallocate -l 4G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+### Per-backend RAM and disk estimates
+
+| Size class | Examples | pgdata | RAM (steady-state) |
+|---|---|---|---|
+| Small | Bremen, Hamburg, Saarland, Berlin | ~200–300 MB | ~50–150 MiB |
+| Medium | Hessen, Thüringen, Sachsen-Anhalt, Brandenburg, MV | ~500 MB–1 GB | ~150–250 MiB |
+| Large | Bayern, NRW, Niedersachsen, BaWü, Sachsen, RLP, SH | ~1–3 GB | ~300–600 MiB |
+
+Check free RAM before adding large backends:
+
+```bash
+free -h
+docker stats --no-stream --format "table {{.Name}}\t{{.MemUsage}}" | sort -k2 -h
+```
+
+## Port allocation
+
+| Stack | Port | Profile(s) |
+|---|---|---|
+| Hub | 8080 | `ui auto-update` |
+| First data-node (e.g. Hessen) | 8081 | `data-node-ui` |
+| Second data-node (e.g. Berlin) | 8082 | `data-node-ui` |
+| … | 8083–8096 | `data-node-ui` |
+
+Use consecutive ports and unique `COMPOSE_PROJECT_NAME` per stack.
+
+## Setup
+
+### Hub
+
+The hub runs `DEPLOY_MODE=ui` with no database. Its `.env` contains no `OSM_RELATION_ID`, `PBF_URL`, or `POSTGRES_PASSWORD`:
+
+```env
+COMPOSE_PROJECT_NAME=spieli
+DEPLOY_MODE=ui
+APP_MODE=hub
+APP_PORT=8080
+REGISTRY_URL=/registry.json
+HUB_POLL_INTERVAL=300
+SITE_URL=https://hub.example.com
+IMPRESSUM_NAME=...
+IMPRESSUM_ADDRESS=...
+IMPRESSUM_EMAIL=...
+```
+
+Bind-mount `registry.json` via `compose.override.yml` so you can update it without rebuilding:
+
+```yaml
+services:
+  app:
+    volumes:
+      - ./registry.json:/usr/share/nginx/html/registry.json:ro
+```
+
+Start with `--profile ui --profile auto-update` (Watchtower lives here and covers all containers on the host):
+
+```bash
+docker compose --profile ui --profile auto-update up -d
+```
+
+### Data-nodes
+
+Use `scripts/setup-germany-backends.sh` as a starting point for bulk setup. Edit the `SKIP_SLUGS` array for backends hosted elsewhere or not yet ready, and set `DOMAIN_SUFFIX` and `TRAEFIK_DYNAMIC_DIR` to match your environment.
+
+For each backend the script creates the directory, patches `compose.yml`, writes `.env`, and drops a Traefik dynamic config. It does **not** start imports — do those manually after checking RAM.
+
+### First import — one-shot before daemon
+
+**Do not start the importer in daemon mode on a fresh database.** The daemon applies `api.sql` on startup before checking whether a reimport is needed. On an empty DB this fails because `planet_osm_polygon` does not exist yet, causing a crash-restart loop.
+
+Instead, run the first import as a one-shot (no daemon env vars), then start the daemon:
+
+```bash
+cd ~/spieli-<slug>
+
+# 1. Start db, postgrest, app — but not importer
+docker compose --profile data-node-ui up -d db postgrest app
+
+# 2. Run one-shot import (overrides daemon env vars from .env)
+docker compose --profile data-node-ui run --rm \
+  -e REIMPORT_INTERVAL_MIN_DAYS= \
+  -e REIMPORT_INTERVAL_MAX_DAYS= \
+  -e REIMPORT_STARTUP_JITTER_MAX_HOURS= \
+  importer
+
+# 3. After success, start daemon
+docker compose --profile data-node-ui up -d importer
+```
+
+Import large backends one at a time. Check `free -h` before each large one.
+
+### Startup jitter
+
+`REIMPORT_STARTUP_JITTER_MAX_HOURS` delays the **first import on a fresh DB** by a random amount. This prevents all backends started at the same time from importing in parallel during initial setup.
+
+!!! warning "Jitter does not affect ongoing daily reimports"
+    Once a backend has data, the next reimport fires at `last_import_time + interval`. Jitter has no effect on this schedule. The spread between daily reimports comes from the natural difference in when each backend's first import completed. This is why swap is important — even with good timing, two backends may occasionally overlap.
+
+Add jitter to `.env` after the first import completes:
+
+```bash
+echo "REIMPORT_STARTUP_JITTER_MAX_HOURS=12" >> ~/spieli-<slug>/.env
+```
+
+## Upgrading
+
+Use `scripts/upgrade-stacks.sh`. It pulls the new image, restarts the app container, runs `API_ONLY=1` for data-nodes (updates DB functions and version), and verifies `get_meta` — sequentially, never in parallel. The hub entry uses `--profile ui` and skips the importer step.
+
+Copy the script to the VPS and edit the `STACKS` array to match your port layout:
+
+```bash
+scp scripts/upgrade-stacks.sh horst@vps:~/upgrade_stacks.sh
+bash ~/upgrade_stacks.sh
+```
+
+## Watchtower
+
+Only the hub stack runs `--profile auto-update`. A second Watchtower on any data-node stack causes both instances to fight over the same containers and kill each other on startup.
+
+The single Watchtower instance in the hub stack watches all containers on the Docker host automatically — data-node containers are updated and restarted even though their stacks don't run `auto-update`.
+
+## See also
+
+- [Federated Deployment](federated-deployment.md) — distributed (multi-host) topology
+- [Add a Data-node](add-data-node.md) — adding one backend at a time
+- [Upgrading](upgrade.md) — multi-stack upgrade procedure
+- [Configuration reference](configuration.md) — all env vars

--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -78,6 +78,51 @@ The importer applies `api.sql` on every daemon-mode startup, so schema changes f
 
 Upgrade each data-node first, verify it works, then upgrade the Hub UI. The Hub is backwards-compatible with older data-nodes (it falls back to the legacy `get_playgrounds` RPC if the tiered RPCs return 404), but an older Hub is not guaranteed to understand new data-node response fields.
 
+### Multiple stacks on one host
+
+When the Hub and its data-nodes share a single VPS, each stack lives in its own directory with a unique `COMPOSE_PROJECT_NAME`. Upgrade in order: **data-nodes first, hub last**. Never upgrade stacks in parallel — concurrent API_ONLY runs plus the resident daemon importers can exhaust RAM.
+
+Use the provided helper script for a one-command upgrade:
+
+```bash
+bash ~/spieli/scripts/upgrade-stacks.sh
+```
+
+The script is in `scripts/upgrade-stacks.sh`. Edit the `STACKS` array at the top to match your deployment before the first run:
+
+```bash
+STACKS=(
+  "$HOME/spieli-berlin:data-node-ui:8082"
+  "$HOME/spieli:data-node-ui auto-update:8080"
+)
+```
+
+Each entry is `directory:profiles:local-port`. The script pulls images, restarts the app container, runs `API_ONLY=1`, and verifies `get_meta` — then moves to the next stack.
+
+To upgrade a single stack manually:
+
+```bash
+cd ~/spieli-<region>
+docker compose pull
+docker compose --profile data-node-ui up -d app
+docker compose --profile data-node-ui run --rm -e API_ONLY=1 importer
+```
+
+For the hub stack (which also carries Watchtower), include `--profile auto-update` on the `up` command:
+
+```bash
+docker compose --profile data-node-ui --profile auto-update up -d app
+```
+
+!!! note "API_ONLY=1 bypasses daemon mode"
+    `docker compose run --rm -e API_ONLY=1 importer` starts a fresh one-shot container. The importer entrypoint checks `API_ONLY` before any reimport logic, so `REIMPORT_INTERVAL_*` settings have no effect — the container applies `api.sql` and exits regardless of how recently data was imported.
+
+!!! note "One Watchtower covers all containers"
+    Only the hub stack should run `--profile auto-update`. Adding a second Watchtower to any data-node stack causes both instances to fight over the same containers. Data-node stacks without `auto-update` are still restarted by the single Watchtower instance when it detects a new image.
+
+!!! note "Daemon importer and API_ONLY"
+    On stacks managed by Watchtower, the importer applies `api.sql` automatically on every daemon-mode restart — the explicit `API_ONLY=1` step is not strictly required. Running it during a manual upgrade just ensures `get_meta()` reports the correct version immediately, without waiting for the next scheduled daemon restart.
+
 ## Downgrading
 
 Downgrading is supported only within the same minor version. Images are tagged `:X.Y.Z` and `:X.Y`, so:

--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -108,10 +108,12 @@ docker compose --profile data-node-ui up -d app
 docker compose --profile data-node-ui run --rm -e API_ONLY=1 importer
 ```
 
-For the hub stack (which also carries Watchtower), include `--profile auto-update` on the `up` command:
+For the hub stack (pure `DEPLOY_MODE=ui` — no importer, no `API_ONLY` step):
 
 ```bash
-docker compose --profile data-node-ui --profile auto-update up -d app
+cd ~/spieli
+docker compose pull
+docker compose --profile ui --profile auto-update up -d app
 ```
 
 !!! note "API_ONLY=1 bypasses daemon mode"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Manual Deploy: ops/manual-deploy.md
       - HTTPS Setup: ops/https-setup.md
       - Federated Deployment: ops/federated-deployment.md
+      - Single-host Federation: ops/single-host-federation.md
       - Add a Data-node: ops/add-data-node.md
       - Configuration: ops/configuration.md
       - Upgrading: ops/upgrade.md

--- a/scripts/setup-germany-backends.sh
+++ b/scripts/setup-germany-backends.sh
@@ -110,6 +110,7 @@ REIMPORT_INTERVAL_MAX_DAYS=1
 EOF
 
   # 5. Create Traefik dynamic config
+  mkdir -p "${TRAEFIK_DYNAMIC_DIR}"
   cat > "${TRAEFIK_DYNAMIC_DIR}/${slug}.yml" << EOF
 http:
   routers:

--- a/scripts/setup-germany-backends.sh
+++ b/scripts/setup-germany-backends.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Sets up Bundesland data-node backends on a host that already runs
+# the spieli hub + Hessen data-node (~/spieli).
+#
+# All 15 non-Hessen Bundesländer are listed. Hessen is omitted — it is
+# integrated into the hub stack (~/spieli). Add slugs you want to skip
+# (already running, hosted elsewhere, not yet ready) to SKIP_SLUGS.
+#
+# Run from your home directory: bash setup-germany-backends.sh
+#
+# What it does per backend:
+#   1. Creates ~/spieli-<slug>/ with compose.yml + db/init.sql
+#   2. Patches compose.yml (PGRST_DB_URI key-value, POSTGRES_HOST_AUTH_METHOD)
+#   3. Writes .env
+#   4. Creates Traefik dynamic config
+#
+# After this script: start each stack and run the importer.
+# See docs/ops/single-host-federation.md for the full walkthrough.
+
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+TRAEFIK_DYNAMIC_DIR="${HOME}/spieli-traefik/dynamic"
+SOURCE_DIR="${HOME}/spieli"
+DOMAIN_SUFFIX="spieli.example.com"   # change to your domain
+
+# Slugs to skip — already running, hosted elsewhere, or not yet ready.
+# Example: SKIP_SLUGS=("berlin" "bawue")
+SKIP_SLUGS=()
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Format: "slug:relation_id:geofabrik_path:port:display_name"
+# Hessen is absent — it is part of the hub stack (~/spieli, port 8080).
+# Ports 8082–8096 are reserved for these 15 backends.
+BACKENDS=(
+  "bawue:62350:europe/germany/baden-wuerttemberg-latest.osm.pbf:8095:Baden-Württemberg"
+  "bayern:2145268:europe/germany/bayern-latest.osm.pbf:8083:Bayern"
+  "berlin:62422:europe/germany/berlin-latest.osm.pbf:8082:Berlin"
+  "brandenburg:62504:europe/germany/brandenburg-latest.osm.pbf:8084:Brandenburg"
+  "bremen:62559:europe/germany/bremen-latest.osm.pbf:8085:Bremen"
+  "hamburg:62782:europe/germany/hamburg-latest.osm.pbf:8086:Hamburg"
+  "mv:62937:europe/germany/mecklenburg-vorpommern-latest.osm.pbf:8087:Mecklenburg-Vorpommern"
+  "niedersachsen:62701:europe/germany/niedersachsen-latest.osm.pbf:8096:Niedersachsen"
+  "nrw:62761:europe/germany/nordrhein-westfalen-latest.osm.pbf:8088:Nordrhein-Westfalen"
+  "rlp:62341:europe/germany/rheinland-pfalz-latest.osm.pbf:8089:Rheinland-Pfalz"
+  "saarland:62372:europe/germany/saarland-latest.osm.pbf:8090:Saarland"
+  "sachsen:62467:europe/germany/sachsen-latest.osm.pbf:8091:Sachsen"
+  "sachsen-anhalt:62606:europe/germany/sachsen-anhalt-latest.osm.pbf:8092:Sachsen-Anhalt"
+  "sh:51482:europe/germany/schleswig-holstein-latest.osm.pbf:8093:Schleswig-Holstein"
+  "thueringen:62366:europe/germany/thueringen-latest.osm.pbf:8094:Thüringen"
+)
+
+skip_slug() {
+  local slug="$1"
+  for s in "${SKIP_SLUGS[@]:-}"; do [[ "$s" == "$slug" ]] && return 0; done
+  return 1
+}
+
+echo "==> Setting up Bundesland backends (skipping: ${SKIP_SLUGS[*]:-none})"
+echo ""
+
+for entry in "${BACKENDS[@]}"; do
+  IFS=: read -r slug relation pbf port name <<< "$entry"
+
+  if skip_slug "$slug"; then
+    echo "--- ${name} (skipped) ---"
+    echo ""
+    continue
+  fi
+
+  deploy_dir="${HOME}/spieli-${slug}"
+  domain="${slug}.${DOMAIN_SUFFIX}"
+  password=$(openssl rand -base64 24 | tr -d '/+=')
+
+  echo "--- ${name} (port ${port}) ---"
+
+  # 1. Create deploy dir
+  mkdir -p "${deploy_dir}"
+  cp "${SOURCE_DIR}/compose.yml" "${deploy_dir}/compose.yml"
+  cp -r "${SOURCE_DIR}/db" "${deploy_dir}/db"
+
+  # 2. Patch PGRST_DB_URI to key-value format (safe for any password)
+  sed -i \
+    's|PGRST_DB_URI:.*postgres://osm:.*@db:5432/osm|PGRST_DB_URI: "host=db port=5432 dbname=osm user=osm password=${POSTGRES_PASSWORD}"|' \
+    "${deploy_dir}/compose.yml"
+
+  # 3. Add POSTGRES_HOST_AUTH_METHOD under the db service only (not importer)
+  python3 - "${deploy_dir}/compose.yml" << 'PYEOF'
+import sys, re
+path = sys.argv[1]
+text = open(path).read()
+patched = text.replace(
+    "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}\n",
+    "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-CHANGE_ME}\n      POSTGRES_HOST_AUTH_METHOD:  scram-sha-256\n",
+    1  # first occurrence only — db service, not importer
+)
+open(path, 'w').write(patched)
+PYEOF
+
+  # 4. Write .env
+  cat > "${deploy_dir}/.env" << EOF
+COMPOSE_PROJECT_NAME=spieli-${slug}
+DEPLOY_MODE=data-node-ui
+APP_PORT=${port}
+OSM_RELATION_ID=${relation}
+PBF_URL=https://download.geofabrik.de/${pbf}
+POSTGRES_PASSWORD=${password}
+REIMPORT_INTERVAL_MIN_DAYS=1
+REIMPORT_INTERVAL_MAX_DAYS=1
+EOF
+
+  # 5. Create Traefik dynamic config
+  cat > "${TRAEFIK_DYNAMIC_DIR}/${slug}.yml" << EOF
+http:
+  routers:
+    ${slug}:
+      rule: "Host(\`${domain}\`)"
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: le
+      service: ${slug}
+      middlewares:
+        - security-headers
+
+  services:
+    ${slug}:
+      loadBalancer:
+        servers:
+          - url: "http://host.docker.internal:${port}"
+EOF
+
+  echo "    dir:    ${deploy_dir}"
+  echo "    domain: https://${domain}/api"
+  echo "    done"
+  echo ""
+done
+
+# 6. Print updated registry.json snippet
+echo "==> Add these entries to ~/spieli/registry.json:"
+echo ""
+echo '{'
+echo '  "instances": ['
+echo '    { "slug": "hessen", "url": "https://spieli.example.com/api", "name": "Hessen" },'
+for entry in "${BACKENDS[@]}"; do
+  IFS=: read -r slug relation pbf port name <<< "$entry"
+  if skip_slug "$slug"; then continue; fi
+  domain="${slug}.${DOMAIN_SUFFIX}"
+  echo "    { \"slug\": \"${slug}\", \"url\": \"https://${domain}/api\", \"name\": \"${name}\" },"
+done
+echo '  ]'
+echo '}'
+
+echo ""
+echo "==> Done. Next steps:"
+echo "    1. Add DNS A records for all new subdomains → this server's IP"
+echo "    2. Start small backends first — check free RAM before large ones (Bayern, NRW, Niedersachsen, BaWü)"
+echo "    3. For each backend, run a one-shot import first (avoids jitter-on-empty-DB crash):"
+echo "         cd ~/spieli-<slug>"
+echo "         docker compose --profile data-node-ui up -d db postgrest app"
+echo "         docker compose --profile data-node-ui run --rm \\"
+echo "           -e REIMPORT_INTERVAL_MIN_DAYS= -e REIMPORT_INTERVAL_MAX_DAYS= importer"
+echo "    4. After import succeeds, add jitter and start daemon:"
+echo "         echo 'REIMPORT_STARTUP_JITTER_MAX_HOURS=12' >> .env"
+echo "         docker compose --profile data-node-ui up -d importer"
+echo "    5. Monitor import: docker logs -f spieli-<slug>-importer-1"
+echo "    5. Update ~/spieli/registry.json with the entries printed above"
+echo "    6. Restart hub app:"
+echo "         cd ~/spieli && docker compose --profile data-node-ui --profile auto-update up -d app"


### PR DESCRIPTION
## Summary

- Extends `docs/ops/upgrade.md` with a **Multiple stacks on one host** section covering sequential upgrade order, the script, and notes on Watchtower + API_ONLY behaviour
- Adds `scripts/upgrade-stacks.sh` — sequential upgrader for all stacks on one VPS (data-nodes first, hub last); verified against 14 stacks (13 Bundesland backends + hub)

## Test plan

- [x] Script run against all 14 production stacks — all reported `0.5.0` and non-zero `playground_count`
- [ ] Read through upgrade.md for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)