### PR TITLE
fix(ops): run API_ONLY=1 before daemon restart to avoid MV race

### DIFF
--- a/docs/ops/upgrade.md
+++ b/docs/ops/upgrade.md
@@ -143,7 +143,7 @@ STACKS=(
 )
 ```
 
-Each entry is `directory:profiles:local-port`. The script pulls images, restarts the app container, runs `API_ONLY=1`, and verifies `get_meta` — then moves to the next stack.
+Each entry is `directory:profiles:local-port`. The script pulls images, restarts the app container, runs `API_ONLY=1`, verifies `get_meta`, then restarts the daemon importer on the new image — and moves to the next stack.
 
 To upgrade a single stack manually:
 
@@ -152,7 +152,13 @@ cd ~/spieli-<region>
 docker compose pull
 docker compose --profile data-node-ui up -d app
 docker compose --profile data-node-ui run --rm -e API_ONLY=1 importer
+# verify first, then restart the daemon:
+curl -sf http://localhost:<port>/api/rpc/get_meta | python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version'], ' playgrounds:', d['playground_count'])"
+docker compose --profile data-node-ui up -d importer
 ```
+
+!!! warning "Run API_ONLY=1 before restarting the daemon importer"
+    The daemon importer runs `api.sql` on every container startup. If you restart the daemon and then immediately run `API_ONLY=1`, both containers apply `api.sql` concurrently — they race on the `DROP`/`CREATE` of the `playground_stats` materialized view. On large datasets this reliably causes `ERROR: relation "public.playground_stats" does not exist`. Always run `API_ONLY=1` first, verify, then restart the daemon.
 
 For the hub stack (pure `DEPLOY_MODE=ui` — no importer, no `API_ONLY` step):
 

--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -54,15 +54,11 @@ for entry in "${STACKS[@]}"; do
 
   # Pure hub stacks (DEPLOY_MODE=ui) have no importer — skip importer steps.
   if [[ "$profiles" == *"data-node"* ]]; then
-    echo "→ Restarting daemon importer..."
-    # Restart the daemon importer so it picks up the new image immediately.
-    # Daemon mode runs api.sql on every startup, so the version in get_meta()
-    # is updated without waiting for the next scheduled Watchtower restart.
-    docker compose "${profile_flags[@]}" up -d importer
-
     echo "→ Applying api.sql (one-shot, never triggers full reimport)..."
-    # API_ONLY=1 is evaluated before any reimport logic in the importer entrypoint,
-    # so REIMPORT_INTERVAL_* settings have no effect here.
+    # Run API_ONLY=1 before restarting the daemon. The daemon only runs api.sql
+    # on container startup; while it is idle between reimport cycles it won't
+    # touch playground_stats. Running both concurrently races on the DROP/CREATE
+    # of that materialized view and reliably fails on large datasets.
     docker compose --profile data-node-ui run --rm -e API_ONLY=1 importer
   else
     echo "→ Pure hub — no importer, skipping api.sql step."
@@ -74,6 +70,13 @@ for entry in "${STACKS[@]}"; do
     python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))") \
     || fail "get_meta unreachable for $name on port $port"
   echo "  $result"
+
+  if [[ "$profiles" == *"data-node"* ]]; then
+    echo "→ Restarting daemon importer on new image..."
+    # Restart after verify so the daemon's api.sql startup run does not race
+    # with the API_ONLY=1 container above.
+    docker compose "${profile_flags[@]}" up -d importer
+  fi
 
   echo "✓ $name done"
 done


### PR DESCRIPTION
Fixes #573

## Problem

`upgrade-stacks.sh` restarted the daemon importer and then immediately ran `API_ONLY=1`. Both containers execute `api.sql` concurrently — they race on the `DROP`/`CREATE` of `playground_stats`. On large datasets (Bayern ~23k playgrounds) the MV rebuild is slow enough that the daemon's `DROP MATERIALIZED VIEW` fired between the API_ONLY container's `CREATE MATERIALIZED VIEW` and `CREATE INDEX`:

```
ERROR:  relation "public.playground_stats" does not exist
```

Small stacks (Hessen ~8k, Berlin ~5k) completed before the daemon reached its DROP, so the race was invisible until Bayern.

## Fix

Run `API_ONLY=1` **before** restarting the daemon importer. The daemon only runs `api.sql` on container startup — while it is idle between reimport cycles, it does not touch `playground_stats`. After `API_ONLY=1` completes and verify passes, the daemon is restarted on the new image; it re-applies `api.sql` in the background with no concurrent actor.

New order per stack:
1. `docker compose pull`
2. `docker compose up -d app`
3. `docker compose run --rm -e API_ONLY=1 importer` ← before daemon restart
4. verify `get_meta`
5. `docker compose up -d importer` ← daemon restart after verify

Also adds a warning admonition to `docs/ops/upgrade.md` explaining why this order matters for manual upgrades.

## Test plan

- [ ] Run `upgrade-stacks.sh` on a multi-stack VPS — Bayern and other large stacks should complete without the `playground_stats` error
- [ ] Verify each stack shows the correct version and non-zero playground count after upgrade
- [ ] Confirm daemon importer is running on the new image after the script completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)