### PR TITLE
fix(importer): pass --overwrite to osmium for the mktemp placeholder

### DIFF
--- a/importer/import.sh
+++ b/importer/import.sh
@@ -211,6 +211,7 @@ run_import() (
             BBOX_TMP=$(mktemp -p /data .bbox.XXXXXX.pbf)
             trap 'rm -f "$BBOX_TMP"' EXIT
             osmium extract \
+                --overwrite \
                 --bbox="$RESOLVED_BBOX" \
                 --strategy=smart \
                 -o "$BBOX_TMP" \
@@ -244,6 +245,7 @@ run_import() (
         TAGS_TMP=$(mktemp -p /data .tags.XXXXXX.pbf)
         trap 'rm -f "$TAGS_TMP"' EXIT
         osmium tags-filter \
+            --overwrite \
             -o "$TAGS_TMP" \
             "$IMPORT_PBF" \
             n/natural=tree \


### PR DESCRIPTION
## Summary

- Every `make import` (and every daemon-mode run) currently fails on every data-node stack at the first osmium step with `Open failed for '/data/.bbox.XXXXXX.pbf': File exists.`
- Root cause: #565 moved osmium output to a `mktemp` file + atomic `mv`, but `mktemp` creates the file (that's how it atomically reserves the name), and the `--overwrite` flag was dropped along with the destination change. Same bug in both osmium calls (bbox extract, tags-filter).
- Fix: add `--overwrite` back to both osmium invocations. The atomic-mv pattern from #565 stays intact; we just allow osmium to clobber the empty placeholder.

Closes #579.

## Test plan

- [ ] `docker compose --profile data-node run --rm importer` succeeds on a clean `pbf_cache` volume (downloads PBF → osmium extract → osmium tags-filter → osm2pgsql → api.sql)
- [ ] Re-run the same command; cache-hit paths still log `Bbox cache hit` / `Tag-filter cache hit` and skip osmium
- [ ] Confirm on `pkg.onms.eu` (`bawue.spieli.eu` stack) that `make import` completes end-to-end
- [ ] After import, verify `playground_stats` is populated (`SELECT count(*) FROM api.playground_stats`)