### PR TITLE
feat(navigation): add 'Take me there' button to playground panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ To test Hub mode locally: set `appMode: 'hub'` in `app/public/config.js`, run `m
 |---|---|
 | `Map.svelte` | OL map, all layers, click/hover handlers, standalone pitch layer (moveend) |
 | `AppShell.svelte` | Top-level shell used by both modes: mounts Map, manages deeplink restore, wires keyboard shortcuts |
-| `PlaygroundPanel.svelte` | Fetches and displays equipment/trees/POIs for selected playground; writes to `overlayFeaturesStore` |
+| `PlaygroundPanel.svelte` | Fetches and displays equipment/trees/POIs for selected playground; writes to `overlayFeaturesStore`; includes "Take me there" navigation button (geo: URL on mobile, OSM directions on desktop) |
 | `EquipmentList.svelte` | Renders device/fitness/pitch/bench lists inside PlaygroundPanel |
 | `NearbyPlaygrounds.svelte` | Shows nearest playgrounds to the selected one; hydrates polygon source on demand |
 | `POIPanel.svelte` | Nearby POI list (cafés, toilets, etc.) shown inside PlaygroundPanel |

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -418,12 +418,14 @@
     const title = getPlaygroundTitle(attr, $_);
     // Mobile: use geo: URL to open navigation app
     // Desktop: use OSM directions URL (empty first part = use current location as source)
-    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
-      const geoUrl = `geo:${centerLat},${centerLon}?q=${centerLat},${centerLon}(${encodeURIComponent(title)})`;
-      window.open(geoUrl, '_blank');
-    } else {
-      const osmUrl = `https://www.openstreetmap.org/directions?engine=fossgis_osrm_foot&route=;${centerLat},${centerLon}`;
-      window.open(osmUrl, '_blank');
+    const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile/i.test(navigator.userAgent);
+    const url = isMobile
+      ? `geo:${centerLat},${centerLon}?q=${centerLat},${centerLon}(${encodeURIComponent(title)})`
+      : `https://www.openstreetmap.org/directions?engine=fossgis_osrm_foot&route=;${centerLat},${centerLon}`;
+    
+    const win = window.open(url, '_blank');
+    if (!win) {
+      console.warn('Navigation popup was blocked');
     }
   }
 </script>
@@ -472,7 +474,7 @@
           {/if}
         </div>
         <div class="flex items-center gap-1 shrink-0">
-          <button class="navigate-btn" onclick={navigateToPlayground}>{$_('info.navigateHere')}</button>
+          <button class="navigate-btn" onclick={navigateToPlayground} aria-label={$_('info.navigateHere')}>{$_('info.navigateHere')}</button>
           <button class="panel-icon-btn" onclick={() => selection.clear()} aria-label={$_('info.closeBtn')}>
             <X class="h-5 w-5" />
           </button>
@@ -517,7 +519,7 @@
           {/if}
         </div>
         <div class="flex items-center gap-1">
-          <button class="navigate-btn" onclick={navigateToPlayground}>{$_('info.navigateHere')}</button>
+          <button class="navigate-btn" onclick={navigateToPlayground} aria-label={$_('info.navigateHere')}>{$_('info.navigateHere')}</button>
           <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label={$_('info.copyLink')}>
             {#if shareConfirmed}
               <Check class="h-5 w-5 text-green-600" />

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -411,6 +411,21 @@
       if (err.name !== 'AbortError') console.warn('Share failed:', err);
     }
   }
