### PR TITLE
chore: bump version to 0.6.1-rc

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spieli-app",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1-rc",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Advance `main` to the next release candidate after cutting **v0.6.0** (release procedure step 4).

- `app/package.json`: `0.6.0` → `0.6.1-rc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)