### PR TITLE
fix(importer): validate PBF cache size and fail loudly on zero-playground import

### DIFF
--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -18,6 +18,9 @@ Check [GitHub Releases](https://github.com/mfuhrmann/spieli/releases) for the la
 
 For patch and minor version upgrades with no breaking changes:
 
+!!! danger "Do not delete volumes during a standard upgrade"
+    A standard upgrade does **not** require deleting Docker volumes. Deleting `pgdata` erases all imported playground data and forces a full re-import (several hours for large states). If you already deleted `pgdata`, see [If you deleted the database volume](#if-you-deleted-the-database-volume) below.
+
 ```bash
 cd /path/to/your/spieli-deployment
 
@@ -42,6 +45,17 @@ Replace `<mode>` with your `DEPLOY_MODE` (`data-node`, `ui`, or `data-node-ui`).
 !!! warning "If API_ONLY fails mid-run"
     `API_ONLY=1` drops and recreates the `playground_stats` materialised view. If it crashes partway through, the view is gone and PostgREST will log errors like `relation "public.playground_stats" does not exist`. Recovery: run a **full re-import** (see below) — this recreates everything from scratch.
 
+### Verify the upgrade
+
+After the `API_ONLY=1` step, confirm the new version is live and playground data is intact:
+
+```bash
+curl -sf http://localhost:<port>/api/rpc/get_meta | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version'], ' playgrounds:', d['playground_count'])"
+```
+
+Both `version` and `playground_count` should be non-zero. If `playground_count` is 0, a full re-import is needed (see below).
+
 ## When to run a full re-import
 
 A full re-import (without `API_ONLY`) is needed when:
@@ -54,6 +68,38 @@ docker compose --profile <mode> run --rm importer
 ```
 
 A full re-import also re-applies `api.sql`, so the separate `API_ONLY=1` step is not needed when you do a full re-import.
+
+## If you deleted the database volume
+
+If you deleted the `pgdata` volume (e.g. `docker compose down -v` or `docker volume rm <stack>_pgdata`), all imported data is gone and you need a full re-import. Before running it:
+
+1. **Check whether the PBF cache volume also survived.** The importer stores downloaded and pre-filtered PBF files in a separate named volume (`<stack>_pbf_cache`). This volume is not removed by `docker compose down -v` if it was created outside the current Compose project.
+
+    ```bash
+    docker volume ls | grep pbf_cache
+    ```
+
+2. **If the cache volume exists, clear it.** A previously interrupted import may have left a corrupt or empty filtered PBF in the cache. The importer checks file timestamps but not content — a corrupt cache causes a full re-import to process 0 objects and silently leave the database empty.
+
+    ```bash
+    # Replace <stack> with your stack name (e.g. spieli-hessen)
+    docker volume rm <stack>_pbf_cache
+    ```
+
+    Alternatively, force a cache bypass by deleting only the filtered files:
+
+    ```bash
+    docker run --rm -v <stack>_pbf_cache:/data alpine \
+      sh -c 'rm -f /data/*_<RELATION_ID>.pbf /data/*_<RELATION_ID>_tags.pbf'
+    ```
+
+3. **Run the full re-import** (downloads the PBF fresh if the cache was cleared):
+
+    ```bash
+    docker compose --profile <mode> run --rm importer
+    ```
+
+4. **Verify** with `get_meta` as shown in the standard upgrade section above.
 
 ## Upgrading the Compose file
 

--- a/importer/import.sh
+++ b/importer/import.sh
@@ -195,9 +195,18 @@ run_import() (
     if [ "$SKIP_PREFILTER" -eq 0 ]; then
         BBOX_PBF="/data/${PBF_BASENAME}_${OSM_RELATION_ID}.pbf"
 
+        BBOX_CACHE_OK=0
         if [ -f "$BBOX_PBF" ] && [ "$BBOX_PBF" -nt "$PBF_FILE" ]; then
-            echo "[importer] Bbox cache hit: $BBOX_PBF is newer than source, skipping osmium extract"
-        else
+            BBOX_SIZE=$(wc -c < "$BBOX_PBF")
+            if [ "$BBOX_SIZE" -ge 10240 ]; then
+                BBOX_CACHE_OK=1
+                echo "[importer] Bbox cache hit: $BBOX_PBF is newer than source, skipping osmium extract"
+            else
+                echo "[importer] WARNING: bbox cache is suspiciously small (${BBOX_SIZE} bytes) — likely corrupt or empty. Invalidating and re-running osmium..."
+                rm -f "$BBOX_PBF"
+            fi
+        fi
+        if [ "$BBOX_CACHE_OK" -eq 0 ]; then
             echo "[importer] Running osmium extract (bbox=$RESOLVED_BBOX)..."
             BBOX_TMP=$(mktemp -p /data .bbox.XXXXXX.pbf)
             trap 'rm -f "$BBOX_TMP"' EXIT
@@ -219,9 +228,18 @@ run_import() (
     # --------------------------------------------------------------------------- #
     TAGS_PBF="/data/${PBF_BASENAME}_${OSM_RELATION_ID}_tags.pbf"
 
+    TAGS_CACHE_OK=0
     if [ -f "$TAGS_PBF" ] && [ "$TAGS_PBF" -nt "$IMPORT_PBF" ]; then
-        echo "[importer] Tag-filter cache hit: $TAGS_PBF is newer than source, skipping osmium tags-filter"
-    else
+        TAGS_SIZE=$(wc -c < "$TAGS_PBF")
+        if [ "$TAGS_SIZE" -ge 10240 ]; then
+            TAGS_CACHE_OK=1
+            echo "[importer] Tag-filter cache hit: $TAGS_PBF is newer than source, skipping osmium tags-filter"
+        else
+            echo "[importer] WARNING: tags cache is suspiciously small (${TAGS_SIZE} bytes) — likely corrupt or empty. Invalidating and re-running osmium..."
+            rm -f "$TAGS_PBF"
+        fi
+    fi
+    if [ "$TAGS_CACHE_OK" -eq 0 ]; then
         echo "[importer] Running osmium tags-filter..."
         TAGS_TMP=$(mktemp -p /data .tags.XXXXXX.pbf)
         trap 'rm -f "$TAGS_TMP"' EXIT
@@ -299,6 +317,18 @@ run_import() (
         "$IMPORT_PBF"
 
     echo "[importer] osm2pgsql finished."
+
+    # Sanity check: any legitimate Bundesland import produces at least some
+    # playground polygons. Zero means the PBF was empty or corrupt — the import
+    # succeeded structurally but the database is now effectively empty.
+    _PLAYGROUND_COUNT=$(psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" \
+        -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+        -t -c "SELECT count(*) FROM planet_osm_polygon WHERE leisure = 'playground'" \
+        2>/dev/null | tr -d ' \n')
+    if [ -z "$_PLAYGROUND_COUNT" ] || [ "$_PLAYGROUND_COUNT" -eq 0 ]; then
+        fail "osm2pgsql imported 0 playground polygons — the PBF is likely empty or corrupt. Delete the cached PBF files and re-run: docker run --rm -v <pbf_cache_volume>:/data alpine sh -c 'rm -f /data/*_${OSM_RELATION_ID}*.pbf'"
+    fi
+    echo "[importer] Verified: ${_PLAYGROUND_COUNT} playground polygons imported."
 
     # --------------------------------------------------------------------------- #
     # Create PostgREST API schema (views / functions)


### PR DESCRIPTION
Closes #566, #567, #568

## Context

The BaWü operator ran a full re-import after upgrading to 0.5.0. A previously interrupted osmium run had left a corrupt (near-empty) `_tags.pbf` in the `pbf_cache` volume. The mtime check passed, osm2pgsql read the corrupt file, processed 0 objects, and reported success — silently emptying the database. No error was shown.

## Changes

### `importer/import.sh` — two new checks

**PBF cache size validation** (fixes #566)

Before accepting a cache hit for the bbox extract or tags-filter, verify the file is ≥ 10 KB. A valid osmium PBF for any German Bundesland is always several MB; a smaller file is either a bare PBF header (osmium ran on empty input) or truncated output from a killed run. Invalidates and re-runs osmium instead of passing the bad file downstream.

**Post-import zero-playground check** (fixes #567)

After osm2pgsql completes, queries `planet_osm_polygon WHERE leisure = 'playground'`. Any legitimate Bundesland import produces at least some playground polygons — zero means the PBF was empty or corrupt. Fails with a clear error message including the exact command to clear the PBF cache and retry.

### `docs/ops/upgrade.md` — three additions (fixes #568)

- **Danger box** at the top of "Standard upgrade": do not delete volumes during a routine upgrade.
- **New section** "If you deleted the database volume": explains that `pgdata` deletion requires a full re-import, how to check whether the `pbf_cache` volume survived, and how to clear it safely before re-importing.
- **Verification step** at the end of the standard upgrade: `curl get_meta`, check `version` and `playground_count`.

## Notes

- Pairs with PR #565 (atomic osmium writes) which prevents *new* corrupt files from being created. This PR catches corrupt files that already exist.
- The 10 KB threshold is conservative — the smallest real-world tags PBF (Saarland) is several hundred KB.