### PR TITLE
fix(ops): verify hub stacks with HTTP check instead of get_meta

### DIFF
--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -66,10 +66,17 @@ for entry in "${STACKS[@]}"; do
 
   echo "→ Verifying..."
   sleep 3
-  result=$(curl -sf "http://localhost:${port}/api/rpc/get_meta" | \
-    python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))") \
-    || fail "get_meta unreachable for $name on port $port"
-  echo "  $result"
+  if [[ "$profiles" == *"data-node"* ]]; then
+    result=$(curl -sf "http://localhost:${port}/api/rpc/get_meta" | \
+      python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))") \
+      || fail "get_meta unreachable for $name on port $port"
+    echo "  $result"
+  else
+    # Pure hub has no PostgREST — verify the app is serving HTTP instead.
+    curl -sf "http://localhost:${port}/" -o /dev/null \
+      || fail "App unreachable for $name on port $port"
+    echo "  app responding on port ${port}"
+  fi
 
   if [[ "$profiles" == *"data-node"* ]]; then
     echo "→ Restarting daemon importer on new image..."


### PR DESCRIPTION
Fixes #577

Pure hub stacks (`DEPLOY_MODE=ui`) have no PostgREST. `get_meta` doesn't exist at their port. The verify step was unconditional, so it always failed on the hub entry, causing the script to exit with an error even though all data-node upgrades completed successfully.

The hub is always last in `STACKS`, so this failure was cosmetic — but it hid the "All stacks upgraded." message and produced a non-zero exit code.

**Fix:** split verify by stack type — data-node stacks use `get_meta`, pure hub stacks use a plain HTTP check on `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)