### PR TITLE
docs: update README tech stack and install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ A free, interactive web map for exploring playgrounds based on [OpenStreetMap](h
 The interactive installer downloads everything it needs and walks you through configuration:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/mfuhrmann/spieli/main/install.sh -o install.sh
-bash install.sh
+TAG=v0.5.1  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
+curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
+sha256sum --check install.sh.sha256 && bash install.sh
 ```
 
 **Requirements:** Docker with the Compose plugin, `bash`, `openssl`
@@ -50,7 +52,7 @@ Includes deployment guides, configuration reference, contributing how-tos, and a
 
 ## Tech stack
 
-Svelte 5 · OpenLayers · PostgreSQL/PostGIS · PostgREST · nginx · Docker
+Svelte 5 · Vite 6 · OpenLayers · Tailwind CSS · PostgreSQL/PostGIS · PostgREST · osm2pgsql · osmium · nginx · Docker
 
 Full details: [Tech stack reference](https://mfuhrmann.github.io/spieli/reference/tech-stack/)
 


### PR DESCRIPTION
Closes #572.

## Summary

- Expand tech stack one-liner to include Vite 6, Tailwind CSS, osm2pgsql, osmium (all present in the full reference page but missing from README)
- Align install snippet with the quick-start guide: versioned release asset URL + sha256 checksum verification instead of raw `main/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)