### PR TITLE
chore: release v0.5.2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.5.2-rc",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,7 @@ The easiest way to deploy spieli is with the interactive installer. It downloads
 ## Install
 
 ```bash
-TAG=v0.5.1  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.5.2  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh
@@ -93,7 +93,7 @@ If someone is running a spieli Hub and you want your region to appear on it, sta
 **1. Run the installer**
 
 ```bash
-TAG=v0.5.1  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.5.2  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh


### PR DESCRIPTION
Release v0.5.2.

## Changes since v0.5.1

- feat(hub): importing ring state for macro view (#582 / #584)
- fix(hub): `spielplatz_backend_importing` Prometheus metric (#583 / #585)
- docs: branch-from-main rule in CLAUDE.md (#586 / #587)
- docs: README tech stack and install snippet (#572 / #581)

No breaking changes — patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)