### PR TITLE
fix(hub): emit spielplatz_backend_importing in Prometheus metrics

### DIFF
--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -59,6 +59,10 @@ Prometheus text exposition format (version 0.0.4):
 # TYPE spielplatz_backend_up gauge
 spielplatz_backend_up{backend="fulda",url="https://fulda.example.com/api"} 1
 
+# HELP spielplatz_backend_importing 1 while osm2pgsql is actively running on this backend, 0 otherwise.
+# TYPE spielplatz_backend_importing gauge
+spielplatz_backend_importing{backend="fulda",url="https://fulda.example.com/api"} 0
+
 # HELP spielplatz_backend_latency_seconds Round-trip time for the last get_meta call.
 # TYPE spielplatz_backend_latency_seconds gauge
 spielplatz_backend_latency_seconds{backend="fulda",url="https://fulda.example.com/api"} 0.043
@@ -88,7 +92,7 @@ spielplatz_backend_playgrounds_missing{backend="fulda",url="https://fulda.exampl
 spielplatz_poll_generated_timestamp 1745668800
 ```
 
-`spielplatz_backend_data_age_seconds` and the four completeness gauges are omitted for a backend when the field is `null` (backend down, pre-P1 backend, or no import yet).
+`spielplatz_backend_data_age_seconds` and the four completeness gauges are omitted for a backend when the field is `null` (backend down, pre-P1 backend, or no import yet). `spielplatz_backend_importing` is always emitted when the backend is reachable; it defaults to `0` for older backends that predate the `importing` field in `get_meta`.
 
 ## Recipes
 
@@ -139,6 +143,14 @@ sum(spielplatz_backend_playgrounds_missing)
 
 # Alert if completeness ratio drops below 50 % for any backend
 spielplatz_backend_playgrounds_complete / spielplatz_backend_playgrounds_total < 0.5
+
+# Which backends are currently importing (data in flux)?
+spielplatz_backend_importing == 1
+
+# Backend online but no data and not importing (degraded ring state)
+spielplatz_backend_up == 1
+  and spielplatz_backend_importing == 0
+  and spielplatz_backend_playgrounds_total == 0
 ```
 
 ### Recipe 3 — Frontend error monitoring (Sentry)

--- a/oci/app/poll-federation.sh
+++ b/oci/app/poll-federation.sh
@@ -185,7 +185,9 @@ while IFS="	" read -r SLUG URL; do
         *\"*|*\\*) ;;  # skip — would break exposition format
         *)
             LABEL="backend=\"${SLUG}\",url=\"${URL}\""
+            IMPORTING_INT=$([ "$IMPORTING" = "true" ] && echo 1 || echo 0)
             METRICS_LINES="${METRICS_LINES}spielplatz_backend_up{${LABEL}} ${UP}\n"
+            METRICS_LINES="${METRICS_LINES}spielplatz_backend_importing{${LABEL}} ${IMPORTING_INT}\n"
             METRICS_LINES="${METRICS_LINES}spielplatz_backend_latency_seconds{${LABEL}} ${LATENCY}\n"
             if [ "$DATA_AGE_SECONDS" != "null" ] && [ -n "$DATA_AGE_SECONDS" ]; then
                 METRICS_LINES="${METRICS_LINES}spielplatz_backend_data_age_seconds{${LABEL}} ${DATA_AGE_SECONDS}\n"
@@ -217,6 +219,8 @@ printf '{"generated_at":"%s","poll_interval_seconds":%d,"backends":{%s}}\n' \
 {
     printf '# HELP spielplatz_backend_up 1 if the backend responded to get_meta, 0 otherwise.\n'
     printf '# TYPE spielplatz_backend_up gauge\n'
+    printf '# HELP spielplatz_backend_importing 1 while osm2pgsql is actively running on this backend, 0 otherwise.\n'
+    printf '# TYPE spielplatz_backend_importing gauge\n'
     printf '# HELP spielplatz_backend_latency_seconds Round-trip time for the last get_meta call.\n'
     printf '# TYPE spielplatz_backend_latency_seconds gauge\n'
     printf '# HELP spielplatz_backend_data_age_seconds Seconds since the backend last imported data.\n'


### PR DESCRIPTION
Closes #583.

## Problem

`importing` state was tracked in `federation-status.json` but had no `/metrics` gauge. Operators couldn't alert on backends that were mid-import.

## Changes

**`oci/app/poll-federation.sh`**
- Convert `$IMPORTING` (`true`/`false`) → `1`/`0`
- Emit `spielplatz_backend_importing{backend,url}` alongside `spielplatz_backend_up`
- Add `HELP`/`TYPE` header lines

**`docs/ops/monitoring.md`**
- Add `spielplatz_backend_importing` to the example Prometheus output block
- Note fallback behaviour for older backends
- Add PromQL recipes for importing state and degraded ring state

## New PromQL

```promql
# backends currently importing
spielplatz_backend_importing == 1

# degraded ring state (online, not importing, no data)
spielplatz_backend_up == 1
  and spielplatz_backend_importing == 0
  and spielplatz_backend_playgrounds_total == 0
```

## Test plan

- [ ] Run `poll-federation.sh` against a local hub with an active import; verify `spielplatz_backend_importing 1` appears in `/metrics`
- [ ] Verify `spielplatz_backend_importing 0` when backend is idle
- [ ] Verify metric omitted for backends with `"` or `\` in slug/URL (existing skip guard covers this — no extra handling needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)