+
+  // ── Navigation button ────────────────────────────────────────────────────
+  function navigateToPlayground() {
+    if (!attr || !centerLat || !centerLon) return;
+    const title = getPlaygroundTitle(attr, $_);
+    // Mobile: use geo: URL to open navigation app
+    // Desktop: use OSM directions URL (empty first part = use current location as source)
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+      const geoUrl = `geo:${centerLat},${centerLon}?q=${centerLat},${centerLon}(${encodeURIComponent(title)})`;
+      window.open(geoUrl, '_blank');
+    } else {
+      const osmUrl = `https://www.openstreetmap.org/directions?engine=fossgis_osrm_foot&route=;${centerLat},${centerLon}`;
+      window.open(osmUrl, '_blank');
+    }
+  }
 </script>
 
 {#if feature && attr}
@@ -457,6 +472,7 @@
           {/if}
         </div>
         <div class="flex items-center gap-1 shrink-0">
+          <button class="navigate-btn" onclick={navigateToPlayground}>{$_('info.navigateHere')}</button>
           <button class="panel-icon-btn" onclick={() => selection.clear()} aria-label={$_('info.closeBtn')}>
             <X class="h-5 w-5" />
           </button>
@@ -500,13 +516,16 @@
             </div>
           {/if}
         </div>
-        <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label={$_('info.copyLink')}>
-          {#if shareConfirmed}
-            <Check class="h-5 w-5 text-green-600" />
-          {:else}
-            <Share2 class="h-5 w-5" />
-          {/if}
-        </button>
+        <div class="flex items-center gap-1">
+          <button class="navigate-btn" onclick={navigateToPlayground}>{$_('info.navigateHere')}</button>
+          <button class="panel-icon-btn shrink-0" onclick={sharePlayground} aria-label={$_('info.copyLink')}>
+            {#if shareConfirmed}
+              <Check class="h-5 w-5 text-green-600" />
+            {:else}
+              <Share2 class="h-5 w-5" />
+            {/if}
+          </button>
+        </div>
       </div>
     {/if}
 
@@ -1050,5 +1069,22 @@
     color: #6b7280;
     line-height: 1.5;
     margin: 0;
+  }
+
+  /* ── Navigation button ────────────────────────────────────────────────── */
+  .navigate-btn {
+    padding: 6px 12px;
+    background: #10b981;
+    color: #ffffff;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+  }
+  .navigate-btn:hover {
+    background: #059669;
   }
 </style>

--- a/app/src/components/PlaygroundPanel.svelte
+++ b/app/src/components/PlaygroundPanel.svelte
@@ -414,7 +414,7 @@
 
   // ── Navigation button ────────────────────────────────────────────────────
   function navigateToPlayground() {
-    if (!attr || !centerLat || !centerLon) return;
+    if (!attr || !Number.isFinite(centerLat) || !Number.isFinite(centerLon)) return;
     const title = getPlaygroundTitle(attr, $_);
     // Mobile: use geo: URL to open navigation app
     // Desktop: use OSM directions URL (empty first part = use current location as source)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -73,6 +73,7 @@ Click any playground to open its detail panel. The panel shows:
 - Street-level photos (from Panoramax, when available)
 - Community reviews (from Mangrove.reviews, when available)
 - Nearby POIs — toilets, cafés, bus stops, and pharmacies within 500 m
+- A "Take me there" button that opens navigation to the playground (geo: URL on mobile, OSM directions on desktop)
 - A "Contribute data" link to add or improve information in OpenStreetMap via MapComplete
 
 ## Standalone pitches layer

--- a/locales/de.json
+++ b/locales/de.json
@@ -67,7 +67,8 @@
     "osmBtn": "Bei OpenStreetMap anzeigen",
     "closeBtn": "Schließen",
     "copyLink": "Link kopieren",
-    "backToMap": "Zurück zur Karte"
+    "backToMap": "Zurück zur Karte",
+    "navigateHere": "Bring mich hierher"
   },
   "completeness": {
     "legendTitle": "Datenqualität",

--- a/locales/en.json
+++ b/locales/en.json
@@ -67,7 +67,8 @@
     "osmBtn": "View on OpenStreetMap",
     "closeBtn": "Close",
     "copyLink": "Copy link",
-    "backToMap": "Back to map"
+    "backToMap": "Back to map",
+    "navigateHere": "Take me there"
   },
   "completeness": {
     "legendTitle": "Data Quality",

--- a/locales/es.json
+++ b/locales/es.json
@@ -67,7 +67,8 @@
     "osmBtn": "Ver en OpenStreetMap",
     "closeBtn": "Cerrar",
     "copyLink": "Copiar enlace",
-    "backToMap": "Volver al mapa"
+    "backToMap": "Volver al mapa",
+    "navigateHere": "Llévame aquí"
   },
   "completeness": {
     "legendTitle": "Calidad de datos",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -67,7 +67,8 @@
     "osmBtn": "Voir sur OpenStreetMap",
     "closeBtn": "Fermer",
     "copyLink": "Copier le lien",
-    "backToMap": "Retour à la carte"
+    "backToMap": "Retour à la carte",
+    "navigateHere": "Emmenez-moi ici"
   },
   "completeness": {
     "legendTitle": "Qualité des données",


### PR DESCRIPTION
Add navigation button to playground detail panel for easy routing.

## Changes
- Add 'Take me there' button to desktop and mobile playground panel headers
- Mobile: opens native navigation app via geo: URL
- Desktop: opens OSM directions with current location as source
- Added aria-label for accessibility (screen reader support)
- Added popup blocker error handling with console warning
- Added translations: en, de, fr, es
- Updated CLAUDE.md and user-guide.md documentation

## Technical Details
- Platform detection via userAgent regex
- Mobile regex improved to include 'Mobile' pattern
- Button styling: green (#10b981) with hover state (#059669)
- Popup detection: checks if window.open() returned null

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>