### PR TITLE
feat(cluster)!: drop restricted bucket — count = complete + partial + missing

### DIFF
--- a/app/src/hub/hubOrchestrator.js
+++ b/app/src/hub/hubOrchestrator.js
@@ -189,14 +189,12 @@ export function attachHubOrchestrator({
           complete:   p.complete,
           partial:    p.partial,
           missing:    p.missing,
-          restricted: p.restricted,
         }),
         reduce: (acc, p) => {
           acc.count      += p.count;
           acc.complete   += p.complete;
           acc.partial    += p.partial;
           acc.missing    += p.missing;
-          acc.restricted += p.restricted;
         },
       });
       await fanOut({
@@ -350,7 +348,6 @@ function bucketToSuperclusterPoint(b, backendUrl) {
       complete:    b.complete   ?? 0,
       partial:     b.partial    ?? 0,
       missing:     b.missing    ?? 0,
-      restricted:  b.restricted ?? 0,
       _backendUrl: backendUrl,
     },
   };
@@ -375,7 +372,6 @@ function superclusterFeatureToOl(c) {
       complete:    c.properties.complete,
       partial:     c.properties.partial,
       missing:     c.properties.missing,
-      restricted:  c.properties.restricted,
     });
   } else {
     // Singleton — original bucket properties pass through.
@@ -386,7 +382,6 @@ function superclusterFeatureToOl(c) {
       complete:    c.properties.complete,
       partial:     c.properties.partial,
       missing:     c.properties.missing,
-      restricted:  c.properties.restricted,
     });
   }
   return f;

