### PR TITLE
chore: release v0.6.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.5.4-rc",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,7 @@ The easiest way to deploy spieli is with the interactive installer. It downloads
 ## Install
 
 ```bash
-TAG=v0.5.3  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.6.0  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh
@@ -93,7 +93,7 @@ If someone is running a spieli Hub and you want your region to appear on it, sta
 **1. Run the installer**
 
 ```bash
-TAG=v0.5.3  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
+TAG=v0.6.0  # check https://github.com/mfuhrmann/spieli/releases for the latest tag
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh" -o install.sh
 curl -fsSL "https://github.com/mfuhrmann/spieli/releases/download/${TAG}/install.sh.sha256" -o install.sh.sha256
 sha256sum --check install.sh.sha256 && bash install.sh


### PR DESCRIPTION
Release **v0.6.0**. Minor bump per the versioning rule — a breaking change merged since v0.5.3.

## Steps in this PR (release procedure 1–2)
- `app/package.json`: `0.5.4-rc` → `0.6.0`
- `docs/getting-started/quick-start.md`: both `TAG=` blocks → `v0.6.0`

## After merge
1. Tag `v0.6.0` on the merge commit and push → CI publishes `:latest`/`:0.6.0`/`:0.6` images, creates the GitHub release, uploads `install.sh`.
2. Advance `main` to `0.6.1-rc` (separate PR).

## Why minor (0.6.0, not 0.5.4)
#626 carries `requires-schema-update` and is breaking (`get_playground_clusters` no longer returns `restricted`; operators run `API_ONLY=1`). Per the versioning rule, any breaking change → minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)