### PR TITLE
chore: bump version to 0.5.2-rc

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2-rc",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Advances main to the next development version after the v0.5.1 release.