--- a/app/src/lib/api.js
+++ b/app/src/lib/api.js
@@ -43,9 +43,9 @@ export async function fetchPlaygrounds(baseUrl = defaultApiBaseUrl, signal) {
 
 /**
  * Cluster-tier buckets for zoom ≤ `clusterMaxZoom` (default 13). Returns an
- * array of `{ lon, lat, count, complete, partial, missing, restricted }`
- * bucket objects, grid-aligned to a zoom-dependent cell size on the server.
- * Invariant: `count = complete + partial + missing + restricted`.
+ * array of `{ lon, lat, count, complete, partial, missing }` bucket objects,
+ * grid-aligned to a zoom-dependent cell size on the server.
+ * Invariant: `count = complete + partial + missing`.
  */
 const clusterFilterMap = {
     private:      'filter_private',

--- a/app/src/lib/clusterStyle.js
+++ b/app/src/lib/clusterStyle.js
@@ -11,17 +11,12 @@ import Style from 'ol/style/Style.js';
 
 // Ring segment colours match the CompletenessLegend fill palette
 // (vectorStyles.js fills) so the ring visually echoes the legend swatches
-// rather than the darker polygon strokes. Access-restricted playgrounds
-// render as a hatched gray segment — same "not public" visual vocabulary
-// as the legend's hatched swatch.
+// rather than the darker polygon strokes.
 const COLOR = {
   complete: '#228b22', // rgb(34, 139, 34)  — legend "complete" fill base
   partial:  '#eab308', // rgb(234, 179, 8)  — legend "partial"  fill base
   missing:  '#ef4444', // rgb(239, 68, 68)  — legend "missing"  fill base
 };
-const RESTRICTED_DOT = '#9ca3af';     // tailwind gray-400 — small dots can't show hatching
-const HATCH_BG       = 'rgba(156, 163, 175, 0.30)';
-const HATCH_LINE     = '#6b7280';     // tailwind gray-500
 const CENTER_FILL   = 'rgba(255, 255, 255, 0.94)';
 const CENTER_STROKE = '#1f2937';
 const CENTER_TEXT   = '#1f2937';
@@ -52,37 +47,20 @@ function countBucket(count) {
   return Math.round(count / 500) * 500;
 }
 
-// Quantise a cluster's (count, complete, partial, missing, restricted) to
-// the tuple the bitmap cache is keyed on. Both the cache key AND the
-// subsequent draw use the same quantised fractions so the cached bitmap is
-// always consistent with its key.
-function quantise(count, complete, partial, missing, restricted) {
-  const total = complete + partial + missing + restricted || 1;
-  const c10 = Math.round((complete   / total) * 10);
-  const p10 = Math.round((partial    / total) * 10);
-  const m10 = Math.round((missing    / total) * 10);
-  const r10 = Math.max(0, 10 - c10 - p10 - m10);
-  return { bucket: countBucket(count), c10, p10, m10, r10 };
+// Quantise a cluster's (count, complete, partial, missing) to the tuple the
+// bitmap cache is keyed on. Both the cache key AND the subsequent draw use the
+// same quantised fractions so the cached bitmap is always consistent with its
+// key. The missing arc absorbs any rounding residual so the three arcs always
+// sum to a full circle.
+function quantise(count, complete, partial, missing) {
+  const total = complete + partial + missing || 1;
+  const c10 = Math.round((complete / total) * 10);
+  const p10 = Math.round((partial  / total) * 10);
+  const m10 = Math.max(0, 10 - c10 - p10);
+  return { bucket: countBucket(count), c10, p10, m10 };
 }
 
-function makeHatchPattern(ctx) {
-  const size = 6;
-  const pat = document.createElement('canvas');
-  pat.width  = size;
-  pat.height = size;
-  const pctx = pat.getContext('2d');
-  pctx.fillStyle = HATCH_BG;
-  pctx.fillRect(0, 0, size, size);
-  pctx.strokeStyle = HATCH_LINE;
-  pctx.lineWidth = 1.5;
-  pctx.beginPath();
-  pctx.moveTo(0, size);
-  pctx.lineTo(size, 0);
-  pctx.stroke();
-  return ctx.createPattern(pat, 'repeat');
-}
-
-function drawStackedRing(canvas, count, c10, p10, m10, r10, pixelRatio) {
+function drawStackedRing(canvas, count, c10, p10, m10, pixelRatio) {
   const radius    = radiusForCount(count);
   const centre    = radius + RING_WIDTH + 2;
   const sizePx    = Math.ceil(centre * 2 * pixelRatio);
@@ -96,12 +74,10 @@ function drawStackedRing(canvas, count, c10, p10, m10, r10, pixelRatio) {
   ctx.lineWidth = RING_WIDTH;
   ctx.lineCap   = 'butt';
 
-  const hatch = r10 > 0 ? makeHatchPattern(ctx) : null;
   const segments = [
     { tenths: c10, stroke: COLOR.complete },
     { tenths: p10, stroke: COLOR.partial  },
     { tenths: m10, stroke: COLOR.missing  },
-    { tenths: r10, stroke: hatch          },
   ];
   let start = -Math.PI / 2; // 12-o'clock
   for (const seg of segments) {
@@ -135,13 +111,13 @@ function drawStackedRing(canvas, count, c10, p10, m10, r10, pixelRatio) {
   ctx.fillText(String(count), centre, centre + 0.5);
 }
 
-function getOrCreateBitmap(count, complete, partial, missing, restricted, pixelRatio) {
-  const q = quantise(count, complete, partial, missing, restricted);
-  const key = `${q.bucket}:${q.c10}:${q.p10}:${q.m10}:${q.r10}@${pixelRatio}`;
+function getOrCreateBitmap(count, complete, partial, missing, pixelRatio) {
+  const q = quantise(count, complete, partial, missing);
+  const key = `${q.bucket}:${q.c10}:${q.p10}:${q.m10}@${pixelRatio}`;
   let canvas = bitmapCache.get(key);
   if (!canvas) {
     canvas = document.createElement('canvas');
-    drawStackedRing(canvas, q.bucket, q.c10, q.p10, q.m10, q.r10, pixelRatio);
+    drawStackedRing(canvas, q.bucket, q.c10, q.p10, q.m10, pixelRatio);
     bitmapCache.set(key, canvas);
   }
   return canvas;
@@ -154,15 +130,12 @@ function renderStackedRing(pixelCoords, state) {
   const complete   = feature.get('complete')   ?? 0;
   const partial    = feature.get('partial')    ?? 0;
   const missing    = feature.get('missing')    ?? 0;
-  const restricted = feature.get('restricted') ?? 0;
 
-  // §4.4 — a cluster of one renders as a solid dot. Access-restricted
-  // single children use light gray (hatching is hard to read at ~10 px dia).
+  // §4.4 — a cluster of one renders as a solid dot in its completeness colour.
   if (count <= 1) {
-    const color = restricted > 0 ? RESTRICTED_DOT
-                : complete   > 0 ? COLOR.complete
-                : partial    > 0 ? COLOR.partial
-                :                  COLOR.missing;
+    const color = complete > 0 ? COLOR.complete
+                : partial  > 0 ? COLOR.partial
+                :                COLOR.missing;
     const ctx = state.context;
     ctx.beginPath();
     ctx.arc(x, y, 5, 0, Math.PI * 2);
@@ -175,7 +148,7 @@ function renderStackedRing(pixelCoords, state) {
   }
 
   const pixelRatio = state.pixelRatio || 1;
-  const bitmap = getOrCreateBitmap(count, complete, partial, missing, restricted, pixelRatio);
+  const bitmap = getOrCreateBitmap(count, complete, partial, missing, pixelRatio);
   const w = bitmap.width  / pixelRatio;
   const h = bitmap.height / pixelRatio;
   state.context.drawImage(bitmap, x - w / 2, y - h / 2, w, h);

--- a/app/src/lib/clusterStyle.js
+++ b/app/src/lib/clusterStyle.js
@@ -50,14 +50,23 @@ function countBucket(count) {
 // Quantise a cluster's (count, complete, partial, missing) to the tuple the
 // bitmap cache is keyed on. Both the cache key AND the subsequent draw use the
 // same quantised fractions so the cached bitmap is always consistent with its
-// key. The missing arc absorbs any rounding residual so the three arcs always
-// sum to a full circle.
+// key. Each segment is rounded independently, then the residual (so the three
+// arcs sum to exactly a full circle) is applied to the *largest* segment — so
+// a small but nonzero segment is never squeezed out by the other two rounding
+// up, and the arcs never overflow the ring.
 function quantise(count, complete, partial, missing) {
   const total = complete + partial + missing || 1;
-  const c10 = Math.round((complete / total) * 10);
-  const p10 = Math.round((partial  / total) * 10);
-  const m10 = Math.max(0, 10 - c10 - p10);
-  return { bucket: countBucket(count), c10, p10, m10 };
+  const seg = {
+    c10: Math.round((complete / total) * 10),
+    p10: Math.round((partial  / total) * 10),
+    m10: Math.round((missing  / total) * 10),
+  };
+  const residual = 10 - (seg.c10 + seg.p10 + seg.m10);
+  if (residual !== 0) {
+    const largest = ['c10', 'p10', 'm10'].reduce((a, b) => (seg[b] > seg[a] ? b : a));
+    seg[largest] = Math.max(0, seg[largest] + residual);
+  }
+  return { bucket: countBucket(count), ...seg };
 }
 
 function drawStackedRing(canvas, count, c10, p10, m10, pixelRatio) {

--- a/app/src/lib/tieredOrchestrator.js
+++ b/app/src/lib/tieredOrchestrator.js
@@ -133,7 +133,6 @@ function fillClusterSource(source, buckets) {
       complete:   b.complete,
       partial:    b.partial,
       missing:    b.missing,
-      restricted: b.restricted ?? 0,
     });
     return f;
   });

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -70,13 +70,12 @@ Pre-aggregated cluster buckets for the cluster tier. Each bucket counts playgrou
     "count":       2,
     "complete":    1,
     "partial":     0,
-    "missing":     1,
-    "restricted":  0
+    "missing":     1
   }
 ]
 ```
 
-**Invariant**: `count = complete + partial + missing + restricted` for every bucket. The three completeness counts include only public playgrounds; access-restricted playgrounds are pulled out into `restricted` so the client can render them as a hatched gray segment.
+**Invariant**: `count = complete + partial + missing` for every bucket. Every playground — including access-restricted ones — is counted into its completeness bucket; there is no separate `restricted` field. The `filter_private` parameter still excludes access-restricted playgrounds from the result when set.
 
 **Bucket centre**: emitted `lon` / `lat` is the **unweighted spatial mean of the bucket's member centroids** (`ST_Centroid(ST_Collect(centroid_3857))`, reprojected to WGS84) — not the grid anchor. The grid still defines *which* playgrounds share a bucket (the grouping key), but the dot is drawn at the geographic mean of those members so it tracks settlements rather than a lattice. Output is deterministic for a given `(z, bbox)` and dataset: identical inputs produce identical positions. See [Architecture — Tiered playground delivery](architecture.md#tiered-playground-delivery) for the grouping-vs-position split.
 
@@ -187,7 +186,7 @@ Existing federation-discovery RPC, extended with completeness counts.
 }
 ```
 
-**Invariant**: `playground_count = complete + partial + missing` (`get_meta` does *not* split out access-restricted; they're rolled into the completeness counts here, unlike `get_playground_clusters`). Hub uses the three counts to render a country-level macro view — see `add-federated-playground-clustering`.
+**Invariant**: `playground_count = complete + partial + missing`. Access-restricted playgrounds are rolled into the completeness counts (same as `get_playground_clusters`). Hub uses the three counts to render a country-level macro view — see `add-federated-playground-clustering`.
 
 Additional fields:
 
@@ -363,7 +362,7 @@ Returns instance metadata used by the Hub for federation discovery. Required for
 | Field | Notes |
 |---|---|
 | `playground_count` | Total playgrounds in the region. Equals `complete + partial + missing`. |
-| `complete`, `partial`, `missing` | Completeness breakdown (access-restricted playgrounds roll into these counts, unlike `get_playground_clusters`). |
+| `complete`, `partial`, `missing` | Completeness breakdown (access-restricted playgrounds roll into these counts, same as `get_playground_clusters`). |
 | `bbox` | `[west, south, east, north]` in WGS84. `null` when the relation is not found. |
 | `last_import_at` | When `import.sh` last ran successfully. `null` before any import. |
 | `data_age_seconds` | Seconds since `last_import_at`. `null` when `last_import_at` is null. |

--- a/importer/api.sql
+++ b/importer/api.sql
@@ -239,7 +239,10 @@ CREATE MATERIALIZED VIEW public.playground_stats AS
     COALESCE(es.for_wheelchair, false) AS for_wheelchair,
     -- Tiered-delivery (P1): persisted centroid + per-playground completeness
     ST_Centroid(pl.way)                           AS centroid_3857,
-    (pl.access IN ('private', 'customers'))       AS access_restricted,
+    -- NULL-safe: untagged playgrounds (access IS NULL) are public, not NULL.
+    -- Retained only to drive filter_private; never excludes a playground from
+    -- the cluster completeness aggregation.
+    (COALESCE(pl.access, '') IN ('private', 'customers')) AS access_restricted,
     CASE
       WHEN ca.has_photo AND ca.has_equipment AND ca.has_info THEN 'complete'
       WHEN ca.has_photo OR  ca.has_equipment OR  ca.has_info THEN 'partial'
@@ -355,7 +358,7 @@ COMMENT ON FUNCTION api.get_playgrounds(bigint) IS
 --     Pre-aggregated cluster buckets for the cluster tier (zoom ≤
 --     clusterMaxZoom, default 13). Snaps each playground centroid to a
 --     zoom-appropriate grid as the *grouping key* and counts playgrounds per
---     cell, broken down by completeness plus a separate restricted count.
+--     cell, broken down by completeness (count = complete + partial + missing).
 --     The emitted `lon` / `lat` is the unweighted spatial mean of the
 --     bucket's member centroids (`ST_Centroid(ST_Collect(centroid_3857))`),
 --     not the grid anchor — so the dot tracks the geographic distribution
@@ -446,21 +449,20 @@ AS $$
       )
   ),
   aggregated AS (
-    -- Restricted playgrounds are counted separately from the three
-    -- completeness buckets so the ring renderer can paint them as a
-    -- hatched "not public" segment. Invariant:
-    --   count = complete + partial + missing + restricted
+    -- Every playground is counted into exactly one completeness bucket by its
+    -- completeness classification (never NULL; defaults to 'missing'), so the
+    -- invariant holds by construction:
+    --   count = complete + partial + missing
     -- The ST_Collect() ORDER BY guarantees bit-stable centroid output
     -- across plan changes (parallel scans, etc.) — the spec contract
     -- "each bucket's lon/lat is identical between calls" depends on it.
     SELECT
       cell,
-      ST_Centroid(ST_Collect(centroid_3857 ORDER BY osm_id))                                        AS bucket_centroid_3857,
-      COUNT(*)::int                                                                                 AS count,
-      SUM(CASE WHEN NOT access_restricted AND completeness = 'complete' THEN 1 ELSE 0 END)::int     AS complete,
-      SUM(CASE WHEN NOT access_restricted AND completeness = 'partial'  THEN 1 ELSE 0 END)::int     AS partial,
-      SUM(CASE WHEN NOT access_restricted AND completeness = 'missing'  THEN 1 ELSE 0 END)::int     AS missing,
-      SUM(CASE WHEN access_restricted                                   THEN 1 ELSE 0 END)::int     AS restricted
+      ST_Centroid(ST_Collect(centroid_3857 ORDER BY osm_id))                  AS bucket_centroid_3857,
+      COUNT(*)::int                                                           AS count,
+      SUM(CASE WHEN completeness = 'complete' THEN 1 ELSE 0 END)::int         AS complete,
+      SUM(CASE WHEN completeness = 'partial'  THEN 1 ELSE 0 END)::int         AS partial,
+      SUM(CASE WHEN completeness = 'missing'  THEN 1 ELSE 0 END)::int         AS missing
     FROM buckets
     GROUP BY cell
   )
@@ -472,8 +474,7 @@ AS $$
         'count',      count,
         'complete',   complete,
         'partial',    partial,
-        'missing',    missing,
-        'restricted', restricted
+        'missing',    missing
       )
     ),
     '[]'::json

--- a/openspec/changes/drop-cluster-restricted-bucket/.openspec.yaml
+++ b/openspec/changes/drop-cluster-restricted-bucket/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/drop-cluster-restricted-bucket/design.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The cluster tier ships four counts per bucket (`complete`/`partial`/`missing`/`restricted`) and renders a four-segment ring, with `restricted` drawn as a light-gray hatch. The `restricted` count comes from `access_restricted = (pl.access IN ('private','customers'))` in the `playground_stats` materialized view.
+
+PostgreSQL three-valued logic makes `access_restricted` **NULL** whenever `access` is absent. In `get_playground_clusters` the aggregation uses `SUM(CASE WHEN NOT access_restricted AND completeness = … THEN 1 ELSE 0 END)` for the three completeness buckets and `SUM(CASE WHEN access_restricted THEN 1 ELSE 0 END)` for restricted. For a NULL row, `NOT NULL` and `NULL` both yield NULL → the `CASE` falls to `ELSE 0`, so the row is counted in `count` (`COUNT(*)`) but in **none** of the four buckets. In the live Fulda dataset 210 / 463 playgrounds (≈45%) are affected; a cell composed solely of such rows arrives at the client as `{count:N, complete:0, partial:0, missing:0, restricted:0}` and the renderer fills the whole circle with the hatch (`r10 = 10`). The documented invariant `count = complete + partial + missing + restricted` is silently violated.
+
+`completeness` itself is never NULL — its `CASE` ends in `ELSE 'missing'` — so classifying purely by `completeness` is well-defined for every row.
+
+The cluster renderer (`clusterStyle.js`) and the macro renderer (`macroRingStyle.js`) are independent modules with separate colour tables. The macro tier reuses the *gray* idea for a different purpose (offline / unknown-completeness backends), so it is untouched here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `count = complete + partial + missing` the cluster-bucket invariant; remove the `restricted` field from the RPC response.
+- Eliminate the NULL artifact so untagged playgrounds render by their true completeness.
+- Remove all grey/hatch rendering from the cluster ring and single-child dot.
+- Keep the `filter_private` toggle working (NULL-safe `access_restricted`).
+
+**Non-Goals:**
+- The macro tier's gray "offline / unknown backend" segment (`macroRingStyle.js`, `MacroView.svelte`) — stays.
+- Removing `access_restricted` from the polygon tier's per-feature `filter_attrs` (it feeds `filter_private`).
+
+**Folded in:** cluster ring sizing tuned down during live-browser review — radii `26/32/38/44 → 18/22/28/34`, `RING_WIDTH 12 → 8`, centre count `bold 22px → 16px`. Already applied to `clusterStyle.js`; carried in this change since it touches the same renderer the restricted removal does.
+
+## Decisions
+
+**1. Fix the aggregation by classifying on `completeness` alone, not by special-casing access.**
+Replace the four `SUM(CASE …)` expressions with three that key only on `completeness` (`SUM(CASE WHEN completeness = 'complete' THEN 1 ELSE 0 END)`, etc.) and drop the `restricted` SUM and JSON key. Because `completeness` is total (never NULL) and the bucket population is otherwise unchanged, `complete + partial + missing = COUNT(*) = count` by construction.
+*Alternative considered:* keep four buckets but fix only the NULL bug (`COALESCE(access,'')`). Rejected — the user's decision is to drop `restricted` from the data model entirely, and keeping a near-always-empty fourth bucket adds renderer complexity for no signal.
+
+**2. Make `access_restricted` NULL-safe at its definition, retained for filtering only.**
+Change `(pl.access IN ('private','customers'))` to a NULL-safe form (`COALESCE(pl.access,'') IN ('private','customers')` or `(pl.access IN (...)) IS TRUE`) in `playground_stats`. This keeps `filter_private` correct (untagged → public) without the column influencing the completeness aggregation.
+*Alternative considered:* drop `access_restricted` + `filter_private` wholesale. Rejected — distinguishing private playgrounds for filtering is still a wanted feature; only the *ring colour* is being simplified.
+
+**3. Cluster renderer becomes three-segment; remove dead grey paths.**
+In `clusterStyle.js`: delete `HATCH_BG`/`HATCH_LINE`/`RESTRICTED_DOT`, `makeHatchPattern()`, the `r10` segment, the `restricted` argument to `quantise()`/`drawStackedRing()`, and `r10` from the bitmap-cache key. The single-child dot loses its `restricted > 0 → gray` branch and colours purely by completeness.
+
+**4. Treat the API response change as `requires-schema-update`.**
+`importer/api.sql` changes; operators run `API_ONLY=1` (function + materialized-view refresh) — no full re-import. Clients reading a missing `restricted` field degrade gracefully (`?? 0` already present in the orchestrators), so a brief backend/frontend skew during deploy is safe.
+
+## Risks / Trade-offs
+
+- **Loss of the "private playground" visual signal on the map** → Mitigation: this is the intended product decision; `filter_private` still lets users hide private playgrounds, and the lock hint remains on the per-playground panel.
+- **Backend/frontend version skew during upgrade** (old frontend expecting `restricted`, or old backend still shipping it) → Mitigation: frontend uses `restricted ?? 0` and, after the renderer change, ignores the field entirely; the new SQL simply omits it. Both directions are non-fatal.
+- **`access_restricted` NULL-fix could shift `filter_private` results** for previously-NULL rows → Intended: those untagged playgrounds were incorrectly excluded when `filter_private` was on; they are now correctly treated as public.
+- **Stale-volume `make db-apply` can mask ordering bugs** → Mitigation: run the fresh-volume import test (`make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`) before merge, per project policy.

--- a/openspec/changes/drop-cluster-restricted-bucket/proposal.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The cluster-tier ring carries a separate `restricted` (access-restricted) segment rendered as light-gray hatching. In practice that segment is dominated by a three-valued-logic bug, not by genuinely private playgrounds: `access_restricted = (pl.access IN ('private','customers'))` evaluates to **NULL** for every untagged playground (≈45% of Fulda's data — 210 of 463). Those rows then fall out of *all four* aggregation buckets (`NOT NULL` and `NULL` both fail the `CASE WHEN`), so a cell of untagged playgrounds renders as a fully gray-hatched ring with no completeness information, silently breaking the documented `count = complete + partial + missing + restricted` invariant. The grey clutters the map and hides the data quality of nearly half the playgrounds.
+
+## What Changes
+
+- **BREAKING** (API response shape): `get_playground_clusters` drops the `restricted` field from each bucket object. The invariant becomes **`count = complete + partial + missing`** — every playground is counted into its completeness bucket by `completeness` alone (which is never NULL; it defaults to `'missing'`).
+- The `NOT access_restricted` guard is removed from the three completeness `SUM`s and the separate `restricted` `SUM` is deleted, so the untagged-playground NULL bug disappears: those rows now render by their true completeness (red/yellow).
+- The cluster ring renderer becomes a **three-segment** ring (complete / partial / missing). All grey/hatch rendering is removed: the hatch pattern, the restricted arc, the gray single-child dot, and the `restricted` term in the bitmap-cache key.
+- The hub cluster-bucket merge stops summing a `restricted` field.
+- The `filter_private` toggle is **kept**, but its identical NULL bug is fixed so `access_restricted` defaults to `false` for untagged playgrounds; the `access_restricted` column is retained for filtering only.
+
+### Out of scope (explicitly unchanged)
+
+- The **macro tier** (`macroRingStyle.js` / `MacroView.svelte`) keeps its own gray segment — there it signals offline / unknown-completeness *backends* (a hub-health indicator), a separate concern with its own colour table.
+- The polygon tier's per-playground `access_restricted` filter attribute is unchanged (it feeds `filter_private`).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `tiered-playground-delivery`: the cluster RPC response no longer includes `restricted`; the bucket invariant changes to `count = complete + partial + missing`; deterministic-output and rendering scenarios drop the restricted segment; the cluster ring renders three segments with no hatched "not public" arc.
+- `federated-playground-clustering`: the hub merge of per-backend cluster buckets no longer aggregates a `restricted` field. The macro-view restricted scenarios (offline / unknown-completeness backends) are unaffected.
+
+## Impact
+
+- **`importer/api.sql`** — `get_playground_clusters` aggregation + JSON output; `access_restricted` definition (NULL→false). `requires-schema-update`: operators run `API_ONLY=1` after upgrading (no full re-import).
+- **`app/src/lib/clusterStyle.js`** — remove `HATCH_*`, `makeHatchPattern()`, `RESTRICTED_DOT`, the restricted arc, and the `restricted` arg in `quantise()`/draw + cache key.
+- **`app/src/lib/api.js`** — update the `fetchPlaygroundClusters` invariant docstring.
+- **`app/src/lib/tieredOrchestrator.js`, `app/src/hub/hubOrchestrator.js`** — drop the now-dead `restricted` passthroughs.
+- **`app/src/components/CompletenessLegend.svelte`** — remove any hatched "not public" swatch if present.
+- **Verification** — fresh-volume import test (`make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`) and confirm `count = complete + partial + missing` holds for `get_playground_clusters`.

--- a/openspec/changes/drop-cluster-restricted-bucket/specs/federated-playground-clustering/spec.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/specs/federated-playground-clustering/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Hub re-clusters merged server results across backends
+
+At the cluster tier, merged cluster buckets from multiple backends SHALL be re-clustered client-side so that no visible seam appears at a backend boundary.
+
+#### Scenario: Re-cluster preserves total counts
+
+- **WHEN** backend A returns buckets summing to count 2000 and backend B returns buckets summing to count 1500 inside the viewport
+- **THEN** the rendered cluster layer, after re-clustering, shows a total count of 3500 across its rings
+- **AND** the sum of `complete` segments equals the sum of `complete` inputs from A and B
+- **AND** likewise for `partial` and `missing` (the three-segment ring; there is no `restricted` bucket)
+
+#### Scenario: Border clusters merge visually
+
+- **WHEN** two clusters from different backends sit within a visual threshold distance at the border
+- **THEN** the re-clusterer may merge them into a single rendered ring whose count is the sum
+- **AND** the ring's segment proportions reflect the combined counts

--- a/openspec/changes/drop-cluster-restricted-bucket/specs/tiered-playground-delivery/spec.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/specs/tiered-playground-delivery/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: Backend exposes cluster aggregates scoped to zoom and bbox
+
+Each data-node SHALL expose a function that returns pre-aggregated playground count buckets for a given zoom level and bounding box, so clients at low zoom can render cluster representations without fetching individual features. Buckets are grouped by snapping each playground's centroid to a zoom-dependent grid (the grouping key); the `lon`/`lat` emitted for each bucket is the unweighted spatial mean of its members' centroids — i.e. `ST_Centroid(ST_Collect(playground_stats.centroid_3857))` over the bucket's members, reprojected to WGS84 — so the bucket dot tracks the geographic distribution of the playgrounds it represents rather than a grid lattice. Every playground contributes to exactly one of the three completeness buckets (`complete` / `partial` / `missing`) by its `completeness` classification, regardless of its `access` tag.
+
+#### Scenario: Clusters RPC returns bucketed counts
+
+- **WHEN** a client calls `api.get_playground_clusters(z, min_lon, min_lat, max_lon, max_lat)` with a zoom level and a WGS84 bbox intersecting the configured region
+- **THEN** the response is a JSON array of bucket objects, each containing `lon`, `lat`, `count`, `complete`, `partial`, and `missing` fields
+- **AND** the response does NOT contain a `restricted` field
+- **AND** `count = complete + partial + missing` for every bucket
+
+#### Scenario: Clusters RPC positions buckets at the mean of member centroids
+
+- **WHEN** a bucket aggregates two or more playgrounds whose centroids are not symmetrically placed within the grid cell
+- **THEN** the returned `lon` / `lat` equal the WGS84 reprojection of `ST_Centroid(ST_Collect(playground_stats.centroid_3857))` over the bucket's members (the unweighted spatial mean of their centroid geometries)
+- **AND** the position is *not* the WGS84 projection of the grid cell anchor
+- **AND** for a bucket with a single member, the returned `lon` / `lat` equal that member's centroid reprojected to WGS84
+
+#### Scenario: Clusters RPC bucketing is deterministic for a fixed dataset
+
+- **WHEN** a client calls the RPC twice with identical `(z, bbox)` against an unchanged dataset
+- **THEN** the two responses contain the same set of buckets with identical `count` / `complete` / `partial` / `missing` values
+- **AND** each bucket's `lon` / `lat` is identical between the two calls
+
+#### Scenario: Clusters RPC honours bbox filter
+
+- **WHEN** the caller supplies a bbox that covers only a subset of the region
+- **THEN** only members whose centroid lies within the bbox contribute to a bucket
+- **AND** a bucket is returned only when at least one of its members satisfies that filter
+- **AND** no playgrounds outside the bbox contribute to any returned bucket
+
+#### Scenario: Clusters RPC scales cell size with zoom
+
+- **WHEN** the caller requests the same bbox at `z = 6` and at `z = 10`
+- **THEN** the `z = 10` response contains more (smaller) buckets than the `z = 6` response
+- **AND** the total `count` across all buckets is identical across zoom levels (no features lost to bucketing)
+
+### Requirement: Clusters are rendered as completeness-segmented stacked rings
+
+Cluster features SHALL be rendered on the map as a ring divided into up to three segments proportional to the complete / partial / missing counts, with the total count as a number at the centre. Segment colours match the legend fill palette (not the darker polygon strokes). There is no restricted/"not public" segment: access-restricted playgrounds are counted into their completeness bucket like any other playground.
+
+#### Scenario: Ring segments are proportional
+
+- **WHEN** a cluster has `complete = 6`, `partial = 19`, `missing = 25` (count = 50)
+- **THEN** the rendered ring has three segments whose arc lengths are proportional to 6 : 19 : 25
+- **AND** the complete / partial / missing segments use the legend fill-base palette (`#228b22`, `#eab308`, `#ef4444`)
+- **AND** no hatched / light-gray segment is drawn
+- **AND** the centre displays `50`
+- **AND** the invariant `count = complete + partial + missing` holds by construction (enforced in the `get_playground_clusters` RPC)
+
+#### Scenario: Single-feature cluster collapses to a dot
+
+- **WHEN** a cluster has `count = 1`
+- **THEN** no ring is drawn
+- **AND** a solid dot is rendered in the single feature's completeness colour
+- **AND** the dot size is 5 CSS px
+
+#### Scenario: Ring renders scale with count
+
+- **WHEN** cluster counts are 5, 25, 100, and 500 respectively
+- **THEN** the outer ring radius is approximately 18 / 22 / 28 / 34 CSS pixels respectively (radii retuned down during live-browser review to reduce overlap at the cluster tier's zoom range)
+- **AND** the ring stroke width is 8 CSS px and the centre count is rendered at 16 px, non-bold
+- **AND** the number remains readable at every size
+
+#### Scenario: Filter-badge appears only when filters are active
+
+- **WHEN** the filter store has any active filter
+- **THEN** each rendered cluster shows a small "N match" pill below the count, where N is the filter-matching child count
+- **WHEN** no filter is active
+- **THEN** no filter badge is rendered
+
+#### Scenario: Cluster click zooms to extent
+
+- **WHEN** the user clicks a cluster
+- **THEN** the map view animates toward the cluster's centre (currently +2 zoom levels — fit-to-extent of bucket children requires a follow-up since server-bucketed clusters don't carry per-child geometry)
+- **AND** no selection is created (the hash is not modified)
+
+## ADDED Requirements
+
+### Requirement: Access classification is NULL-safe and does not drop untagged playgrounds
+
+The `access_restricted` classification SHALL default to `false` for playgrounds that lack a `private`/`customers` `access` tag (i.e. it MUST NOT evaluate to NULL for untagged playgrounds). The `access_restricted` attribute is retained only to drive the `filter_private` toggle; it MUST NOT remove any playground from the cluster completeness aggregation.
+
+#### Scenario: Untagged playground counts into its completeness bucket
+
+- **WHEN** a playground has no `access` tag and a computed completeness of `missing`
+- **THEN** it contributes to its bucket's `missing` count
+- **AND** it is not omitted from `complete` + `partial` + `missing`
+
+#### Scenario: filter_private keeps untagged playgrounds visible
+
+- **WHEN** `get_playground_clusters` is called with `filter_private` enabled
+- **THEN** playgrounds with `access IN ('private','customers')` are excluded from the buckets
+- **AND** playgrounds without an `access` tag remain included (treated as public)

--- a/openspec/changes/drop-cluster-restricted-bucket/tasks.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/tasks.md
@@ -29,7 +29,7 @@
 
 ## 5. Tests & verification
 
-- [x] 5.1 No unit tests reference `restricted` cluster fields / hatch rendering — nothing to update (cluster-style has no test; orchestrator tests don't touch restricted).
+- [x] 5.1 Updated tests referencing the removed `restricted` field (found in Playwright E2E specs, not unit tests): `tests/cluster-position.spec.js` invariant assertion dropped `+ bucket.restricted` (was producing `NaN` against the live API); stale `restricted: 0` removed from the `tests/helpers.js` and `tests/hub-multi-backend.spec.js` cluster-bucket stubs.
 - [ ] 5.2 Fresh-volume import test (`make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`) — DESTRUCTIVE (wipes data + full re-import); left for the operator to run. Note: the single-transaction `db-apply` already validated api.sql ordering end-to-end.
 - [x] 5.3 `make docker-build` done; live `:8080` API verified (`/api/rpc/get_playground_clusters` returns no `restricted` field, 0 invariant violations). Visual eyeball of the map (grey rings gone) left for the user.
 - [~] 5.4 `make build` green. `make test`: Playwright E2E not run in this session; `make test-unit` has a PRE-EXISTING `completeness.test.js` failure (local Node 24 vs CI Node 20, reproduces on pristine `main`) — unrelated to this change. CI gate is Playwright-only and will run on the PR.

--- a/openspec/changes/drop-cluster-restricted-bucket/tasks.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Database — `importer/api.sql`
 
-- [ ] 1.1 In `playground_stats`, make `access_restricted` NULL-safe: change `(pl.access IN ('private','customers'))` to a form that yields `false` for untagged rows (e.g. `COALESCE(pl.access,'') IN ('private','customers')`).
-- [ ] 1.2 In `get_playground_clusters`, replace the four `SUM(CASE …)` expressions with three keyed only on `completeness`: `complete`, `partial`, `missing` (drop the `NOT access_restricted` guard and the separate `restricted` SUM).
-- [ ] 1.3 Remove `'restricted'` from the `json_build_object` output of `get_playground_clusters`.
-- [ ] 1.4 Confirm `filter_private` and the completeness-filter WHERE clauses still reference `access_restricted`/`completeness` correctly after the NULL-safety fix.
-- [ ] 1.5 `make db-apply` and sanity-check: `count = complete + partial + missing` for sample buckets via `get_playground_clusters`.
+- [x] 1.1 In `playground_stats`, make `access_restricted` NULL-safe: change `(pl.access IN ('private','customers'))` to a form that yields `false` for untagged rows (e.g. `COALESCE(pl.access,'') IN ('private','customers')`).
+- [x] 1.2 In `get_playground_clusters`, replace the four `SUM(CASE …)` expressions with three keyed only on `completeness`: `complete`, `partial`, `missing` (drop the `NOT access_restricted` guard and the separate `restricted` SUM).
+- [x] 1.3 Remove `'restricted'` from the `json_build_object` output of `get_playground_clusters`.
+- [x] 1.4 Confirm `filter_private` and the completeness-filter WHERE clauses still reference `access_restricted`/`completeness` correctly after the NULL-safety fix. (Verified: `NOT filter_private OR NOT access_restricted` is now correct with a non-NULL column; completeness filters never referenced access.)
+- [x] 1.5 `make db-apply` and sanity-check. Applied via single-transaction psql (no `.env` present; env pulled from running container). Verified: `access_restricted IS NULL` count 210 → 0; `get_playground_clusters` 0 invariant violations across 179 buckets.
 
 ## 2. Cluster renderer — `app/src/lib/clusterStyle.js`
 
-- [ ] 2.1 Remove `HATCH_BG`, `HATCH_LINE`, `RESTRICTED_DOT` constants and `makeHatchPattern()`.
-- [ ] 2.2 Drop the `restricted` parameter and the `r10` arc from `quantise()` and `drawStackedRing()`; the ring now draws three segments (complete/partial/missing).
-- [ ] 2.3 Remove `r10` from the bitmap-cache key in `getOrCreateBitmap()`.
-- [ ] 2.4 In the single-child dot path, remove the `restricted > 0 → RESTRICTED_DOT` branch; colour purely by completeness.
-- [ ] 2.5 Remove the `restricted` read in `renderStackedRing()` (`feature.get('restricted')`).
+- [x] 2.1 Remove `HATCH_BG`, `HATCH_LINE`, `RESTRICTED_DOT` constants and `makeHatchPattern()`.
+- [x] 2.2 Drop the `restricted` parameter and the `r10` arc from `quantise()` and `drawStackedRing()`; the ring now draws three segments (complete/partial/missing). The missing arc absorbs the rounding residual.
+- [x] 2.3 Remove `r10` from the bitmap-cache key in `getOrCreateBitmap()`.
+- [x] 2.4 In the single-child dot path, remove the `restricted > 0 → RESTRICTED_DOT` branch; colour purely by completeness.
+- [x] 2.5 Remove the `restricted` read in `renderStackedRing()` (`feature.get('restricted')`).
 - [x] 2.6 (done) Ring sizing retuned from live-browser review: radii `26/32/38/44 → 18/22/28/34`, `RING_WIDTH 12 → 8`, centre count `bold 22px → 16px`.
 
 ## 3. Frontend data plumbing
 
-- [ ] 3.1 `app/src/lib/api.js` — update the `fetchPlaygroundClusters` docstring: response shape `{lon,lat,count,complete,partial,missing}` and invariant `count = complete + partial + missing`.
-- [ ] 3.2 `app/src/lib/tieredOrchestrator.js` — remove the now-dead `restricted` passthrough.
-- [ ] 3.3 `app/src/hub/hubOrchestrator.js` — remove the cluster-bucket `restricted` passthroughs/accumulation (leave the macro-tier code untouched).
-- [ ] 3.4 `app/src/components/CompletenessLegend.svelte` — if a hatched "not public" swatch is present, remove it; otherwise note no change.
+- [x] 3.1 `app/src/lib/api.js` — update the `fetchPlaygroundClusters` docstring: response shape `{lon,lat,count,complete,partial,missing}` and invariant `count = complete + partial + missing`.
+- [x] 3.2 `app/src/lib/tieredOrchestrator.js` — remove the now-dead `restricted` passthrough.
+- [x] 3.3 `app/src/hub/hubOrchestrator.js` — remove the cluster-bucket `restricted` passthroughs/accumulation (map/reduce + both `superclusterFeatureToOl` branches + `bucketToSuperclusterPoint`). Macro-tier code untouched.
+- [x] 3.4 `app/src/components/CompletenessLegend.svelte` — no hatched "not public" swatch present; no change required.
 
 ## 4. Confirm out-of-scope code untouched
 
-- [ ] 4.1 Verify `app/src/hub/macroRingStyle.js` and `app/src/hub/MacroView.svelte` still render their gray "offline / unknown-completeness backend" segment (no changes).
-- [ ] 4.2 Verify the polygon tier's per-feature `access_restricted` filter attribute (`get_playgrounds_bbox` / `filter_attrs`) is unchanged.
+- [x] 4.1 Verified `app/src/hub/macroRingStyle.js` and `app/src/hub/MacroView.svelte` still render their gray "offline / unknown-completeness backend" segment (no changes).
+- [x] 4.2 Verified the polygon tier's per-feature `access_restricted` filter attribute (`get_playgrounds_bbox` / `filter_attrs`) is unchanged (the column is now NULL-safe, an improvement, but still emitted).
 
 ## 5. Tests & verification
 
-- [ ] 5.1 Update unit tests referencing `restricted` cluster fields / hatch rendering (e.g. cluster-style and orchestrator tests) to the three-segment model.
-- [ ] 5.2 Fresh-volume import test: `make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`, then confirm `get_playground_clusters` returns no `restricted` field and the new invariant holds.
-- [ ] 5.3 `make docker-build`; visually confirm on `localhost:8080` that the previously fully-grey Fulda clusters now render in completeness colours and no hatched rings remain.
-- [ ] 5.4 `make build` and `make test` green.
+- [x] 5.1 No unit tests reference `restricted` cluster fields / hatch rendering — nothing to update (cluster-style has no test; orchestrator tests don't touch restricted).
+- [ ] 5.2 Fresh-volume import test (`make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`) — DESTRUCTIVE (wipes data + full re-import); left for the operator to run. Note: the single-transaction `db-apply` already validated api.sql ordering end-to-end.
+- [x] 5.3 `make docker-build` done; live `:8080` API verified (`/api/rpc/get_playground_clusters` returns no `restricted` field, 0 invariant violations). Visual eyeball of the map (grey rings gone) left for the user.
+- [~] 5.4 `make build` green. `make test`: Playwright E2E not run in this session; `make test-unit` has a PRE-EXISTING `completeness.test.js` failure (local Node 24 vs CI Node 20, reproduces on pristine `main`) — unrelated to this change. CI gate is Playwright-only and will run on the PR.
 
 ## 6. Release hygiene
 
-- [ ] 6.1 Label the PR `requires-schema-update` (operators run `API_ONLY=1` after upgrade).
-- [ ] 6.2 Update `docs/reference/api.md` for the new `get_playground_clusters` response shape and invariant.
+- [ ] 6.1 Label the PR `requires-schema-update` (operators run `API_ONLY=1` after upgrade). — pending PR creation.
+- [x] 6.2 Update `docs/reference/api.md` for the new `get_playground_clusters` response shape and invariant (plus the two stale "unlike get_playground_clusters" cross-references).

--- a/openspec/changes/drop-cluster-restricted-bucket/tasks.md
+++ b/openspec/changes/drop-cluster-restricted-bucket/tasks.md
@@ -1,0 +1,40 @@
+## 1. Database — `importer/api.sql`
+
+- [ ] 1.1 In `playground_stats`, make `access_restricted` NULL-safe: change `(pl.access IN ('private','customers'))` to a form that yields `false` for untagged rows (e.g. `COALESCE(pl.access,'') IN ('private','customers')`).
+- [ ] 1.2 In `get_playground_clusters`, replace the four `SUM(CASE …)` expressions with three keyed only on `completeness`: `complete`, `partial`, `missing` (drop the `NOT access_restricted` guard and the separate `restricted` SUM).
+- [ ] 1.3 Remove `'restricted'` from the `json_build_object` output of `get_playground_clusters`.
+- [ ] 1.4 Confirm `filter_private` and the completeness-filter WHERE clauses still reference `access_restricted`/`completeness` correctly after the NULL-safety fix.
+- [ ] 1.5 `make db-apply` and sanity-check: `count = complete + partial + missing` for sample buckets via `get_playground_clusters`.
+
+## 2. Cluster renderer — `app/src/lib/clusterStyle.js`
+
+- [ ] 2.1 Remove `HATCH_BG`, `HATCH_LINE`, `RESTRICTED_DOT` constants and `makeHatchPattern()`.
+- [ ] 2.2 Drop the `restricted` parameter and the `r10` arc from `quantise()` and `drawStackedRing()`; the ring now draws three segments (complete/partial/missing).
+- [ ] 2.3 Remove `r10` from the bitmap-cache key in `getOrCreateBitmap()`.
+- [ ] 2.4 In the single-child dot path, remove the `restricted > 0 → RESTRICTED_DOT` branch; colour purely by completeness.
+- [ ] 2.5 Remove the `restricted` read in `renderStackedRing()` (`feature.get('restricted')`).
+- [x] 2.6 (done) Ring sizing retuned from live-browser review: radii `26/32/38/44 → 18/22/28/34`, `RING_WIDTH 12 → 8`, centre count `bold 22px → 16px`.
+
+## 3. Frontend data plumbing
+
+- [ ] 3.1 `app/src/lib/api.js` — update the `fetchPlaygroundClusters` docstring: response shape `{lon,lat,count,complete,partial,missing}` and invariant `count = complete + partial + missing`.
+- [ ] 3.2 `app/src/lib/tieredOrchestrator.js` — remove the now-dead `restricted` passthrough.
+- [ ] 3.3 `app/src/hub/hubOrchestrator.js` — remove the cluster-bucket `restricted` passthroughs/accumulation (leave the macro-tier code untouched).
+- [ ] 3.4 `app/src/components/CompletenessLegend.svelte` — if a hatched "not public" swatch is present, remove it; otherwise note no change.
+
+## 4. Confirm out-of-scope code untouched
+
+- [ ] 4.1 Verify `app/src/hub/macroRingStyle.js` and `app/src/hub/MacroView.svelte` still render their gray "offline / unknown-completeness backend" segment (no changes).
+- [ ] 4.2 Verify the polygon tier's per-feature `access_restricted` filter attribute (`get_playgrounds_bbox` / `filter_attrs`) is unchanged.
+
+## 5. Tests & verification
+
+- [ ] 5.1 Update unit tests referencing `restricted` cluster fields / hatch rendering (e.g. cluster-style and orchestrator tests) to the three-segment model.
+- [ ] 5.2 Fresh-volume import test: `make down && docker volume rm spieli_pgdata spieli_pgdata2 && make up`, then confirm `get_playground_clusters` returns no `restricted` field and the new invariant holds.
+- [ ] 5.3 `make docker-build`; visually confirm on `localhost:8080` that the previously fully-grey Fulda clusters now render in completeness colours and no hatched rings remain.
+- [ ] 5.4 `make build` and `make test` green.
+
+## 6. Release hygiene
+
+- [ ] 6.1 Label the PR `requires-schema-update` (operators run `API_ONLY=1` after upgrade).
+- [ ] 6.2 Update `docs/reference/api.md` for the new `get_playground_clusters` response shape and invariant.

--- a/tests/cluster-position.spec.js
+++ b/tests/cluster-position.spec.js
@@ -85,7 +85,7 @@ test.describe('Cluster position semantics (live API)', () => {
     ).toBeGreaterThan(0);
     const bucket = multi[0];
 
-    expect(bucket.count).toBe(bucket.complete + bucket.partial + bucket.missing + bucket.restricted);
+    expect(bucket.count).toBe(bucket.complete + bucket.partial + bucket.missing);
 
     const centroidsRes = await request.get(centroidsUrl(BBOX));
     expect(centroidsRes.ok(), `centroids RPC failed: ${centroidsRes.status()}`).toBeTruthy();

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -55,7 +55,6 @@ export async function stubApiRoutes(page, playgrounds = fixture, clusters = null
         complete: 0,
         partial: 0,
         missing: totalCount,
-        restricted: 0,
       }]);
 
   await page.route('**/rpc/get_playgrounds**', route => {

--- a/tests/hub-multi-backend.spec.js
+++ b/tests/hub-multi-backend.spec.js
@@ -107,7 +107,6 @@ test.describe('Hub multi-backend orchestration (P2 §9)', () => {
       complete: 20,
       partial: 25,
       missing: 5,
-      restricted: 0,
       ...extra,
     }];
 


### PR DESCRIPTION
Implements OpenSpec change `drop-cluster-restricted-bucket`. Every playground is counted into its completeness bucket by `completeness` alone, so cluster buckets satisfy `count = complete + partial + missing`. Removes the access-restricted (grey/hatched) segment.


## Why
`access_restricted = (pl.access IN ('private','customers'))` is **NULL** for untagged playgrounds (three-valued logic) — ~45% of Fulda data (210/463). Those rows fell out of *all four* buckets and rendered as fully grey/hatched rings, silently breaking the documented invariant. Now they render by their true completeness.

## Changes
- **`importer/api.sql`**: `get_playground_clusters` sums by `completeness` only (drops the `NOT access_restricted` guard, the separate `restricted` SUM, and the `restricted` JSON key). `access_restricted` in `playground_stats` made NULL-safe (`COALESCE`) — retained only to drive `filter_private`.
- **`clusterStyle.js`**: all grey/hatch rendering removed (hatch pattern, restricted arc, gray single-child dot, `restricted` arg + cache-key term) → three-segment ring.
- **`api.js` / `tieredOrchestrator.js` / `hubOrchestrator.js`**: drop `restricted` passthroughs. Macro tier left intact (its grey = offline/unknown backend).
- **`docs/reference/api.md`**: new response shape + invariant.

## Verification
- Applied to running DB: `access_restricted IS NULL` 210 → 0; `get_playground_clusters` 0 invariant violations across 179 buckets; live `:8080` API returns no `restricted` field.
- `make build` green.
- Fresh-volume import test (destructive) **not run** — left for the operator.

## Breaking
`get_playground_clusters` no longer returns `restricted`. Operators run `API_ONLY=1` after upgrade — **`requires-schema-update`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)