### PR TITLE
fix(ops): restart daemon importer during upgrade to prevent version revert

### DIFF
--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -24,14 +24,17 @@ cd /path/to/your/spieli-deployment
 # Pull the latest images
 docker compose pull
 
-# Restart app container (zero-database-downtime)
-docker compose --profile <mode> up -d app
+# Restart app and importer containers
+docker compose --profile <mode> up -d app importer
 
 # Re-apply api.sql — updates DB functions and the version reported by get_meta()
 docker compose --profile <mode> run --rm -e API_ONLY=1 importer
 ```
 
 Replace `<mode>` with your `DEPLOY_MODE` (`data-node`, `ui`, or `data-node-ui`).
+
+!!! warning "Always restart the importer, not just the app"
+    `docker compose up -d app` alone leaves the daemon importer running the old image. The daemon re-applies `api.sql` on its next scheduled reimport — using the old image, which reverts the version in `get_meta()` back to the previous release. Always include `importer` in the `up -d` call.
 
 !!! note
     The `API_ONLY=1` step is required on every upgrade, not just when the release notes mention SQL changes. The version number visible in the Hub regions panel comes from the database (written by the importer), not the app image — skipping this step leaves the reported version stale.

--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -49,11 +49,12 @@ for entry in "${STACKS[@]}"; do
   echo "→ Pulling images..."
   docker compose pull
 
-  echo "→ Restarting app and importer containers..."
+  echo "→ Restarting app container..."
   docker compose "${profile_flags[@]}" up -d app
 
   # Pure hub stacks (DEPLOY_MODE=ui) have no importer — skip importer steps.
   if [[ "$profiles" == *"data-node"* ]]; then
+    echo "→ Restarting daemon importer..."
     # Restart the daemon importer so it picks up the new image immediately.
     # Daemon mode runs api.sql on every startup, so the version in get_meta()
     # is updated without waiting for the next scheduled Watchtower restart.

--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# upgrade-stacks.sh — sequential upgrade of all spieli stacks on one host.
+#
+# Run on the VPS as the user who owns the stack directories.
+# Edit STACKS below to match your deployment. List data-nodes first, hub last.
+#
+# Usage: bash upgrade-stacks.sh
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+# Format per entry: "DIRECTORY:SPACE-SEPARATED-PROFILES:LOCAL_PORT"
+# data-nodes first, hub (ui auto-update) last.
+# Pure hub stacks (DEPLOY_MODE=ui) skip the API_ONLY step — no importer.
+STACKS=(
+  "$HOME/spieli-hessen:data-node-ui:8081"
+  "$HOME/spieli-berlin:data-node-ui:8082"
+  "$HOME/spieli-bayern:data-node-ui:8083"
+  "$HOME/spieli-brandenburg:data-node-ui:8084"
+  "$HOME/spieli-bremen:data-node-ui:8085"
+  "$HOME/spieli-hamburg:data-node-ui:8086"
+  "$HOME/spieli-mv:data-node-ui:8087"
+  "$HOME/spieli-nrw:data-node-ui:8088"
+  "$HOME/spieli-rlp:data-node-ui:8089"
+  "$HOME/spieli-saarland:data-node-ui:8090"
+  "$HOME/spieli-sachsen:data-node-ui:8091"
+  "$HOME/spieli-sachsen-anhalt:data-node-ui:8092"
+  "$HOME/spieli-sh:data-node-ui:8093"
+  "$HOME/spieli-thueringen:data-node-ui:8094"
+  "$HOME/spieli:ui auto-update:8080"
+)
+# ─────────────────────────────────────────────────────────────────────────────
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+for entry in "${STACKS[@]}"; do
+  IFS=: read -r dir profiles port <<< "$entry"
+  name=$(basename "$dir")
+
+  echo ""
+  echo "━━━ $name ━━━"
+
+  cd "$dir" || fail "Cannot cd to $dir"
+
+  profile_flags=()
+  for p in $profiles; do
+    profile_flags+=(--profile "$p")
+  done
+
+  echo "→ Pulling images..."
+  docker compose pull
+
+  echo "→ Restarting app and importer containers..."
+  docker compose "${profile_flags[@]}" up -d app
+
+  # Pure hub stacks (DEPLOY_MODE=ui) have no importer — skip importer steps.
+  if [[ "$profiles" == *"data-node"* ]]; then
+    # Restart the daemon importer so it picks up the new image immediately.
+    # Daemon mode runs api.sql on every startup, so the version in get_meta()
+    # is updated without waiting for the next scheduled Watchtower restart.
+    docker compose "${profile_flags[@]}" up -d importer
+
+    echo "→ Applying api.sql (one-shot, never triggers full reimport)..."
+    # API_ONLY=1 is evaluated before any reimport logic in the importer entrypoint,
+    # so REIMPORT_INTERVAL_* settings have no effect here.
+    docker compose --profile data-node-ui run --rm -e API_ONLY=1 importer
+  else
+    echo "→ Pure hub — no importer, skipping api.sql step."
+  fi
+
+  echo "→ Verifying..."
+  sleep 3
+  result=$(curl -sf "http://localhost:${port}/api/rpc/get_meta" | \
+    python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))") \
+    || fail "get_meta unreachable for $name on port $port"
+  echo "  $result"
+
+  echo "✓ $name done"
+done
+
+echo ""
+echo "All stacks upgraded."


### PR DESCRIPTION
## Summary

- `upgrade-stacks.sh` only restarted the `app` container — the daemon importer kept running the old image
- On its next scheduled reimport, the daemon re-applied old `api.sql` → reverted `get_meta().version` to the previous release
- Fix: add `docker compose up -d importer` before the `API_ONLY=1` step so the daemon picks up the new image immediately

Also adds a `warning` admonition to `upgrade.md` explaining why restarting the importer is required, and introduces `upgrade-stacks.sh` on `main` (it previously only lived in the `docs/upgrade-multi-stack-vps` branch).

## Test plan

- [ ] Run `upgrade-stacks.sh` against a multi-stack VPS
- [ ] Verify hub regions panel shows the new version for all backends immediately after the script completes
- [ ] Wait for at least one daemon reimport cycle — version should stay on the new release

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)