### PR TITLE
fix(importer): write osmium output atomically to prevent corrupt cache

### DIFF
--- a/importer/import.sh
+++ b/importer/import.sh
@@ -199,12 +199,15 @@ run_import() (
             echo "[importer] Bbox cache hit: $BBOX_PBF is newer than source, skipping osmium extract"
         else
             echo "[importer] Running osmium extract (bbox=$RESOLVED_BBOX)..."
+            BBOX_TMP=$(mktemp -p /data .bbox.XXXXXX.pbf)
+            trap 'rm -f "$BBOX_TMP"' EXIT
             osmium extract \
                 --bbox="$RESOLVED_BBOX" \
                 --strategy=smart \
-                -o "$BBOX_PBF" \
-                "$PBF_FILE" \
-                --overwrite
+                -o "$BBOX_TMP" \
+                "$PBF_FILE"
+            mv "$BBOX_TMP" "$BBOX_PBF"
+            trap - EXIT
             echo "[importer] Bbox extract complete: $(du -sh "$BBOX_PBF" | cut -f1)"
         fi
 
@@ -220,10 +223,11 @@ run_import() (
         echo "[importer] Tag-filter cache hit: $TAGS_PBF is newer than source, skipping osmium tags-filter"
     else
         echo "[importer] Running osmium tags-filter..."
+        TAGS_TMP=$(mktemp -p /data .tags.XXXXXX.pbf)
+        trap 'rm -f "$TAGS_TMP"' EXIT
         osmium tags-filter \
-            -o "$TAGS_PBF" \
+            -o "$TAGS_TMP" \
             "$IMPORT_PBF" \
-            --overwrite \
             n/natural=tree \
             w/natural=tree_row \
             n/leisure=playground \
@@ -260,6 +264,8 @@ run_import() (
             r/leisure=pitch \
             r/type=multipolygon \
             r/boundary=administrative
+        mv "$TAGS_TMP" "$TAGS_PBF"
+        trap - EXIT
         echo "[importer] Tag-filter complete: $(du -sh "$TAGS_PBF" | cut -f1)"
     fi
 


### PR DESCRIPTION
Fixes #563

## Root cause

`osmium extract` and `osmium tags-filter` wrote directly to the final cache path (`-o "$BBOX_PBF"` / `-o "$TAGS_PBF" --overwrite`). If osmium was interrupted mid-write (SIGTERM, OOM, disk full), the partial output file remained at the cache path with a recent mtime. The next import treated it as a cache hit (`$TAGS_PBF -nt $IMPORT_PBF`) and passed the corrupt/empty file to osm2pgsql, which then processed 0 nodes / 0 ways / 0 relations — silently emptying the database.

Reported by the Baden-Württemberg operator after upgrading to 0.5.0.

## Fix

Write osmium output to a `mktemp` file in `/data` (same filesystem as the final path), then `mv` to the final cache path on success. An EXIT trap deletes the temp file if the process is interrupted before the `mv` — leaving no partial file behind. The trap is cleared after a successful `mv` so it does not interfere with the subsequent `_clear_importing` EXIT trap.

Applied to both the bbox extract and the tags-filter steps.

## Recovery for affected operators

Delete the corrupt cache files and re-import:

```bash
docker run --rm -v <stack>_pbf_cache:/data alpine \
  sh -c 'rm -f /data/*_<RELATION_ID>.pbf /data/*_<RELATION_ID>_tags.pbf'
docker compose --profile <mode> run --rm importer
```