### PR TITLE
feat(hub): add importing ring state to macro view

### DIFF
--- a/app/src/hub/MacroView.svelte
+++ b/app/src/hub/MacroView.svelte
@@ -2,7 +2,7 @@
   // Country-level macro view (P2 §5).
   //
   // Subscribes to the backends store and rebuilds one Point feature per
-  // backend at the backend's bbox centroid, with stacked-ring properties
+  // backend at the backend's bbox centroid, with ring properties
   // (count + completeness) sourced from each backend's cached `get_meta`
   // response. The resulting features live in `source` and are styled by
   // `macroRingStyleFn` (registered on `macroLayer` in Map.svelte).
@@ -43,12 +43,13 @@
   function buildFeature(backend) {
     const centroid = bboxCentroid(backend.bbox);
     if (!centroid) return null;
-    const offline = !isBackendHealthy(backend);
+    const offline   = !isBackendHealthy(backend);
+    const importing = !offline && (backend.importing ?? false);
     // Pre-P1 backends → unknown completeness; map the count into the
     // restricted bucket so the renderer draws a flat gray ring.
     const c     = backend.completeness;
     const count = backend.playgroundCount ?? 0;
-    const degraded = !offline && count === 0;
+    const degraded = !offline && !importing && count === 0;
     const props = c
       ? {
           count,
@@ -71,6 +72,7 @@
       _backendSlug: backend.slug ?? null,
       _bbox:        backend.bbox,
       _offline:     offline,
+      _importing:   importing,
       _degraded:    degraded,
       _name:        backend.name ?? backend.region ?? backend.slug ?? backend.url,
       ...props,

--- a/app/src/hub/macroRingStyle.js
+++ b/app/src/hub/macroRingStyle.js
@@ -5,8 +5,9 @@
 //
 //   1. Always rendered as rings, never as the cluster-tier single-child dot
 //      (a backend with one playground is still a "region", not a singleton).
-//   2. Three visual variants — healthy (filled segments + count), offline
-//      (dashed outline, muted, "offline" label, last known count), and
+//   2. Four visual variants — healthy (filled segments + count), offline
+//      (dashed outline, muted, "offline" label, last known count), importing
+//      (solid blue ring, "updating" label — osm2pgsql actively running), and
 //      degraded (amber ring, "no data" label — backend reachable but empty).
 //
 // The bitmap cache from clusterStyle.js isn't reused here: macro features are
@@ -32,6 +33,9 @@ const OFFLINE_TEXT     = '#6b7280';
 const DEGRADED_STROKE  = '#d97706'; // amber-600
 const DEGRADED_FILL    = 'rgba(255, 251, 235, 0.92)'; // amber-50
 const DEGRADED_TEXT    = '#92400e'; // amber-800
+const IMPORTING_STROKE = '#3b82f6'; // blue-500
+const IMPORTING_FILL   = 'rgba(239, 246, 255, 0.92)'; // blue-50
+const IMPORTING_TEXT   = '#1e40af'; // blue-800
 const COUNT_FONT      = 'bold 22px ui-monospace, "SF Mono", Menlo, system-ui, -apple-system, sans-serif';
 const LABEL_FONT      = '600 11px system-ui, -apple-system, "Helvetica Neue", sans-serif';
 
@@ -155,6 +159,39 @@ function renderDegradedMacroRing(pixelCoords, state) {
   ctx.fillText('no data', x, y);
 }
 
+function renderImportingMacroRing(pixelCoords, state) {
+  const [x, y]   = pixelCoords;
+  const f        = state.feature;
+  const count    = f.get('count') ?? 0;
+  const ctx      = state.context;
+  const radius   = radiusForCount(count);
+
+  ctx.lineWidth   = RING_WIDTH;
+  ctx.lineCap     = 'butt';
+  ctx.strokeStyle = IMPORTING_STROKE;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(x, y, radius - RING_WIDTH / 2 - 1, 0, Math.PI * 2);
+  ctx.fillStyle   = IMPORTING_FILL;
+  ctx.strokeStyle = IMPORTING_STROKE;
+  ctx.lineWidth   = 1;
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle    = IMPORTING_TEXT;
+  ctx.font         = COUNT_FONT;
+  if ('fontFeatureSettings' in ctx) ctx.fontFeatureSettings = '"tnum" 1';
+  ctx.textAlign    = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(formatCount(count), x, y - 7);
+
+  ctx.font = LABEL_FONT;
+  ctx.fillText('updating', x, y + 11);
+}
+
 // Compact display: 65000 → "65k", 1500 → "1.5k", <1000 unchanged. Spec
 // scenario uses 65000 directly but at radius 44 the digit string blows
 // outside the inner disc; the "k" suffix keeps it inside.
@@ -164,12 +201,14 @@ function formatCount(n) {
   return `${Math.round(n / 1000)}k`;
 }
 
-const healthyStyle  = new Style({ renderer: renderHealthyMacroRing });
-const offlineStyle  = new Style({ renderer: renderOfflineMacroRing });
-const degradedStyle = new Style({ renderer: renderDegradedMacroRing });
+const healthyStyle   = new Style({ renderer: renderHealthyMacroRing });
+const offlineStyle   = new Style({ renderer: renderOfflineMacroRing });
+const degradedStyle  = new Style({ renderer: renderDegradedMacroRing });
+const importingStyle = new Style({ renderer: renderImportingMacroRing });
 
 export function macroRingStyleFn(feature) {
-  if (feature.get('_offline'))  return offlineStyle;
-  if (feature.get('_degraded')) return degradedStyle;
+  if (feature.get('_offline'))   return offlineStyle;
+  if (feature.get('_importing')) return importingStyle;
+  if (feature.get('_degraded'))  return degradedStyle;
   return healthyStyle;
 }

--- a/app/src/lib/clusterStyle.js
+++ b/app/src/lib/clusterStyle.js
@@ -1,4 +1,4 @@
-// Canvas renderer for the cluster-tier stacked-ring style.
+// Canvas renderer for the cluster-tier ring style.
 //
 // Server buckets ship `{count, complete, partial, missing}` per grid cell.
 // The ring is divided into three arcs proportional to those counts, with

--- a/app/src/lib/vectorStyles.js
+++ b/app/src/lib/vectorStyles.js
@@ -139,7 +139,7 @@ export function treeStyleFn(feature) {
 
 // ── Tiered-delivery styles (P1 §3 / §4) ───────────────────────────────────────
 
-// Cluster tier (zoom ≤ clusterMaxZoom) — canvas-rendered stacked ring with
+// Cluster tier (zoom ≤ clusterMaxZoom) — canvas-rendered ring with
 // complete/partial/missing segments and the count in the centre.
 // Single-child clusters (count === 1) render as a solid completeness dot.
 // See app/src/lib/clusterStyle.js for the renderer + bitmap cache.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -138,7 +138,7 @@ Browser → tiered orchestrator → OL cluster layer / polygon layer
 
 The default. One region, one database. The tiered orchestrator fires on every `moveend`:
 
-- **Zoom ≤ 13** → `get_playground_clusters(z, bbox)` → cluster layer (stacked ring rings, sized by `complete/partial/missing/restricted` counts)
+- **Zoom ≤ 13** → `get_playground_clusters(z, bbox)` → cluster layer (rings, sized by `complete/partial/missing/restricted` counts)
 - **Zoom > 13** → `get_playgrounds_bbox(bbox)` → polygon layer (full GeoJSON polygons, colour-coded by completeness)
 
 Clicking a playground writes `#W<osm_id>` (or `#<slug>/W<osm_id>` in hub mode) to the URL hash and opens `PlaygroundPanel`, which loads equipment, trees, POIs, and reviews.

--- a/docs/reference/federation.md
+++ b/docs/reference/federation.md
@@ -130,11 +130,20 @@ The polygon tier doesn't re-cluster — every backend's polygons render in a sin
 
 ### Country-level macro view
 
-At `zoom ≤ macroMaxZoom` the Hub renders one stacked-ring per registered backend, sized by `playground_count` and segmented by the `{complete, partial, missing}` counts the P1 `get_meta` extension ships. No per-playground fetch is issued at this zoom — the rings come entirely from the cached registry metadata.
+At `zoom ≤ macroMaxZoom` the Hub renders one ring per registered backend, sized by `playground_count` and segmented by the `{complete, partial, missing}` counts the P1 `get_meta` extension ships. No per-playground fetch is issued at this zoom — the rings come entirely from the cached registry metadata.
 
-Clicking a macro ring animates `view.fit` to the backend's bbox, which lands in the cluster or polygon tier and triggers a tier fetch scoped to that backend only.
+Clicking a ring animates `view.fit` to the backend's bbox, which lands in the cluster or polygon tier and triggers a tier fetch scoped to that backend only.
 
-Backends marked as offline (via `federation-status.json` — see [Monitoring](../ops/monitoring.md)) render as a dashed outline with their last-known count and an "offline" label, so the operator sees that the region exists but isn't currently reachable.
+Each ring has one of four visual states, driven by `federation-status.json` (see [Monitoring](../ops/monitoring.md)) and the cached `get_meta` response:
+
+| State | Visual | Condition |
+|---|---|---|
+| **Healthy** | Coloured segments (green / amber / red / gray) + count in centre | Backend reachable, data present |
+| **Offline** | Dashed gray ring + last-known count + "offline" label | `federation-status.json` reports `up: false` |
+| **Importing** | Solid blue ring + count + "updating" label | Backend reachable, osm2pgsql actively running |
+| **Degraded** | Solid amber ring + "no data" label | Backend reachable, not importing, but playground count is zero |
+
+Pre-P1 backends that omit the completeness fields from `get_meta` render as a flat gray ring (all count mapped into the "restricted / unknown" segment) so the operator sees "data quality unknown" rather than a misleading all-zero healthy ring.
 
 ### Architecture flow
 
@@ -158,7 +167,7 @@ flowchart LR
     sc --> render[Repaint clusterSource<br/>incrementally per arrival]
     concat --> render2[Append to polygonSource<br/>incrementally per arrival]
 
-    macro --> macroLayer[Render macroSource<br/>one ring per backend]
+    macro --> macroLayer[Render macroSource<br/>one ring per backend<br/>healthy/offline/importing/degraded]
 ```
 
 Each box in the cluster/polygon path runs once per moveend. Fan-out is the only step that produces network traffic; everything else is in-memory.

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -27,7 +27,7 @@ spieli/                            ← Monorepo root
 │       │   ├── equipmentGrouping.js ← Groups devices inside playground=structure polygons
 │       │   ├── equipmentAttributes.js ← Renders per-device detail HTML from OSM tags
 │       │   ├── vectorStyles.js    ← OL style functions (playground fill, equipment points)
-│       │   ├── clusterStyle.js    ← Canvas renderer for cluster rings (stacked ring style)
+│       │   ├── clusterStyle.js    ← Canvas renderer for cluster rings
 │       │   ├── i18n.js            ← svelte-i18n setup and locale detection
 │       │   ├── panoramax.js       ← Panoramax photo integration helpers
 │       │   ├── playgroundHelpers.js ← Misc. feature property helpers


### PR DESCRIPTION
## Summary

- Adds a fourth macro ring state for backends actively running osm2pgsql
- Standardises the term "ring" across all code comments and docs

## Ring states (after this PR)

| State | Visual | Condition |
|---|---|---|
| Healthy | Coloured segments + count | default |
| Offline | Dashed gray + "offline" | `federation-status.json` reports `up: false` |
| **Importing** (new) | Solid blue + count + "updating" | backend reachable, osm2pgsql running |
| Degraded | Solid amber + "no data" | reachable, not importing, `count == 0` |

## Changes

- `app/src/hub/macroRingStyle.js` — `renderImportingMacroRing`, `importingStyle`, updated `macroRingStyleFn` priority order
- `app/src/hub/MacroView.svelte` — `_importing` feature property, `degraded` excludes importing backends
- `docs/reference/federation.md` — ring state table, terminology cleanup
- `app/src/lib/clusterStyle.js`, `vectorStyles.js`, `docs/project-overview.md`, `docs/source-tree-analysis.md` — "stacked-ring" → "ring"

## Follow-up

#583 — expose `spielplatz_backend_importing` as a Prometheus metric so the importing state is alertable alongside `spielplatz_backend_up`.

## Test plan

- [ ] Seed a local hub with two backends (`make seed-load` + `make seed-load2`)
- [ ] Trigger import on one backend while watching macro view at zoom ≤ 7
- [ ] Verify blue ring appears while `importing: true`, reverts to healthy after
- [ ] Verify offline ring still shows for a stopped backend
- [ ] Verify degraded ring shows for a backend with `count == 0` and not importing

🤖 Generated with [Claude Code](https://claude.com/claude-code)