### PR TITLE
fix(ops): force-pull images by name in upgrade-stacks.sh to bypass daemon cache

### DIFF
--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -47,6 +47,10 @@ for entry in "${STACKS[@]}"; do
   done
 
   echo "→ Pulling images..."
+  # Explicitly pull each image by name to bypass the Docker daemon's manifest
+  # cache, which can cause `docker compose pull` to skip a freshly-pushed tag
+  # it already has locally (observed with rapid CI push + immediate upgrade run).
+  docker compose config --images | sort -u | xargs -I{} docker pull {}
   docker compose pull
 
   echo "→ Restarting app container..."


### PR DESCRIPTION
Closes #590.

## Problem

`docker compose pull` skips re-fetching when the daemon has a recently-pulled local manifest for the same tag. Caused `version: 0.5.1` to persist after a `0.5.2` CI push during an upgrade run.

## Fix

```bash
docker compose config --images | sort -u | xargs -I{} docker pull {}
docker compose pull   # still runs for any images compose.config misses
```

`docker pull <image>` always re-checks the registry digest, bypassing the daemon cache.

## Test plan

- [ ] Run `upgrade-stacks.sh` immediately after a new image is pushed — verify new version appears in the verify line

🤖 Generated with [Claude Code](https://claude.com/claude-code)