### PR TITLE
chore: release v0.5.3

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.5.3-rc",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,7 @@ The easiest way to deploy spieli is with the interactive installer. It downloads
 ## Install
 
 ```bash
-TAG=v0.5.2  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.5.3  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh
@@ -93,7 +93,7 @@ If someone is running a spieli Hub and you want your region to appear on it, sta
 **1. Run the installer**
 
 ```bash
-TAG=v0.5.2  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.5.3  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh


### PR DESCRIPTION
## Summary

- Bump `app/package.json` version: `0.5.3-rc` → `0.5.3`
- Update `TAG=v0.5.3` in both install blocks in `docs/getting-started/quick-start.md`

## What's in v0.5.3

- fix(importer): pass `--overwrite` to osmium so forced reimport works (#580)
- fix(ops): force-pull images by name in upgrade-stacks.sh to bypass daemon cache (#591)
- fix(hub): emit `spielplatz_backend_importing` in Prometheus metrics (#585)
- feat(hub): add importing ring state to macro view (#584)
- fix(ops): verify hub stacks with HTTP check instead of get_meta (#578)
- docs(ops): hub stale-cache troubleshooting and migrate-hub-hessen script (#593)

🤖 Generated with [Claude Code](https://claude.com/claude-code)