### PR TITLE
fix(about): broken logo in the About modal

### DIFF
--- a/app/src/components/DataContributionModal.svelte
+++ b/app/src/components/DataContributionModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { _ , locale } from 'svelte-i18n';
   import { version } from '../../package.json';
+  import logoUrl from '../images/spieli_logo.png';
 
   export let open = false;
   /** Community chat URL; hidden when null/falsy. */
@@ -44,7 +45,7 @@
               mapcompleteLink: '<a href="https://mapcomplete.org/playgrounds.html" target="_blank" rel="noopener">MapComplete</a>'
             } })}
           </p>
-          <img src="src/images/spieli_logo.png" alt="spieli logo" class="logo" />
+          <img src={logoUrl} alt="spieli logo" class="logo" />
         </div>
 
         <div class="link-grid">


### PR DESCRIPTION
The About modal (`DataContributionModal.svelte`) showed a broken-image placeholder for the spieli logo (visible in v0.6.0).

## Cause
The `<img>` used a hardcoded source path: `src="src/images/spieli_logo.png"`. That's a dev-tree path Vite doesn't process — it was never emitted to `dist/`, so the URL 404s in the built app.

## Fix
`import logoUrl from '../images/spieli_logo.png'` and use `src={logoUrl}`, so Vite fingerprints the asset into the bundle.

## Verification
- `make build` → logo now emitted as `dist/assets/spieli_logo-<hash>.png` and referenced from the built JS (previously absent from `dist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)