### PR TITLE
docs: correct stale i18n note in objPlaygroundEquipment.js and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ For Copilot users: open this file manually — `.github/copilot-instructions.md`
 
 ## What this project is
 
-spieli is an interactive web map for exploring playgrounds based on OpenStreetMap data. It is deployable per-region (e.g. Fulda) by setting environment variables. UI strings are in German; i18n via svelte-i18n is integrated but device names in `objPlaygroundEquipment.js` remain German-only — full i18n is tracked in epic #157.
+spieli is an interactive web map for exploring playgrounds based on OpenStreetMap data. It is deployable per-region (e.g. Fulda) by setting environment variables. The UI is fully internationalised via svelte-i18n; de, en, fr, and es include complete device name translations. `name_de` in `objPlaygroundEquipment.js` is a fallback for locales that do not yet have translations.
 
 ## Git workflow
 

--- a/app/src/lib/objPlaygroundEquipment.js
+++ b/app/src/lib/objPlaygroundEquipment.js
@@ -25,7 +25,7 @@
 // 2. Add a new key to objDevices using the OSM tag value as the key name:
 //
 //    mydevice: {
-//        name_de:     "German name",        // REQUIRED — shown in the detail panel
+//        name_de:     "German name",        // REQUIRED — fallback if locale key is absent
 //        image:       "File:Example.jpg",   // OPTIONAL — Wikimedia Commons filename
 //        category:    "stationary",         // OPTIONAL — groups the device in filters
 //        filterable:  true,                 // OPTIONAL — show in sidebar filter?
@@ -35,9 +35,10 @@
 // Field details:
 //
 //   name_de      (string, required)
-//                German display name shown in the collapsible device row.
-//                There is currently no i18n for device names — German is the
-//                primary language of the project.
+//                Fallback label used when the svelte-i18n key
+//                `equipment.devices.<key>` is missing for the active locale.
+//                Primary display names come from locales/ — add a matching
+//                key there when adding a new device.
 //
 //   image        (string, optional)
 //                A Wikimedia Commons filename in the format "File:Example.jpg".


### PR DESCRIPTION
## What

The i18n epic (#157) is complete: svelte-i18n is wired in and `locales/en.json` (and fr, es) already contain all `equipment.devices.*` keys. Two places still described the old state:

- `objPlaygroundEquipment.js` — the `name_de` field docs said *"There is currently no i18n for device names"*, which is no longer true. Updated to describe `name_de` correctly as a locale fallback.
- `CLAUDE.md` — said device names remain German-only and pointed to epic #157 (closed). Updated to reflect the current state.

## Why

A contributor following the "how to add a new device" guide would skip adding a locale key, since the old comment implied the locale system didn't cover device names. Now the guide directs them to add a key in `locales/` as well.

## Checklist

- [x] No behaviour change — docs/comments only
- [x] Verified against `EquipmentList.svelte` which uses `$_('equipment.devices.' + key, { default: objDevices[key]?.name_de ?? key })`