### PR TITLE
fix(ci): stop duplicating release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,6 @@ jobs:
           sha256sum install.sh > install.sh.sha256
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
-            --generate-notes \
             --notes-file <(gh api "/repos/${{ github.repository }}/releases/generate-notes" \
               -f tag_name="${{ github.ref_name }}" \
               --jq '.body' && printf '%s' "$RELEASE_FOOTER") \


### PR DESCRIPTION
The GitHub Release step passed **both** `--generate-notes` and `--notes-file` to `gh release create`. `gh` concatenates them, and the `--notes-file` process substitution already builds the full body (API-generated changelog via `/releases/generate-notes` + the upgrade-actions footer). Result: the changelog appears **twice** — visible on the v0.6.0 release.

## Fix
Drop `--generate-notes`; the `--notes-file` substitution is the single source of the release body.

I already de-duplicated the published v0.6.0 notes manually; this prevents recurrence on future tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)