### PR TITLE
fix(ops): auto force-reimport stacks with 0 playgrounds after upgrade

### DIFF
--- a/scripts/force-reimport-empty.sh
+++ b/scripts/force-reimport-empty.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# force-reimport-empty.sh — triggers forced reimport for every data-node stack
+# that currently reports 0 playgrounds. Runs imports in the background so all
+# stacks start in parallel. Logs to /tmp/<name>-reimport.log.
+#
+# Usage: bash scripts/force-reimport-empty.sh
+set -euo pipefail
+
+STACKS=(
+  "$HOME/spieli-hessen:data-node-ui:8081"
+  "$HOME/spieli-berlin:data-node-ui:8082"
+  "$HOME/spieli-bayern:data-node-ui:8083"
+  "$HOME/spieli-brandenburg:data-node-ui:8084"
+  "$HOME/spieli-bremen:data-node-ui:8085"
+  "$HOME/spieli-hamburg:data-node-ui:8086"
+  "$HOME/spieli-mv:data-node-ui:8087"
+  "$HOME/spieli-nrw:data-node-ui:8088"
+  "$HOME/spieli-rlp:data-node-ui:8089"
+  "$HOME/spieli-saarland:data-node-ui:8090"
+  "$HOME/spieli-sachsen:data-node-ui:8091"
+  "$HOME/spieli-sachsen-anhalt:data-node-ui:8092"
+  "$HOME/spieli-sh:data-node-ui:8093"
+  "$HOME/spieli-thueringen:data-node-ui:8094"
+)
+
+pids=()
+
+for entry in "${STACKS[@]}"; do
+  IFS=: read -r dir profiles port <<< "$entry"
+  name=$(basename "$dir")
+
+  count=$(curl -sf "http://localhost:${port}/api/rpc/get_meta" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('playground_count', -1))" 2>/dev/null \
+    || echo -1)
+
+  if [[ "$count" -gt 0 ]]; then
+    echo "✓ $name — $count playgrounds, skipping"
+    continue
+  fi
+
+  logfile="/tmp/${name}-reimport.log"
+  echo "→ $name — 0 playgrounds, triggering forced reimport (log: $logfile)"
+  (
+    cd "$dir"
+    docker compose --profile data-node-ui run --rm \
+      -e REIMPORT_INTERVAL_MIN_DAYS= \
+      -e REIMPORT_INTERVAL_MAX_DAYS= \
+      importer
+  ) > "$logfile" 2>&1 &
+  pids+=("$!:$name:$logfile")
+done
+
+if [[ ${#pids[@]} -eq 0 ]]; then
+  echo "All stacks have data — nothing to do."
+  exit 0
+fi
+
+echo ""
+echo "Waiting for ${#pids[@]} reimport(s) to complete..."
+failed=()
+for entry in "${pids[@]}"; do
+  IFS=: read -r pid name logfile <<< "$entry"
+  if wait "$pid"; then
+    echo "✓ $name done"
+  else
+    echo "✗ $name FAILED — see $logfile"
+    failed+=("$name")
+  fi
+done
+
+echo ""
+if [[ ${#failed[@]} -gt 0 ]]; then
+  echo "Failed: ${failed[*]}"
+  exit 1
+fi
+echo "All forced reimports completed."

--- a/scripts/upgrade-stacks.sh
+++ b/scripts/upgrade-stacks.sh
@@ -71,15 +71,19 @@ for entry in "${STACKS[@]}"; do
   echo "→ Verifying..."
   sleep 3
   if [[ "$profiles" == *"data-node"* ]]; then
-    result=$(curl -sf "http://localhost:${port}/api/rpc/get_meta" | \
-      python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))") \
+    meta=$(curl -sf "http://localhost:${port}/api/rpc/get_meta") \
       || fail "get_meta unreachable for $name on port $port"
+    result=$(printf '%s' "$meta" | \
+      python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d.get('version','?'), ' playgrounds:', d.get('playground_count','?'))")
+    playground_count=$(printf '%s' "$meta" | \
+      python3 -c "import sys,json; print(json.load(sys.stdin).get('playground_count', 0))")
     echo "  $result"
   else
     # Pure hub has no PostgREST — verify the app is serving HTTP instead.
     curl -sf "http://localhost:${port}/" -o /dev/null \
       || fail "App unreachable for $name on port $port"
     echo "  app responding on port ${port}"
+    playground_count=-1
   fi
 
   if [[ "$profiles" == *"data-node"* ]]; then
@@ -87,6 +91,18 @@ for entry in "${STACKS[@]}"; do
     # Restart after verify so the daemon's api.sql startup run does not race
     # with the API_ONLY=1 container above.
     docker compose "${profile_flags[@]}" up -d importer
+
+    if [[ "$playground_count" -eq 0 ]]; then
+      logfile="/tmp/${name}-reimport.log"
+      echo "→ No playgrounds found — triggering forced reimport in background (log: $logfile)"
+      (
+        docker compose --profile data-node-ui run --rm \
+          -e REIMPORT_INTERVAL_MIN_DAYS= \
+          -e REIMPORT_INTERVAL_MAX_DAYS= \
+          importer
+      ) > "$logfile" 2>&1 &
+      echo "  PID $! — check log when done: tail -f $logfile"
+    fi
   fi
 
   echo "✓ $name done"


### PR DESCRIPTION
## Summary

- `upgrade-stacks.sh`: after restarting the daemon importer, checks `playground_count` from `get_meta`. If 0, triggers a forced reimport in the background (bypasses `REIMPORT_INTERVAL`). Logs to `/tmp/<name>-reimport.log`.
- `force-reimport-empty.sh`: new one-shot script that queries all stacks, skips those with data, and runs parallel forced reimports for the empty ones. Immediate fix for stacks broken by the v0.5.1 osmium bug.

## Why

Previous failed imports (osmium `--overwrite` missing in v0.5.1) still wrote a `last_import_at` timestamp. After upgrade the daemon sees a recent timestamp and waits out the interval — leaving 0 playgrounds indefinitely. Upgrade script must detect and recover from this automatically.

## Test plan

- [ ] Run upgrade on a stack with data — no forced reimport triggered
- [ ] Run upgrade on a stack with 0 playgrounds — forced reimport starts in background
- [ ] Run `force-reimport-empty.sh` — only empty stacks get reimported

🤖 Generated with [Claude Code](https://claude.com/claude-code)